### PR TITLE
feat: deduplicate measurements on sync with ownership tracking

### DIFF
--- a/omop_core/migrations/0079_measurement_ownership.py
+++ b/omop_core/migrations/0079_measurement_ownership.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+
+def backfill_ownership(apps, schema_editor):
+    """Create ownership records for all existing measurements."""
+    MeasurementOwnership = apps.get_model('omop_core', 'MeasurementOwnership')
+    Measurement = apps.get_model('omop_core', 'Measurement')
+
+    rows = Measurement.objects.filter(
+        visit_occurrence_id__isnull=False,
+    ).values_list('measurement_id', 'visit_occurrence_id')
+
+    batch = []
+    for m_id, v_id in rows.iterator(chunk_size=2000):
+        batch.append(MeasurementOwnership(
+            measurement_id=m_id,
+            visit_occurrence_id=v_id,
+        ))
+        if len(batch) >= 2000:
+            MeasurementOwnership.objects.bulk_create(batch, ignore_conflicts=True)
+            batch = []
+    if batch:
+        MeasurementOwnership.objects.bulk_create(batch, ignore_conflicts=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('omop_core', '0078_backfill_measurement_source_value'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MeasurementOwnership',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('measurement_id', models.BigIntegerField()),
+                ('visit_occurrence_id', models.BigIntegerField()),
+            ],
+            options={
+                'db_table': 'measurement_ownership',
+                'unique_together': {('measurement_id', 'visit_occurrence_id')},
+            },
+        ),
+        migrations.AddIndex(
+            model_name='measurementownership',
+            index=models.Index(fields=['visit_occurrence_id'], name='ix_measown_visit'),
+        ),
+        migrations.RunPython(backfill_ownership, migrations.RunPython.noop),
+    ]

--- a/omop_core/models.py
+++ b/omop_core/models.py
@@ -626,6 +626,24 @@ class Measurement(models.Model):
         return f"Measurement {self.measurement_id} for Person {self.person_id}"
 
 
+class MeasurementOwnership(models.Model):
+    """Tracks which VisitOccurrences (uploads) contributed to a Measurement.
+
+    When the same lab result is uploaded multiple times, dedup reuses the
+    existing Measurement but adds an ownership record for each visit.
+    A Measurement is only deleted when its last ownership record is removed.
+    """
+    measurement_id = models.BigIntegerField()
+    visit_occurrence_id = models.BigIntegerField()
+
+    class Meta:
+        db_table = 'measurement_ownership'
+        unique_together = [('measurement_id', 'visit_occurrence_id')]
+        indexes = [
+            models.Index(fields=['visit_occurrence_id'], name='ix_measown_visit'),
+        ]
+
+
 class Observation(models.Model):
     """OMOP CDM Observation table - clinical facts that don't fit other domains."""
     observation_id = models.BigIntegerField(primary_key=True)

--- a/patient_portal/api/lab_results/sync.py
+++ b/patient_portal/api/lab_results/sync.py
@@ -26,7 +26,8 @@ from rest_framework.views import APIView
 
 from omop_core.authorization import can_access_patient, get_actor_role
 from omop_core.models import (
-    CareSite, Concept, Measurement, Person, ProvenanceRecord, VisitOccurrence,
+    CareSite, Concept, Measurement, MeasurementOwnership,
+    Person, ProvenanceRecord, VisitOccurrence,
 )
 from omop_core.services.pk import next_pk, next_pk_batch
 from patient_portal.api.permissions import ScopedTokenPermission, get_request_org
@@ -267,10 +268,31 @@ class SyncView(APIView):
             type_concept=type_concept,
         )
 
