### PR TITLE
fix: add email fallback to /me endpoint

### DIFF
--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -306,16 +306,28 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
     def me(self, request):
         """GET/PATCH /api/patient-info/me/ — current user's own PatientInfo."""
         from patient_portal.models import PatientUser
+        person = None
+        patient_info = None
+
         try:
             patient_user = PatientUser.objects.select_related('person').get(identity=request.user)
+            person = patient_user.person
         except PatientUser.DoesNotExist:
-            return Response({'error': 'No patient record linked to this account'}, status=status.HTTP_404_NOT_FOUND)
+            pass
 
-        person = patient_user.person
-        try:
-            patient_info = PatientInfo.objects.get(person=person)
-        except PatientInfo.DoesNotExist:
-            return Response({'error': 'Patient information not found'}, status=status.HTTP_404_NOT_FOUND)
+        if person is not None:
+            try:
+                patient_info = PatientInfo.objects.get(person=person)
+            except PatientInfo.DoesNotExist:
+                pass
+
+        if patient_info is None and getattr(request.user, 'email', None):
+            patient_info = PatientInfo.objects.filter(email=request.user.email).first()
+            if patient_info is not None:
+                person = patient_info.person
+
+        if patient_info is None:
+            return Response({'error': 'No patient record linked to this account'}, status=status.HTTP_404_NOT_FOUND)
 
         if request.method == 'GET':
             user_serializer = UserSerializer(request.user)


### PR DESCRIPTION
## Summary
- The `/api/patient-info/me/` endpoint returned 404 when no `PatientUser` record was linked to the authenticated Identity
- Added email-based fallback matching against `PatientInfo.email`, consistent with the existing `_resolve_person_id()` strategy in lab-results views
- This resolves the staging 404 for users whose Firebase Identity exists but lacks a PatientUser linkage

## Test plan
- [ ] Verify `/api/patient-info/me/` returns patient data for a user with no PatientUser record but a matching email in PatientInfo
- [ ] Verify the existing PatientUser path still works when the linkage exists
- [ ] Verify 404 is still returned when neither PatientUser nor email match exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)