### PR TITLE
fix: stream vocab files from GCS to avoid Cloud Run OOM

### DIFF
--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -1,8 +1,12 @@
 import csv
+import io
 import os
+import sys
 import time
 from datetime import date
 from pathlib import Path
+
+csv.field_size_limit(sys.maxsize)
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -34,6 +38,13 @@ def _open_tsv(base, filename):
     return open(path, encoding='utf-8', newline='')
 
 
+def _open_gcs_blob(bucket, filename):
+    blob = bucket.blob(filename)
+    if not blob.exists():
+        raise CommandError(f'Required blob not found: gs://{bucket.name}/{filename}')
+    return io.TextIOWrapper(blob.open('rb'), encoding='utf-8', newline='')
+
+
 def _concept_in_scope(row):
     vid = row['vocabulary_id']
     if vid not in VOCAB_SCOPE:
@@ -56,8 +67,10 @@ class Command(BaseCommand):
     help = 'Load OHDSI Athena vocabulary TSV files into OMOP vocabulary tables'
 
     def add_arguments(self, parser):
-        parser.add_argument('--path', required=True,
+        parser.add_argument('--path',
                             help='Directory containing Athena TSV files')
+        parser.add_argument('--bucket',
+                            help='GCS bucket name to stream files from (alternative to --path)')
         parser.add_argument('--replace', action='store_true',
                             help='Clear vocabulary rows before loading')
         parser.add_argument('--dry-run', action='store_true', dest='dry_run',
@@ -65,30 +78,48 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         base = options['path']
+        bucket_name = options['bucket']
         replace = options['replace']
         dry_run = options['dry_run']
+
+        if not base and not bucket_name:
+            raise CommandError('Provide either --path or --bucket')
+
+        self._gcs_bucket = None
+        if bucket_name:
+            from google.cloud import storage as gcs
+            self._gcs_bucket = gcs.Client().bucket(bucket_name)
+            self.stdout.write(f'Streaming from gs://{bucket_name}/')
+
         t0 = time.monotonic()
+
+        self._base = base
 
         if replace and not dry_run:
             self._clear()
             self.stdout.write('Cleared existing vocabulary data.')
 
         counts = {
-            'relationship':         self._load_relationships(base, dry_run),
-            'vocabulary':           self._load_small(base, 'VOCABULARY.csv', dry_run,
+            'relationship':         self._load_relationships(dry_run),
+            'vocabulary':           self._load_small('VOCABULARY.csv', dry_run,
                                         self._vocab_row),
-            'domain':               self._load_small(base, 'DOMAIN.csv', dry_run,
+            'domain':               self._load_small('DOMAIN.csv', dry_run,
                                         self._domain_row),
-            'concept_class':        self._load_small(base, 'CONCEPT_CLASS.csv', dry_run,
+            'concept_class':        self._load_small('CONCEPT_CLASS.csv', dry_run,
                                         self._cc_row),
-            'concept':              self._load_concepts(base, dry_run),
-            'concept_relationship': self._load_concept_relationships(base, dry_run),
-            'concept_ancestor':     self._load_concept_ancestors(base, dry_run),
+            'concept':              self._load_concepts(dry_run),
+            'concept_relationship': self._load_concept_relationships(dry_run),
+            'concept_ancestor':     self._load_concept_ancestors(dry_run),
         }
         verb = 'would load' if dry_run else 'loaded'
         for table, n in counts.items():
             self.stdout.write(f'  {table}: {n} rows {verb}')
         self.stdout.write(f'Done in {time.monotonic() - t0:.1f}s')
+
+    def _open(self, filename):
+        if self._gcs_bucket:
+            return _open_gcs_blob(self._gcs_bucket, filename)
+        return _open_tsv(self._base, filename)
 
     def _clear(self):
         ConceptAncestor.objects.all().delete()
@@ -97,10 +128,10 @@ class Command(BaseCommand):
         Relationship.objects.all().delete()
         Vocabulary.objects.filter(vocabulary_id__in=VOCAB_SCOPE).delete()
 
-    def _load_relationships(self, base, dry_run):
+    def _load_relationships(self, dry_run):
         count = 0
         batch = []
-        with _open_tsv(base, 'RELATIONSHIP.csv') as f:
+        with self._open('RELATIONSHIP.csv') as f:
             for row in csv.DictReader(f, delimiter='\t'):
                 try:
                     obj = Relationship(
@@ -148,13 +179,13 @@ class Command(BaseCommand):
             concept_class_concept_id=int(row.get('concept_class_concept_id') or 0),
         )
 
-    def _load_small(self, base, filename, dry_run, row_fn):
+    def _load_small(self, filename, dry_run, row_fn):
         """Generic loader for small lookup tables (Vocabulary, Domain, ConceptClass)."""
         count = 0
         batch = []
         model = None
         try:
-            f = _open_tsv(base, filename)
+            f = self._open(filename)
         except CommandError:
             return 0
         with f:
@@ -174,10 +205,10 @@ class Command(BaseCommand):
             model.objects.bulk_create(batch, ignore_conflicts=True)
         return count
 
-    def _load_concepts(self, base, dry_run):
+    def _load_concepts(self, dry_run):
         count = 0
         batch = []
-        with _open_tsv(base, 'CONCEPT.csv') as f:
+        with self._open('CONCEPT.csv') as f:
             for row in csv.DictReader(f, delimiter='\t'):
                 if not _concept_in_scope(row):
                     continue
@@ -208,14 +239,14 @@ class Command(BaseCommand):
         _bulk(Concept, batch, dry_run)
         return count
 
-    def _load_concept_relationships(self, base, dry_run):
+    def _load_concept_relationships(self, dry_run):
         loaded_ids = set(
             Concept.objects.filter(vocabulary_id__in=VOCAB_SCOPE)
                            .values_list('concept_id', flat=True)
         )
         count = 0
         batch = []
-        with _open_tsv(base, 'CONCEPT_RELATIONSHIP.csv') as f:
+        with self._open('CONCEPT_RELATIONSHIP.csv') as f:
             for row in csv.DictReader(f, delimiter='\t'):
                 try:
                     c1 = int(row['concept_id_1'])
@@ -240,14 +271,14 @@ class Command(BaseCommand):
         _bulk(ConceptRelationship, batch, dry_run)
         return count
 
-    def _load_concept_ancestors(self, base, dry_run):
+    def _load_concept_ancestors(self, dry_run):
         hemonc_ids = set(
             Concept.objects.filter(vocabulary_id='HemOnc')
                            .values_list('concept_id', flat=True)
         )
         count = 0
         batch = []
-        with _open_tsv(base, 'CONCEPT_ANCESTOR.csv') as f:
+        with self._open('CONCEPT_ANCESTOR.csv') as f:
             for row in csv.DictReader(f, delimiter='\t'):
                 try:
                     anc = int(row['ancestor_concept_id'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.8.1
 google-cloud-bigquery==3.25.0
+google-cloud-storage==2.18.2
 certifi==2024.8.30
 cffi==1.16.0
 charset-normalizer==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.8.1
 google-cloud-bigquery==3.25.0
-google-cloud-storage==2.18.2
+google-cloud-storage>=3.1.1
 certifi==2024.8.30
 cffi==1.16.0
 charset-normalizer==3.3.2

--- a/scripts/load-vocab.sh
+++ b/scripts/load-vocab.sh
@@ -1,28 +1,7 @@
 #!/bin/sh
 set -e
 
-VOCAB_DIR="/tmp/vocab"
-
-echo "Downloading vocabulary files from gs://${VOCAB_BUCKET}/..."
-mkdir -p "$VOCAB_DIR"
-python -c "
-from google.cloud import storage
-import os
-
-bucket_name = os.environ['VOCAB_BUCKET']
-client = storage.Client()
-bucket = client.bucket(bucket_name)
-
-for blob in bucket.list_blobs():
-    if blob.name.endswith('.csv'):
-        dest = f'/tmp/vocab/{blob.name}'
-        print(f'  {blob.name} ({blob.size // 1024}KB)')
-        blob.download_to_filename(dest)
-
-print('Download complete.')
-"
-
-echo "Loading vocabularies into database..."
-python manage.py load_athena_vocabularies --path "$VOCAB_DIR" --replace
+echo "Loading vocabularies from gs://${VOCAB_BUCKET}/ (streaming)..."
+python manage.py load_athena_vocabularies --bucket "$VOCAB_BUCKET" --replace
 
 echo "Done."

--- a/scripts/upload-vocab.sh
+++ b/scripts/upload-vocab.sh
@@ -4,20 +4,93 @@ set -e
 BUCKET="${1:-ctomop-staging-vocab}"
 VOCAB_DIR="${2:-$HOME/Downloads/vocabulary_download_v5_*}"
 
-echo "Uploading vocabulary files to gs://${BUCKET}/..."
-echo "Source: ${VOCAB_DIR}"
+FILES="CONCEPT.csv CONCEPT_CLASS.csv CONCEPT_RELATIONSHIP.csv \
+       CONCEPT_ANCESTOR.csv DOMAIN.csv RELATIONSHIP.csv VOCABULARY.csv"
 
-for file in CONCEPT.csv CONCEPT_CLASS.csv CONCEPT_RELATIONSHIP.csv \
-            CONCEPT_ANCESTOR.csv DOMAIN.csv RELATIONSHIP.csv VOCABULARY.csv; do
-  if [ -f "${VOCAB_DIR}/${file}" ]; then
-    echo "  ${file}..."
-    gcloud storage cp "${VOCAB_DIR}/${file}" "gs://${BUCKET}/${file}"
+human_size() {
+  local bytes=$1
+  if [ "$bytes" -ge 1073741824 ]; then
+    printf "%.1fGB" "$(echo "$bytes / 1073741824" | bc -l)"
+  elif [ "$bytes" -ge 1048576 ]; then
+    printf "%.1fMB" "$(echo "$bytes / 1048576" | bc -l)"
+  elif [ "$bytes" -ge 1024 ]; then
+    printf "%.0fKB" "$(echo "$bytes / 1024" | bc -l)"
   else
-    echo "  SKIP ${file} (not found)"
+    printf "%dB" "$bytes"
+  fi
+}
+
+total_bytes=0
+file_count=0
+for file in $FILES; do
+  if [ -f "${VOCAB_DIR}/${file}" ]; then
+    size=$(stat -f%z "${VOCAB_DIR}/${file}" 2>/dev/null || stat --printf="%s" "${VOCAB_DIR}/${file}" 2>/dev/null)
+    total_bytes=$((total_bytes + size))
+    file_count=$((file_count + 1))
   fi
 done
 
-echo "Upload complete."
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║  OMOP Vocabulary Upload → gs://${BUCKET}/                   "
+echo "║  Source: ${VOCAB_DIR}"
+echo "║  Files: ${file_count} found, total $(human_size $total_bytes)"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+uploaded_bytes=0
+file_num=0
+start_time=$(date +%s)
+
+for file in $FILES; do
+  src="${VOCAB_DIR}/${file}"
+  if [ ! -f "$src" ]; then
+    echo "  ⊘ SKIP ${file} (not found)"
+    continue
+  fi
+
+  file_num=$((file_num + 1))
+  file_size=$(stat -f%z "$src" 2>/dev/null || stat --printf="%s" "$src" 2>/dev/null)
+
+  pct=0
+  if [ "$total_bytes" -gt 0 ]; then
+    pct=$((uploaded_bytes * 100 / total_bytes))
+  fi
+
+  printf "\n[%d/%d] %s (%s)\n" "$file_num" "$file_count" "$file" "$(human_size $file_size)"
+
+  bar_width=40
+  filled=$((pct * bar_width / 100))
+  empty=$((bar_width - filled))
+  bar=$(printf '%*s' "$filled" '' | tr ' ' '█')$(printf '%*s' "$empty" '' | tr ' ' '░')
+  printf "  Overall: [%s] %3d%%\n" "$bar" "$pct"
+
+  file_start=$(date +%s)
+  gcloud storage cp "$src" "gs://${BUCKET}/${file}" 2>&1 | grep -E "^(Copying|Average)" || true
+  file_end=$(date +%s)
+
+  uploaded_bytes=$((uploaded_bytes + file_size))
+  elapsed=$((file_end - file_start))
+  if [ "$elapsed" -gt 0 ]; then
+    speed=$((file_size / elapsed))
+    printf "  ✓ Done in %ds @ %s/s\n" "$elapsed" "$(human_size $speed)"
+  else
+    printf "  ✓ Done (<1s)\n"
+  fi
+done
+
+end_time=$(date +%s)
+total_elapsed=$((end_time - start_time))
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+printf "║  Upload complete: %s in %dm %ds" "$(human_size $uploaded_bytes)" "$((total_elapsed / 60))" "$((total_elapsed % 60))"
+echo ""
+if [ "$total_elapsed" -gt 0 ]; then
+  avg_speed=$((uploaded_bytes / total_elapsed))
+  printf "║  Average speed: %s/s" "$(human_size $avg_speed)"
+  echo ""
+fi
+echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 echo "To run the load job:"
 echo "  gcloud run jobs execute ctomop-staging-load-vocab --region us-central1 --wait"


### PR DESCRIPTION
## Summary
- Load job was OOM-ing (exit code 137) because it downloaded all ~4GB of vocab files to RAM-backed `/tmp` on a 2GB Cloud Run container
- Added `--bucket` flag to `load_athena_vocabularies` command that streams CSVs directly from GCS via `blob.open('rb')` — no disk/tmpfs usage
- Simplified `load-vocab.sh` to a one-liner using the new `--bucket` mode
- Added progress bars, per-file speed, and summary stats to `upload-vocab.sh`
- Added `google-cloud-storage` to requirements, fixed CSV field size limit

## Test plan
- [x] Local dry-run with `--path` passes (764,669 concepts in scope)
- [ ] Re-run Cloud Run job after merge and deploy
- [ ] Verify vocab tables populated in staging DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)