-        measurement_ids = next_pk_batch(Measurement, 'measurement_id', len(items))
-        measurement_objects = []
-        for m_id, item in zip(measurement_ids, items):
-            measurement_objects.append(self._build_measurement(
+        # Dedup: check for existing measurements, only create new ones
+        all_measurement_ids = []
+        new_items = []
+        deduplicated_count = 0
+
+        for item in items:
+            existing_id = self._find_existing_measurement(
+                person_id, item, loinc_cache, hk_concept_cache,
+            )
+            if existing_id is not None:
+                all_measurement_ids.append(existing_id)
+                deduplicated_count += 1
+            else:
+                all_measurement_ids.append(None)
+                new_items.append(item)
+
+        new_ids = next_pk_batch(Measurement, 'measurement_id', len(new_items)) if new_items else []
+        new_id_iter = iter(new_ids)
+        new_objects = []
+        for i, item in enumerate(items):
+            if all_measurement_ids[i] is not None:
+                continue
+            m_id = next(new_id_iter)
+            all_measurement_ids[i] = m_id
+            new_objects.append(self._build_measurement(
                 measurement_id=m_id,
                 person_id=person_id,
                 item=item,
@@ -280,7 +302,20 @@ class SyncView(APIView):
                 ucum_cache=ucum_cache,
                 hk_concept_cache=hk_concept_cache,
             ))
-        Measurement.objects.bulk_create(measurement_objects)
+        if new_objects:
+            Measurement.objects.bulk_create(new_objects)
+
+        # Ownership: link all measurements (created + deduped) to this visit
+        MeasurementOwnership.objects.bulk_create(
+            [
+                MeasurementOwnership(
+                    measurement_id=m_id,
+                    visit_occurrence_id=visit.visit_occurrence_id,
+                )
+                for m_id in all_measurement_ids
+            ],
+            ignore_conflicts=True,
+        )
 
         # Provenance
         self._record_provenance(
@@ -290,15 +325,18 @@ class SyncView(APIView):
             target_person_id=person_id,
             is_on_behalf_of=is_on_behalf_of,
             visit=visit,
-            measurement_ids=measurement_ids,
+            measurement_ids=all_measurement_ids,
             org=org,
             source_type=source_type,
         )
 
+        created_count = len(new_objects)
         return Response({
             'visit_occurrence_id': visit.visit_occurrence_id,
-            'measurement_ids': measurement_ids,
-            'count': len(measurement_ids),
+            'measurement_ids': all_measurement_ids,
+            'count': len(all_measurement_ids),
+            'created_count': created_count,
+            'deduplicated_count': deduplicated_count,
         }, status=status.HTTP_201_CREATED)
 
     def _resolve_actor_identity(self, actor_iss, actor_sub, request_user):
@@ -476,3 +514,42 @@ class SyncView(APIView):
             unit_source_value=(item.get('source_unit') or item.get('unit') or '')[:50],
             value_source_value=(item.get('source_text') or '')[:50],
         )
+
+    _DEDUP_SQL = """
+    SELECT measurement_id FROM measurement
+    WHERE person_id = %s
+      AND measurement_date = %s
+      AND (measurement_concept_id = %s OR measurement_source_concept_id = %s)
+      AND value_as_number IS NOT DISTINCT FROM %s
+      AND value_as_string IS NOT DISTINCT FROM %s
+    LIMIT 1
+    """
+
+    def _find_existing_measurement(self, person_id, item, loinc_cache, hk_concept_cache):
+        """Return measurement_id of an existing duplicate, or None."""
+        loinc_code = item.get('loinc_code')
+        test_name = item['test_name']
+
+        concept_id = 0
+        source_concept_id = None
+        if loinc_code:
+            concept = loinc_cache.get(loinc_code)
+            if concept:
+                concept_id = concept.concept_id
+            else:
+                source_concept_id = hk_concept_cache.get(test_name)
+        else:
+            source_concept_id = hk_concept_cache.get(test_name)
+
+        from django.db import connection
+        with connection.cursor() as cur:
+            cur.execute(self._DEDUP_SQL, [
+                person_id,
+                item['measured_at'],
+                concept_id,
+                source_concept_id,
+                item.get('value'),
+                item.get('value_string') or '',
+            ])
+            row = cur.fetchone()
+        return row[0] if row else None

--- a/patient_portal/api/lab_results/tests.py
+++ b/patient_portal/api/lab_results/tests.py
@@ -11,7 +11,8 @@ from rest_framework.test import APIClient
 
 from omop_core.models import (
     CareSite, Concept, ConceptClass, Domain, LoincClass, LoincCodeClass,
-    Measurement, Person, PatientInfo, Vocabulary, VisitOccurrence,
+    Measurement, MeasurementOwnership, Person, PatientInfo, Vocabulary,
+    VisitOccurrence,
 )
 
 
@@ -1084,3 +1085,148 @@ class SyncNonSuperuserTest(TestCase):
     def test_sync_nonexistent_person_denied(self):
         resp = self.client.post('/api/lab-results/sync/', self._payload(person_id=9999), format='json')
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class DedupSyncTest(TestCase):
+    """Tests for measurement deduplication on sync."""
+
+    def setUp(self):
+        _setup_vocab()
+        self.user = Identity.objects.create_user(email='dedup@test.com', password='test')
+        self.user.is_superuser = True
+        self.user.save()
+        self.person = Person.objects.create(person_id=3001)
+        PatientInfo.objects.create(person=self.person)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _payload(self, **overrides):
+        data = {
+            'person_id': 3001,
+            'measurements': [
+                {
+                    'loinc_code': '718-7',
+                    'test_name': 'Hemoglobin',
+                    'value': '13.5',
+                    'unit': 'g/dL',
+                    'measured_at': '2026-05-15',
+                },
+            ],
+            'lab_name': 'Quest',
+            'lab_date': '2026-05-15',
+            'report_filename': 'report.pdf',
+            'source_type': 'document_extraction',
+        }
+        data.update(overrides)
+        return data
+
+    def test_duplicate_upload_deduplicates(self):
+        """Same report uploaded twice creates one measurement, two visits, two ownership records."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        self.assertEqual(r1.status_code, 201)
+        self.assertEqual(r1.data['created_count'], 1)
+        self.assertEqual(r1.data['deduplicated_count'], 0)
+        m_id = r1.data['measurement_ids'][0]
+
+        r2 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        self.assertEqual(r2.status_code, 201)
+        self.assertEqual(r2.data['created_count'], 0)
+        self.assertEqual(r2.data['deduplicated_count'], 1)
+        self.assertEqual(r2.data['measurement_ids'][0], m_id)
+
+        self.assertEqual(Measurement.objects.filter(person_id=3001).count(), 1)
+        self.assertEqual(MeasurementOwnership.objects.filter(measurement_id=m_id).count(), 2)
+
+    def test_different_value_not_deduplicated(self):
+        """Same test on same day with different value creates two measurements."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        self.assertEqual(r1.data['created_count'], 1)
+
+        payload2 = self._payload()
+        payload2['measurements'][0]['value'] = '14.0'
+        r2 = self.client.post('/api/lab-results/sync/', payload2, format='json')
+        self.assertEqual(r2.data['created_count'], 1)
+        self.assertEqual(r2.data['deduplicated_count'], 0)
+
+        self.assertEqual(Measurement.objects.filter(person_id=3001).count(), 2)
+
+    def test_qualitative_dedup(self):
+        """Qualitative results (value=null, value_string set) are deduplicated correctly."""
+        payload = self._payload()
+        payload['measurements'] = [{
+            'loinc_code': '718-7',
+            'test_name': 'Hemoglobin',
+            'value': None,
+            'value_string': 'Negative',
+            'measured_at': '2026-05-15',
+        }]
+        r1 = self.client.post('/api/lab-results/sync/', payload, format='json')
+        self.assertEqual(r1.data['created_count'], 1)
+
+        r2 = self.client.post('/api/lab-results/sync/', payload, format='json')
+        self.assertEqual(r2.data['created_count'], 0)
+        self.assertEqual(r2.data['deduplicated_count'], 1)
+        self.assertEqual(r2.data['measurement_ids'], r1.data['measurement_ids'])
+
+    def test_qualitative_different_string_not_deduplicated(self):
+        """Same test, same day, null value, different value_string creates two measurements."""
+        payload1 = self._payload()
+        payload1['measurements'] = [{
+            'loinc_code': '718-7',
+            'test_name': 'Hemoglobin',
+            'value': None,
+            'value_string': 'Negative',
+            'measured_at': '2026-05-15',
+        }]
+        self.client.post('/api/lab-results/sync/', payload1, format='json')
+
+        payload2 = self._payload()
+        payload2['measurements'] = [{
+            'loinc_code': '718-7',
+            'test_name': 'Hemoglobin',
+            'value': None,
+            'value_string': 'Positive',
+            'measured_at': '2026-05-15',
+        }]
+        r2 = self.client.post('/api/lab-results/sync/', payload2, format='json')
+        self.assertEqual(r2.data['created_count'], 1)
+        self.assertEqual(Measurement.objects.filter(person_id=3001).count(), 2)
+
+    def test_delete_one_of_two_owners_preserves_measurement(self):
+        """Deleting one visit when two own the measurement preserves the measurement."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        r2 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        m_id = r1.data['measurement_ids'][0]
+        v1 = r1.data['visit_occurrence_id']
+
+        del_resp = self.client.delete(f'/api/lab-results/visits/{v1}/')
+        self.assertEqual(del_resp.status_code, 200)
+        self.assertEqual(del_resp.data['deleted_measurements'], 0)
+
+        # Measurement still exists, owned by second visit
+        self.assertTrue(Measurement.objects.filter(measurement_id=m_id).exists())
+        self.assertEqual(MeasurementOwnership.objects.filter(measurement_id=m_id).count(), 1)
+
+    def test_delete_last_owner_deletes_measurement(self):
+        """Deleting the last owning visit removes the measurement."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        r2 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        m_id = r1.data['measurement_ids'][0]
+
+        self.client.delete(f'/api/lab-results/visits/{r1.data["visit_occurrence_id"]}/')
+        self.assertTrue(Measurement.objects.filter(measurement_id=m_id).exists())
+
+        self.client.delete(f'/api/lab-results/visits/{r2.data["visit_occurrence_id"]}/')
+        self.assertFalse(Measurement.objects.filter(measurement_id=m_id).exists())
+
+    def test_ownership_records_created_on_sync(self):
+        """Every sync creates ownership records for all measurements."""
+        r = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        visit_id = r.data['visit_occurrence_id']
+        m_id = r.data['measurement_ids'][0]
+
+        self.assertTrue(
+            MeasurementOwnership.objects.filter(
+                measurement_id=m_id, visit_occurrence_id=visit_id,
+            ).exists()
+        )

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -9,7 +9,8 @@ from rest_framework.views import APIView
 
 from omop_core.models import (
     CareSite, Concept, LoincClass, LoincCodeClass,
-    Measurement, PatientInfo, ProvenanceRecord, VisitOccurrence,
+    Measurement, MeasurementOwnership, PatientInfo,
+    ProvenanceRecord, VisitOccurrence,
 )
 from patient_portal.api.permissions import ScopedTokenPermission, get_request_org
 
@@ -680,12 +681,35 @@ class VisitDeleteView(APIView):
                 object_id=visit_id,
             )
 
