### PR TITLE
fix: sort Other category last in lab results

### DIFF
--- a/frontend/src/components/labs/PaginationControls.tsx
+++ b/frontend/src/components/labs/PaginationControls.tsx
@@ -53,7 +53,7 @@ export function PaginationControls({
   const availableSizes = (pageSizes ?? DEFAULT_PAGE_SIZES).filter(isValidPageSize);
 
   return (
-    <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground sm:flex-row sm:justify-between">
+    <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
       <span>
         {totalCount === 0
           ? "No results"

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -182,13 +182,7 @@ SELECT
     c.concept_code,
     c.concept_name,
     c.vocabulary_id,
-    COALESCE(
-        lc.display_name,
-        CASE WHEN c.vocabulary_id IN ('LOINC', 'HK-Labs')
-             THEN 'Uncategorized'
-             ELSE 'Other'
-        END
-    ) AS category
+    COALESCE(lc.display_name, 'Other') AS category
 FROM eff
 JOIN concept c ON c.concept_id = eff.eff_id
 LEFT JOIN loinc_code_class lcc
@@ -197,14 +191,11 @@ LEFT JOIN loinc_code_class lcc
 LEFT JOIN loinc_class lc
        ON lc.code = lcc.loinc_class_code
 GROUP BY eff.eff_id, c.concept_code, c.concept_name, c.vocabulary_id,
-         COALESCE(
-             lc.display_name,
-             CASE WHEN c.vocabulary_id IN ('LOINC', 'HK-Labs')
-                  THEN 'Uncategorized'
-                  ELSE 'Other'
-             END
-         )
-ORDER BY category, latest_date DESC
+         COALESCE(lc.display_name, 'Other')
+ORDER BY CASE WHEN COALESCE(lc.display_name, 'Other') = 'Other'
+              THEN 1 ELSE 0 END,
+         COALESCE(lc.display_name, 'Other'),
+         latest_date DESC
 """
 
 
@@ -419,9 +410,9 @@ class ValuesView(APIView):
 
         category_cache = _build_category_cache()
         if concept.vocabulary_id == 'LOINC':
-            category = category_cache.get(concept.concept_code, 'Uncategorized')
+            category = category_cache.get(concept.concept_code, 'Other')
         elif concept.vocabulary_id == 'HK-Labs':
-            category = 'Uncategorized'
+            category = 'Other'
         else:
             category = 'Other'
 


### PR DESCRIPTION
## Summary
- Fix SQL ORDER BY to push "Other" category to the end across all pages, preventing it from being split by alphabetically-later categories (e.g. Urinalysis)
- Rename "Uncategorized" to "Other" in both SQL and Python fallbacks
- Simplify redundant COALESCE+CASE to `COALESCE(lc.display_name, 'Other')`
- Make pagination controls horizontal instead of vertically stacked

## Test plan
- [ ] Verify lab results list shows all named categories alphabetically, with "Other" always last
- [ ] Verify pagination does not split "Other" group across pages
- [ ] Verify pagination controls render horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)