### PR TITLE
fix: add request error logging for staging visibility

### DIFF
--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -74,16 +74,33 @@ LOGGING = {
             '()': 'logging.Formatter',
             'format': '%(message)s',
         },
+        'verbose': {
+            'format': '[%(asctime)s] %(levelname)s %(name)s %(message)s',
+        },
     },
     'handlers': {
         'audit_stdout': {
             'class': 'logging.StreamHandler',
             'formatter': 'audit_json',
         },
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
     },
     'loggers': {
         'audit': {
             'handlers': ['audit_stdout'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'django.request': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'patient_portal': {
+            'handlers': ['console'],
             'level': 'INFO',
             'propagate': False,
         },


### PR DESCRIPTION
## Summary
- Unhandled 500s on staging produced no traceback in Cloud Logging
- Added `django.request` (ERROR) and `patient_portal` (INFO) loggers to stderr
- Will allow us to diagnose the lab-results sync 500

## Test plan
- [ ] Deploy to staging and retry the lab-results sync — traceback should now appear in Cloud Logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)