-            meas_count, _ = Measurement.objects.filter(
-                visit_occurrence=visit,
-            ).delete()
+            # Ownership-aware delete: only remove measurements with no remaining owners
+            owned_ids = list(
+                MeasurementOwnership.objects.filter(
+                    visit_occurrence_id=visit_id,
+                ).values_list('measurement_id', flat=True)
+            )
+            MeasurementOwnership.objects.filter(visit_occurrence_id=visit_id).delete()
+
+            if owned_ids:
+                still_owned = set(
+                    MeasurementOwnership.objects.filter(
+                        measurement_id__in=owned_ids,
+                    ).values_list('measurement_id', flat=True)
+                )
+                orphaned = [m_id for m_id in owned_ids if m_id not in still_owned]
+                if orphaned:
+                    Measurement.objects.filter(measurement_id__in=orphaned).delete()
+            else:
+                # Fallback for measurements created before ownership tracking
+                orphaned = list(
+                    Measurement.objects.filter(
+                        visit_occurrence=visit,
+                    ).values_list('measurement_id', flat=True)
+                )
+                Measurement.objects.filter(measurement_id__in=orphaned).delete()
+
             visit.delete()
 
         return Response(
-            {'deleted_measurements': meas_count},
+            {'deleted_measurements': len(orphaned)},
             status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## Summary
- Add `MeasurementOwnership` model that tracks which visits (uploads) own each measurement
- Dedup on write in `SyncView.post()`: before creating a measurement, check for existing match on `(person_id, date, concept, value_as_number, value_as_string)` using `IS NOT DISTINCT FROM` for NULL-safe comparison
- Ownership-aware delete in `VisitDeleteView`: only delete measurements that have zero remaining owners after removing the visit's ownership records
- Migration 0079 creates the table and backfills ownership for all existing measurements
- Response now includes `created_count` and `deduplicated_count`

## Test plan
- [x] 7 new tests pass: dedup, qualitative dedup, different-value-not-deduped, ownership create, delete-one-owner-preserves, delete-last-owner-removes
- [x] All 61 existing lab results tests still pass
- [ ] Deploy to staging, upload same PDF twice, verify only one set of measurements created
- [ ] Delete one upload, verify measurements preserved; delete second, verify measurements removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)