### PR TITLE
fix: add statement_timeout to next_pk to prevent hangs

### DIFF
--- a/omop_core/services/pk.py
+++ b/omop_core/services/pk.py
@@ -14,6 +14,7 @@ def next_pk(model, pk_field):
     """Return the next PK value from the table's sequence."""
     seq = _seq_name(model, pk_field)
     with connection.cursor() as cur:
+        cur.execute("SET LOCAL statement_timeout = '5s'")
         cur.execute("SELECT nextval(%s)", [seq])
         return cur.fetchone()[0]
 
@@ -24,6 +25,7 @@ def next_pk_batch(model, pk_field, count):
         return []
     seq = _seq_name(model, pk_field)
     with connection.cursor() as cur:
+        cur.execute("SET LOCAL statement_timeout = '5s'")
         cur.execute(
             "SELECT nextval(%s) FROM generate_series(1, %s)",
             [seq, count],


### PR DESCRIPTION
## Summary
- `SELECT nextval()` in `next_pk` can hang indefinitely when the sequence is locked by a stuck transaction
- This caused all gunicorn workers to block, taking down ctomop-staging entirely
- Added `SET LOCAL statement_timeout = '5s'` so the call fails fast instead of hanging

## Test plan
- [ ] Sync endpoint returns an error within 5s instead of hanging for 300s when sequence is locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)