### PR TITLE
fix: save patient name via /me endpoint

### DIFF
--- a/frontend/src/federation/PatientInfo.tsx
+++ b/frontend/src/federation/PatientInfo.tsx
@@ -92,8 +92,7 @@ function PatientInfoInner({ readOnly, onPatientUpdated }: Pick<PatientInfoProps,
 
   const initialName = useMemo(() => {
     if (!data) return "";
-    const user = data.user;
-    return user ? (user.name || user.email || "Patient") : "Patient";
+    return data.patient_name || data.user?.name || data.user?.email || "Patient";
   }, [data]);
 
   const [editedInfo, setEditedInfo] = useState<Record<string, unknown>>(initialInfo);
@@ -162,7 +161,8 @@ function PatientInfoInner({ readOnly, onPatientUpdated }: Pick<PatientInfoProps,
   const handleNameChange = useCallback((name: string) => {
     if (readOnly) return;
     setEditedName(name);
-    scheduleAutoSave(pendingDataRef.current ?? editedInfoRef.current);
+    const base = pendingDataRef.current ?? editedInfoRef.current;
+    scheduleAutoSave({ ...base, patient_name: name });
   }, [scheduleAutoSave, readOnly]);
 
   const handleMutationAdd = useCallback(() => {

--- a/frontend/src/federation/patientInfoTypes.ts
+++ b/frontend/src/federation/patientInfoTypes.ts
@@ -15,4 +15,5 @@ export interface PatientInfoProps {
 export interface PatientInfoData {
   patient_info: Record<string, unknown>;
   user: { id: number; email: string; name: string } | null;
+  patient_name: string;
 }

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -320,19 +320,30 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
         if request.method == 'GET':
             user_serializer = UserSerializer(request.user)
             patient_serializer = PatientInfoSerializer(patient_info)
+            full_name = f"{person.given_name or ''} {person.family_name or ''}".strip()
             return Response({
                 'patient_info': patient_serializer.data,
                 'user': user_serializer.data,
+                'patient_name': full_name,
             })
 
         # PATCH
-        serializer = PatientInfoSerializer(patient_info, data=request.data, partial=True)
+        patient_name = request.data.pop('patient_name', None) if hasattr(request.data, 'pop') else request.data.get('patient_name')
+        patch_data = {k: v for k, v in request.data.items() if k != 'patient_name'}
+
+        if patient_name is not None:
+            parts = str(patient_name).strip().split(None, 1)
+            person.given_name = parts[0] if parts else ''
+            person.family_name = parts[1] if len(parts) > 1 else ''
+            person.save(update_fields=['given_name', 'family_name'])
+
+        serializer = PatientInfoSerializer(patient_info, data=patch_data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        changed_fields = set(request.data.keys())
+        changed_fields = set(patch_data.keys())
         try:
-            sync_to_omop(patient_info, changed_fields, changed_data=dict(request.data))
+            sync_to_omop(patient_info, changed_fields, changed_data=dict(patch_data))
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- Backend `/api/patient-info/me/` GET now returns `patient_name` from `Person.given_name + family_name`
- PATCH accepts `patient_name`, splits into `given_name`/`family_name` on the Person record, strips it before passing to PatientInfo serializer
- Frontend `handleNameChange` now includes `patient_name` in the auto-save payload
- `initialName` prefers `patient_name` (Person's name) over Identity name

## Test plan
- [ ] Edit patient name in General tab → verify "Saved" indicator appears
- [ ] Reload page → verify name persists
- [ ] Verify name with single word saves as `given_name` only
- [ ] Verify name with two+ words splits into `given_name` / `family_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)