### PR TITLE
fix: lab detail UI — edit dialog prefill and report filename

### DIFF
--- a/frontend/src/components/labs/DataSourceBadge.tsx
+++ b/frontend/src/components/labs/DataSourceBadge.tsx
@@ -17,7 +17,7 @@ export function DataSourceBadge({ source, labName, reportFilename, timeAgo }: Pr
   }
 
   if (labName) parts.push(labName);
-  if (reportFilename && !labName) parts.push(reportFilename);
+  if (reportFilename) parts.push(reportFilename);
   if (timeAgo) parts.push(timeAgo);
 
   if (parts.length === 0) return null;

--- a/frontend/src/components/labs/EditMeasurementDialog.tsx
+++ b/frontend/src/components/labs/EditMeasurementDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui-labs/button";
 import {
   Dialog,
@@ -31,28 +31,53 @@ export function EditMeasurementDialog({
   onSave,
   isPending,
 }: EditMeasurementDialogProps) {
-  const [value, setValue] = useState("");
-  const [valueString, setValueString] = useState("");
-  const [measuredAt, setMeasuredAt] = useState("");
-  const [rangeLow, setRangeLow] = useState("");
-  const [rangeHigh, setRangeHigh] = useState("");
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Edit measurement</DialogTitle>
+        </DialogHeader>
+        {measurement && (
+          <EditForm
+            key={measurement.measurement_id}
+            measurement={measurement}
+            onSave={onSave}
+            onCancel={() => onOpenChange(false)}
+            isPending={isPending}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
 
-  useEffect(() => {
-    if (measurement) {
-      setValue(measurement.value != null ? String(Number(measurement.value)) : "");
-      setValueString(measurement.value_string ?? "");
-      setMeasuredAt(measurement.measured_at ?? "");
-      setRangeLow(measurement.range_low != null ? String(Number(measurement.range_low)) : "");
-      setRangeHigh(measurement.range_high != null ? String(Number(measurement.range_high)) : "");
-    }
-  }, [measurement]);
+function EditForm({
+  measurement,
+  onSave,
+  onCancel,
+  isPending,
+}: {
+  measurement: LabResultValue;
+  onSave: EditMeasurementDialogProps["onSave"];
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  const [value, setValue] = useState(
+    measurement.value != null ? String(Number(measurement.value)) : "",
+  );
+  const [valueString, setValueString] = useState(measurement.value_string ?? "");
+  const [measuredAt, setMeasuredAt] = useState(measurement.measured_at ?? "");
+  const [rangeLow, setRangeLow] = useState(
+    measurement.range_low != null ? String(Number(measurement.range_low)) : "",
+  );
+  const [rangeHigh, setRangeHigh] = useState(
+    measurement.range_high != null ? String(Number(measurement.range_high)) : "",
+  );
 
-  const isQualitative = measurement?.value == null && measurement?.value_string != null;
+  const isQualitative = measurement.value == null && measurement.value_string != null;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!measurement) return;
-
     onSave({
       measurementId: measurement.measurement_id,
       value: value ? Number(value) : null,
@@ -64,75 +89,68 @@ export function EditMeasurementDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Edit measurement</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-3">
-          {isQualitative ? (
-            <label className="block">
-              <span className="text-sm font-medium text-foreground">Value</span>
-              <input
-                type="text"
-                value={valueString}
-                onChange={(e) => setValueString(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              />
-            </label>
-          ) : (
-            <label className="block">
-              <span className="text-sm font-medium text-foreground">Value</span>
-              <input
-                type="number"
-                step="any"
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              />
-            </label>
-          )}
-          <label className="block">
-            <span className="text-sm font-medium text-foreground">Measured at</span>
-            <input
-              type="date"
-              value={measuredAt}
-              onChange={(e) => setMeasuredAt(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            />
-          </label>
-          <div className="grid grid-cols-2 gap-3">
-            <label className="block">
-              <span className="text-sm font-medium text-foreground">Range low</span>
-              <input
-                type="number"
-                step="any"
-                value={rangeLow}
-                onChange={(e) => setRangeLow(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium text-foreground">Range high</span>
-              <input
-                type="number"
-                step="any"
-                value={rangeHigh}
-                onChange={(e) => setRangeHigh(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              />
-            </label>
-          </div>
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button variant="outline" type="button" onClick={() => onOpenChange(false)} disabled={isPending}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isPending}>
-              {isPending ? "Saving…" : "Save"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <form onSubmit={handleSubmit} className="space-y-3">
+      {isQualitative ? (
+        <label className="block">
+          <span className="text-sm font-medium text-foreground">Value</span>
+          <input
+            type="text"
+            value={valueString}
+            onChange={(e) => setValueString(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+        </label>
+      ) : (
+        <label className="block">
+          <span className="text-sm font-medium text-foreground">Value</span>
+          <input
+            type="number"
+            step="any"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+        </label>
+      )}
+      <label className="block">
+        <span className="text-sm font-medium text-foreground">Measured at</span>
+        <input
+          type="date"
+          value={measuredAt}
+          onChange={(e) => setMeasuredAt(e.target.value)}
+          className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+        />
+      </label>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="text-sm font-medium text-foreground">Range low</span>
+          <input
+            type="number"
+            step="any"
+            value={rangeLow}
+            onChange={(e) => setRangeLow(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-foreground">Range high</span>
+          <input
+            type="number"
+            step="any"
+            value={rangeHigh}
+            onChange={(e) => setRangeHigh(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+        </label>
+      </div>
+      <DialogFooter className="gap-2 sm:gap-0">
+        <Button variant="outline" type="button" onClick={onCancel} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving…" : "Save"}
+        </Button>
+      </DialogFooter>
+    </form>
   );
 }

--- a/frontend/src/components/labs/EditMeasurementDialog.tsx
+++ b/frontend/src/components/labs/EditMeasurementDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui-labs/button";
 import {
   Dialog,
@@ -37,18 +37,17 @@ export function EditMeasurementDialog({
   const [rangeLow, setRangeLow] = useState("");
   const [rangeHigh, setRangeHigh] = useState("");
 
-  const isQualitative = measurement?.value == null && measurement?.value_string != null;
-
-  const handleOpen = (next: boolean) => {
-    if (next && measurement) {
+  useEffect(() => {
+    if (measurement) {
       setValue(measurement.value != null ? String(Number(measurement.value)) : "");
       setValueString(measurement.value_string ?? "");
       setMeasuredAt(measurement.measured_at ?? "");
       setRangeLow(measurement.range_low != null ? String(Number(measurement.range_low)) : "");
       setRangeHigh(measurement.range_high != null ? String(Number(measurement.range_high)) : "");
     }
-    onOpenChange(next);
-  };
+  }, [measurement]);
+
+  const isQualitative = measurement?.value == null && measurement?.value_string != null;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -65,7 +64,7 @@ export function EditMeasurementDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpen}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle>Edit measurement</DialogTitle>


### PR DESCRIPTION
## Summary
- Fix edit measurement dialog not being populated with current values when opened
- Show report filename alongside lab name in DataSourceBadge (was hidden when lab name was present)

## Test plan
- [ ] Click edit on a measurement in lab detail view — fields should be pre-filled with current values
- [ ] DataSourceBadge shows both lab name and report filename, e.g. "Document · BioReference, LLC · 2024.03.22.pdf"

🤖 Generated with [Claude Code](https://claude.com/claude-code)