### PR TITLE
Add GCP vocab loading scripts

### DIFF
--- a/scripts/load-vocab.sh
+++ b/scripts/load-vocab.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+VOCAB_DIR="/tmp/vocab"
+
+echo "Downloading vocabulary files from gs://${VOCAB_BUCKET}/..."
+mkdir -p "$VOCAB_DIR"
+python -c "
+from google.cloud import storage
+import os
+
+bucket_name = os.environ['VOCAB_BUCKET']
+client = storage.Client()
+bucket = client.bucket(bucket_name)
+
+for blob in bucket.list_blobs():
+    if blob.name.endswith('.csv'):
+        dest = f'/tmp/vocab/{blob.name}'
+        print(f'  {blob.name} ({blob.size // 1024}KB)')
+        blob.download_to_filename(dest)
+
+print('Download complete.')
+"
+
+echo "Loading vocabularies into database..."
+python manage.py load_athena_vocabularies --path "$VOCAB_DIR" --replace
+
+echo "Done."

--- a/scripts/upload-vocab.sh
+++ b/scripts/upload-vocab.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+BUCKET="${1:-ctomop-staging-vocab}"
+VOCAB_DIR="${2:-$HOME/Downloads/vocabulary_download_v5_*}"
+
+echo "Uploading vocabulary files to gs://${BUCKET}/..."
+echo "Source: ${VOCAB_DIR}"
+
+for file in CONCEPT.csv CONCEPT_CLASS.csv CONCEPT_RELATIONSHIP.csv \
+            CONCEPT_ANCESTOR.csv DOMAIN.csv RELATIONSHIP.csv VOCABULARY.csv; do
+  if [ -f "${VOCAB_DIR}/${file}" ]; then
+    echo "  ${file}..."
+    gcloud storage cp "${VOCAB_DIR}/${file}" "gs://${BUCKET}/${file}"
+  else
+    echo "  SKIP ${file} (not found)"
+  fi
+done
+
+echo "Upload complete."
+echo ""
+echo "To run the load job:"
+echo "  gcloud run jobs execute ctomop-staging-load-vocab --region us-central1 --wait"


### PR DESCRIPTION
## Summary
- Add `scripts/load-vocab.sh` — Cloud Run Job entrypoint that downloads Athena vocabulary CSVs from GCS and runs `load_athena_vocabularies --replace`
- Add `scripts/upload-vocab.sh` — local convenience script to upload vocab files to GCS bucket

Terraform infra (GCS bucket + Cloud Run Job) is in HealthTree/ht-phr#feat/ctomop-vocab-infra.

## Usage
```sh
# Upload files from local machine
./scripts/upload-vocab.sh ctomop-staging-vocab ~/Downloads/vocabulary_download_v5_*/

# Run the load job
gcloud run jobs execute ctomop-staging-load-vocab --region us-central1 --wait
```

## Test plan
- [ ] Merge ht-phr infra PR and apply terraform
- [ ] Upload vocab CSVs to bucket
- [ ] Execute Cloud Run Job and verify concepts loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)