### PR TITLE
feat: HK-Labs integration — dedup, provenance, and UI fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,11 +430,12 @@ Expected output: `MISSING from DB: []` and `EXTRA in DB: []`.
 
 | Purpose | DATABASE_URL |
 |---|---|
-| Tests & local dev | `postgresql://postgres@localhost:5432/ctomop_test` |
+| Running tests | `postgresql://postgres@localhost:5432/ctomop_test` |
+| Local development (manual testing, sync uploads, shell exploration) | `postgresql://postgres@localhost:5432/ctomop_dev` |
 | Staging migrations | `postgresql://ctomop_dev_user:IehVp8TGNcelOymGcjtfL6Up6W63DOf2@dpg-d7pqr35ckfvc73bm0lc0-a.oregon-postgres.render.com/ctomop_dev` |
 | Production (read-only checks) | `postgresql://ctomop_user:K7mqaHP5krJHiojJFtZmCOepH3Lj66jl@dpg-d6ptpqi4d50c739fufqg-a.oregon-postgres.render.com/ctomop` |
 
-Never use the production DB for writes. Never use remote databases for running tests — use local PostgreSQL to match CI.
+Never use the production DB for writes. Never use remote databases for running tests — use local PostgreSQL to match CI. Never write test data into `ctomop_dev` — use `ctomop_test` for automated tests.
 
 ---
 

--- a/docs/lab-results-dedup-plan.md
+++ b/docs/lab-results-dedup-plan.md
@@ -20,14 +20,17 @@ In `SyncView.post()`, before creating each measurement, check for an existing ma
 SELECT measurement_id FROM measurement
 WHERE person_id = %s
   AND measurement_date = %s
-  AND (measurement_concept_id = %s OR measurement_source_value = %s)
-  AND value_as_number = %s  -- NULL-safe comparison for qualitative results
+  AND (measurement_concept_id = %s OR measurement_source_concept_id = %s)
+  AND value_as_number IS NOT DISTINCT FROM %s
+  AND value_as_string IS NOT DISTINCT FROM %s
 ```
 
-Match criteria: `(person_id, measurement_date, concept_id OR source_value, value_as_number)`
+Match criteria: `(person_id, measurement_date, concept_id OR source_concept_id, value_as_number, value_as_string)`
+
+`IS NOT DISTINCT FROM` handles NULL-safe comparison for both numeric and qualitative results — two NULLs match, NULL vs non-NULL does not.
 
 - If match found → reuse existing measurement_id, skip creation
-- If no match → create new measurement as before
+- If no match → create new measurement
 
 A new `VisitOccurrence` is always created (represents the upload/commit event).
 
@@ -35,8 +38,8 @@ A new `VisitOccurrence` is always created (represents the upload/commit event).
 
 ```python
 class MeasurementOwnership(models.Model):
-    measurement_id = models.IntegerField()
-    visit_occurrence_id = models.IntegerField()
+    measurement_id = models.BigIntegerField()
+    visit_occurrence_id = models.BigIntegerField()
 
     class Meta:
         db_table = "measurement_ownership"
@@ -50,7 +53,45 @@ class MeasurementOwnership(models.Model):
 - For every measurement (created or deduplicated), insert an ownership record linking it to the new visit
 - The Measurement's `visit_occurrence_id` FK stays pointing to the original creating visit (OMOP-compliant)
 
-### 3. Updated Sync Response
+### 3. Implementation Details
+
+#### PK allocation
+
+Currently `next_pk_batch()` reserves IDs for all items upfront. With dedup, reserve IDs only for measurements that need creation:
+
+```python
+# 1. Run dedup check for all items, collect (index, existing_measurement_id) pairs
+existing = {}
+for i, item in enumerate(items):
+    match = _find_existing_measurement(person_id, item, loinc_cache, hk_concept_cache)
+    if match:
+        existing[i] = match
+
+# 2. Reserve PKs only for new measurements
+new_count = len(items) - len(existing)
+new_ids = next_pk_batch(Measurement, 'measurement_id', new_count) if new_count else []
+
+# 3. Build objects for new measurements only, track all IDs for ownership
+new_id_iter = iter(new_ids)
+all_measurement_ids = []
+new_objects = []
+for i, item in enumerate(items):
+    if i in existing:
+        all_measurement_ids.append(existing[i])
+    else:
+        m_id = next(new_id_iter)
+        all_measurement_ids.append(m_id)
+        new_objects.append(_build_measurement(m_id, ...))
+
+if new_objects:
+    Measurement.objects.bulk_create(new_objects)
+```
+
+#### Provenance
+
+Provenance records are created for ALL measurements in the sync (created + deduplicated). This preserves the audit trail showing which uploads contributed to which measurements.
+
+### 4. Updated Sync Response
 
 ```json
 {
@@ -64,7 +105,7 @@ class MeasurementOwnership(models.Model):
 
 hk-labs doesn't need to distinguish — it stores `visit_occurrence_id` and considers the upload saved.
 
-### 4. Updated Delete Logic (VisitDeleteView)
+### 5. Updated Delete Logic (VisitDeleteView)
 
 When deleting a visit:
 
@@ -74,23 +115,29 @@ When deleting a visit:
 4. Delete the `VisitOccurrence` itself
 
 ```python
-# Pseudocode
-ownership_measurement_ids = MeasurementOwnership.objects.filter(
-    visit_occurrence_id=visit_id
-).values_list("measurement_id", flat=True)
+with transaction.atomic():
+    owned_ids = list(
+        MeasurementOwnership.objects.filter(
+            visit_occurrence_id=visit_id
+        ).values_list("measurement_id", flat=True)
+    )
 
-MeasurementOwnership.objects.filter(visit_occurrence_id=visit_id).delete()
+    MeasurementOwnership.objects.filter(visit_occurrence_id=visit_id).delete()
 
-orphaned = [
-    m_id for m_id in ownership_measurement_ids
-    if not MeasurementOwnership.objects.filter(measurement_id=m_id).exists()
-]
+    # Find measurements with no remaining owners
+    from django.db.models import Subquery
+    still_owned = set(
+        MeasurementOwnership.objects.filter(
+            measurement_id__in=owned_ids
+        ).values_list("measurement_id", flat=True)
+    )
+    orphaned = [m_id for m_id in owned_ids if m_id not in still_owned]
 
-Measurement.objects.filter(measurement_id__in=orphaned).delete()
-VisitOccurrence.objects.filter(visit_occurrence_id=visit_id).delete()
+    Measurement.objects.filter(measurement_id__in=orphaned).delete()
+    visit.delete()
 ```
 
-### 5. hk-labs Changes
+### 6. hk-labs Changes
 
 None required. The existing flow works:
 - `ctomop_client.sync_measurements()` — returns success with measurement_ids (created or deduplicated)
@@ -100,10 +147,11 @@ None required. The existing flow works:
 
 | Scenario | Behavior |
 |----------|----------|
-| Same PDF uploaded twice | Second commit deduplicates all 67 measurements, creates new visit, adds ownership records |
+| Same PDF uploaded twice | Second commit deduplicates all measurements, creates new visit, adds ownership records |
 | Same test on same day from different labs | Different `care_site` but dedup matches on value — acceptable for patient-uploaded reports |
 | Same test, same day, different value | Not deduplicated (different `value_as_number`) — both kept |
-| Qualitative result (value=NULL, value_string="Negative") | Match on `value_as_number IS NULL AND measurement_source_value` |
+| Same test, same day, same numeric value, different string value | Not deduplicated (different `value_as_string`) — both kept |
+| Qualitative result (value=NULL, value_string="Negative") | Matches via `IS NOT DISTINCT FROM` on both `value_as_number` (NULL=NULL) and `value_as_string` |
 | Delete one of two duplicate uploads | Ownership records removed, measurements preserved (still owned by other visit) |
 | Delete last remaining upload | Ownership count drops to 0, measurements deleted |
 
@@ -118,6 +166,6 @@ None required. The existing flow works:
 ## Files to Modify
 
 - `omop_core/models.py` — add `MeasurementOwnership` model
-- `patient_portal/api/lab_results/sync.py` — add dedup check in `_build_measurement` loop
+- `patient_portal/api/lab_results/sync.py` — add dedup check in measurement loop, split `bulk_create` for new-only, add ownership records
 - `patient_portal/api/lab_results/views.py` — update `VisitDeleteView` delete logic
 - New migration for `measurement_ownership` table + backfill

--- a/frontend/src/federation/LabResults.tsx
+++ b/frontend/src/federation/LabResults.tsx
@@ -38,7 +38,8 @@ function ResultDetail({
   const latest = values[0];
   const testName = data?.original_name || data?.concept_name || "";
   const category = data?.category ?? "";
-  const isQualitative = latest && latest.value == null && latest.value_string != null;
+  const hasNumeric = values.some((v) => v.value != null);
+  const isQualitative = !hasNumeric;
   const unit = latest?.unit ?? "";
 
   if (isError) {
@@ -134,11 +135,22 @@ function ResultDetail({
                     </div>
                     <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
                       {r.measured_at && <span>{formatShortDate(r.measured_at)}</span>}
-                      <DataSourceBadge
-                        source={r.source}
-                        labName={r.lab_name}
-                        reportFilename={r.report_filename}
-                      />
+                      {r.uploads && r.uploads.length > 1 ? (
+                        r.uploads.map((u, i) => (
+                          <DataSourceBadge
+                            key={i}
+                            source={r.source}
+                            labName={u.lab_name}
+                            reportFilename={u.report_filename}
+                          />
+                        ))
+                      ) : (
+                        <DataSourceBadge
+                          source={r.source}
+                          labName={r.lab_name}
+                          reportFilename={r.report_filename}
+                        />
+                      )}
                       {(r.range_low != null || r.range_high != null) && (
                         <span>
                           ref{" "}

--- a/frontend/src/federation/types.ts
+++ b/frontend/src/federation/types.ts
@@ -28,6 +28,11 @@ export interface LabResultsProps extends LabsBaseProps {
 
 export type LabValueStatus = "in_range" | "below" | "above" | "unknown";
 
+export interface UploadProvenance {
+  lab_name: string | null;
+  report_filename: string | null;
+}
+
 export interface LabResultValue {
   measurement_id: number;
   value: number | null;
@@ -40,6 +45,7 @@ export interface LabResultValue {
   source: string | null;
   lab_name: string | null;
   report_filename: string | null;
+  uploads?: UploadProvenance[];
 }
 
 export interface LabResultCard {

--- a/omop_core/migrations/0079_measurement_ownership.py
+++ b/omop_core/migrations/0079_measurement_ownership.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+
+def backfill_ownership(apps, schema_editor):
+    """Create ownership records for all existing measurements."""
+    MeasurementOwnership = apps.get_model('omop_core', 'MeasurementOwnership')
+    Measurement = apps.get_model('omop_core', 'Measurement')
+
+    rows = Measurement.objects.filter(
+        visit_occurrence_id__isnull=False,
+    ).values_list('measurement_id', 'visit_occurrence_id')
+
+    batch = []
+    for m_id, v_id in rows.iterator(chunk_size=2000):
+        batch.append(MeasurementOwnership(
+            measurement_id=m_id,
+            visit_occurrence_id=v_id,
+        ))
+        if len(batch) >= 2000:
+            MeasurementOwnership.objects.bulk_create(batch, ignore_conflicts=True)
+            batch = []
+    if batch:
+        MeasurementOwnership.objects.bulk_create(batch, ignore_conflicts=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('omop_core', '0078_backfill_measurement_source_value'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MeasurementOwnership',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('measurement_id', models.BigIntegerField()),
+                ('visit_occurrence_id', models.BigIntegerField()),
+            ],
+            options={
+                'db_table': 'measurement_ownership',
+                'unique_together': {('measurement_id', 'visit_occurrence_id')},
+            },
+        ),
+        migrations.AddIndex(
+            model_name='measurementownership',
+            index=models.Index(fields=['visit_occurrence_id'], name='ix_measown_visit'),
+        ),
+        migrations.RunPython(backfill_ownership, migrations.RunPython.noop),
+    ]

--- a/omop_core/models.py
+++ b/omop_core/models.py
@@ -626,6 +626,24 @@ class Measurement(models.Model):
         return f"Measurement {self.measurement_id} for Person {self.person_id}"
 
 
+class MeasurementOwnership(models.Model):
+    """Tracks which VisitOccurrences (uploads) contributed to a Measurement.
+
+    When the same lab result is uploaded multiple times, dedup reuses the
+    existing Measurement but adds an ownership record for each visit.
+    A Measurement is only deleted when its last ownership record is removed.
+    """
+    measurement_id = models.BigIntegerField()
+    visit_occurrence_id = models.BigIntegerField()
+
+    class Meta:
+        db_table = 'measurement_ownership'
+        unique_together = [('measurement_id', 'visit_occurrence_id')]
+        indexes = [
+            models.Index(fields=['visit_occurrence_id'], name='ix_measown_visit'),
+        ]
+
+
 class Observation(models.Model):
     """OMOP CDM Observation table - clinical facts that don't fit other domains."""
     observation_id = models.BigIntegerField(primary_key=True)

--- a/patient_portal/api/lab_results/serializers.py
+++ b/patient_portal/api/lab_results/serializers.py
@@ -1,6 +1,11 @@
 from rest_framework import serializers
 
 
+class UploadProvenanceSerializer(serializers.Serializer):
+    lab_name = serializers.CharField(allow_null=True)
+    report_filename = serializers.CharField(allow_null=True)
+
+
 class LabValueSerializer(serializers.Serializer):
     measurement_id = serializers.IntegerField()
     value = serializers.DecimalField(max_digits=15, decimal_places=5, allow_null=True)
@@ -13,6 +18,7 @@ class LabValueSerializer(serializers.Serializer):
     source = serializers.CharField(allow_null=True)
     lab_name = serializers.CharField(allow_null=True)
     report_filename = serializers.CharField(allow_null=True)
+    uploads = UploadProvenanceSerializer(many=True, required=False, default=list)
 
 
 class MeasurementUpdateSerializer(serializers.Serializer):

--- a/patient_portal/api/lab_results/sync.py
+++ b/patient_portal/api/lab_results/sync.py
@@ -26,7 +26,8 @@ from rest_framework.views import APIView
 
 from omop_core.authorization import can_access_patient, get_actor_role
 from omop_core.models import (
-    CareSite, Concept, Measurement, Person, ProvenanceRecord, VisitOccurrence,
+    CareSite, Concept, Measurement, MeasurementOwnership,
+    Person, ProvenanceRecord, VisitOccurrence,
 )
 from omop_core.services.pk import next_pk, next_pk_batch
 from patient_portal.api.permissions import ScopedTokenPermission, get_request_org
@@ -267,10 +268,31 @@ class SyncView(APIView):
             type_concept=type_concept,
         )
 
-        measurement_ids = next_pk_batch(Measurement, 'measurement_id', len(items))
-        measurement_objects = []
-        for m_id, item in zip(measurement_ids, items):
-            measurement_objects.append(self._build_measurement(
+        # Dedup: check for existing measurements, only create new ones
+        all_measurement_ids = []
+        new_items = []
+        deduplicated_count = 0
+
+        for item in items:
+            existing_id = self._find_existing_measurement(
+                person_id, item, loinc_cache, hk_concept_cache,
+            )
+            if existing_id is not None:
+                all_measurement_ids.append(existing_id)
+                deduplicated_count += 1
+            else:
+                all_measurement_ids.append(None)
+                new_items.append(item)
+
+        new_ids = next_pk_batch(Measurement, 'measurement_id', len(new_items)) if new_items else []
+        new_id_iter = iter(new_ids)
+        new_objects = []
+        for i, item in enumerate(items):
+            if all_measurement_ids[i] is not None:
+                continue
+            m_id = next(new_id_iter)
+            all_measurement_ids[i] = m_id
+            new_objects.append(self._build_measurement(
                 measurement_id=m_id,
                 person_id=person_id,
                 item=item,
@@ -280,7 +302,20 @@ class SyncView(APIView):
                 ucum_cache=ucum_cache,
                 hk_concept_cache=hk_concept_cache,
             ))
-        Measurement.objects.bulk_create(measurement_objects)
+        if new_objects:
+            Measurement.objects.bulk_create(new_objects)
+
+        # Ownership: link all measurements (created + deduped) to this visit
+        MeasurementOwnership.objects.bulk_create(
+            [
+                MeasurementOwnership(
+                    measurement_id=m_id,
+                    visit_occurrence_id=visit.visit_occurrence_id,
+                )
+                for m_id in all_measurement_ids
+            ],
+            ignore_conflicts=True,
+        )
 
         # Provenance
         self._record_provenance(
@@ -290,15 +325,18 @@ class SyncView(APIView):
             target_person_id=person_id,
             is_on_behalf_of=is_on_behalf_of,
             visit=visit,
-            measurement_ids=measurement_ids,
+            measurement_ids=all_measurement_ids,
             org=org,
             source_type=source_type,
         )
 
+        created_count = len(new_objects)
         return Response({
             'visit_occurrence_id': visit.visit_occurrence_id,
-            'measurement_ids': measurement_ids,
-            'count': len(measurement_ids),
+            'measurement_ids': all_measurement_ids,
+            'count': len(all_measurement_ids),
+            'created_count': created_count,
+            'deduplicated_count': deduplicated_count,
         }, status=status.HTTP_201_CREATED)
 
     def _resolve_actor_identity(self, actor_iss, actor_sub, request_user):
@@ -476,3 +514,42 @@ class SyncView(APIView):
             unit_source_value=(item.get('source_unit') or item.get('unit') or '')[:50],
             value_source_value=(item.get('source_text') or '')[:50],
         )
+
+    _DEDUP_SQL = """
+    SELECT measurement_id FROM measurement
+    WHERE person_id = %s
+      AND measurement_date = %s
+      AND (measurement_concept_id = %s OR measurement_source_concept_id = %s)
+      AND value_as_number IS NOT DISTINCT FROM %s
+      AND value_as_string IS NOT DISTINCT FROM %s
+    LIMIT 1
+    """
+
+    def _find_existing_measurement(self, person_id, item, loinc_cache, hk_concept_cache):
+        """Return measurement_id of an existing duplicate, or None."""
+        loinc_code = item.get('loinc_code')
+        test_name = item['test_name']
+
+        concept_id = 0
+        source_concept_id = None
+        if loinc_code:
+            concept = loinc_cache.get(loinc_code)
+            if concept:
+                concept_id = concept.concept_id
+            else:
+                source_concept_id = hk_concept_cache.get(test_name)
+        else:
+            source_concept_id = hk_concept_cache.get(test_name)
+
+        from django.db import connection
+        with connection.cursor() as cur:
+            cur.execute(self._DEDUP_SQL, [
+                person_id,
+                item['measured_at'],
+                concept_id,
+                source_concept_id,
+                item.get('value'),
+                item.get('value_string') or '',
+            ])
+            row = cur.fetchone()
+        return row[0] if row else None

--- a/patient_portal/api/lab_results/tests.py
+++ b/patient_portal/api/lab_results/tests.py
@@ -11,7 +11,8 @@ from rest_framework.test import APIClient
 
 from omop_core.models import (
     CareSite, Concept, ConceptClass, Domain, LoincClass, LoincCodeClass,
-    Measurement, Person, PatientInfo, Vocabulary, VisitOccurrence,
+    Measurement, MeasurementOwnership, Person, PatientInfo, Vocabulary,
+    VisitOccurrence,
 )
 
 
@@ -1084,3 +1085,148 @@ class SyncNonSuperuserTest(TestCase):
     def test_sync_nonexistent_person_denied(self):
         resp = self.client.post('/api/lab-results/sync/', self._payload(person_id=9999), format='json')
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class DedupSyncTest(TestCase):
+    """Tests for measurement deduplication on sync."""
+
+    def setUp(self):
+        _setup_vocab()
+        self.user = Identity.objects.create_user(email='dedup@test.com', password='test')
+        self.user.is_superuser = True
+        self.user.save()
+        self.person = Person.objects.create(person_id=3001)
+        PatientInfo.objects.create(person=self.person)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _payload(self, **overrides):
+        data = {
+            'person_id': 3001,
+            'measurements': [
+                {
+                    'loinc_code': '718-7',
+                    'test_name': 'Hemoglobin',
+                    'value': '13.5',
+                    'unit': 'g/dL',
+                    'measured_at': '2026-05-15',
+                },
+            ],
+            'lab_name': 'Quest',
+            'lab_date': '2026-05-15',
+            'report_filename': 'report.pdf',
+            'source_type': 'document_extraction',
+        }
+        data.update(overrides)
+        return data
+
+    def test_duplicate_upload_deduplicates(self):
+        """Same report uploaded twice creates one measurement, two visits, two ownership records."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        self.assertEqual(r1.status_code, 201)
+        self.assertEqual(r1.data['created_count'], 1)
+        self.assertEqual(r1.data['deduplicated_count'], 0)
+        m_id = r1.data['measurement_ids'][0]
+
+        r2 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        self.assertEqual(r2.status_code, 201)
+        self.assertEqual(r2.data['created_count'], 0)
+        self.assertEqual(r2.data['deduplicated_count'], 1)
+        self.assertEqual(r2.data['measurement_ids'][0], m_id)
+
+        self.assertEqual(Measurement.objects.filter(person_id=3001).count(), 1)
+        self.assertEqual(MeasurementOwnership.objects.filter(measurement_id=m_id).count(), 2)
+
+    def test_different_value_not_deduplicated(self):
+        """Same test on same day with different value creates two measurements."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        self.assertEqual(r1.data['created_count'], 1)
+
+        payload2 = self._payload()
+        payload2['measurements'][0]['value'] = '14.0'
+        r2 = self.client.post('/api/lab-results/sync/', payload2, format='json')
+        self.assertEqual(r2.data['created_count'], 1)
+        self.assertEqual(r2.data['deduplicated_count'], 0)
+
+        self.assertEqual(Measurement.objects.filter(person_id=3001).count(), 2)
+
+    def test_qualitative_dedup(self):
+        """Qualitative results (value=null, value_string set) are deduplicated correctly."""
+        payload = self._payload()
+        payload['measurements'] = [{
+            'loinc_code': '718-7',
+            'test_name': 'Hemoglobin',
+            'value': None,
+            'value_string': 'Negative',
+            'measured_at': '2026-05-15',
+        }]
+        r1 = self.client.post('/api/lab-results/sync/', payload, format='json')
+        self.assertEqual(r1.data['created_count'], 1)
+
+        r2 = self.client.post('/api/lab-results/sync/', payload, format='json')
+        self.assertEqual(r2.data['created_count'], 0)
+        self.assertEqual(r2.data['deduplicated_count'], 1)
+        self.assertEqual(r2.data['measurement_ids'], r1.data['measurement_ids'])
+
+    def test_qualitative_different_string_not_deduplicated(self):
+        """Same test, same day, null value, different value_string creates two measurements."""
+        payload1 = self._payload()
+        payload1['measurements'] = [{
+            'loinc_code': '718-7',
+            'test_name': 'Hemoglobin',
+            'value': None,
+            'value_string': 'Negative',
+            'measured_at': '2026-05-15',
+        }]
+        self.client.post('/api/lab-results/sync/', payload1, format='json')
+
+        payload2 = self._payload()
+        payload2['measurements'] = [{
+            'loinc_code': '718-7',
+            'test_name': 'Hemoglobin',
+            'value': None,
+            'value_string': 'Positive',
+            'measured_at': '2026-05-15',
+        }]
+        r2 = self.client.post('/api/lab-results/sync/', payload2, format='json')
+        self.assertEqual(r2.data['created_count'], 1)
+        self.assertEqual(Measurement.objects.filter(person_id=3001).count(), 2)
+
+    def test_delete_one_of_two_owners_preserves_measurement(self):
+        """Deleting one visit when two own the measurement preserves the measurement."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        r2 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        m_id = r1.data['measurement_ids'][0]
+        v1 = r1.data['visit_occurrence_id']
+
+        del_resp = self.client.delete(f'/api/lab-results/visits/{v1}/')
+        self.assertEqual(del_resp.status_code, 200)
+        self.assertEqual(del_resp.data['deleted_measurements'], 0)
+
+        # Measurement still exists, owned by second visit
+        self.assertTrue(Measurement.objects.filter(measurement_id=m_id).exists())
+        self.assertEqual(MeasurementOwnership.objects.filter(measurement_id=m_id).count(), 1)
+
+    def test_delete_last_owner_deletes_measurement(self):
+        """Deleting the last owning visit removes the measurement."""
+        r1 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        r2 = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        m_id = r1.data['measurement_ids'][0]
+
+        self.client.delete(f'/api/lab-results/visits/{r1.data["visit_occurrence_id"]}/')
+        self.assertTrue(Measurement.objects.filter(measurement_id=m_id).exists())
+
+        self.client.delete(f'/api/lab-results/visits/{r2.data["visit_occurrence_id"]}/')
+        self.assertFalse(Measurement.objects.filter(measurement_id=m_id).exists())
+
+    def test_ownership_records_created_on_sync(self):
+        """Every sync creates ownership records for all measurements."""
+        r = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
+        visit_id = r.data['visit_occurrence_id']
+        m_id = r.data['measurement_ids'][0]
+
+        self.assertTrue(
+            MeasurementOwnership.objects.filter(
+                measurement_id=m_id, visit_occurrence_id=visit_id,
+            ).exists()
+        )

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -9,7 +9,8 @@ from rest_framework.views import APIView
 
 from omop_core.models import (
     CareSite, Concept, LoincClass, LoincCodeClass,
-    Measurement, PatientInfo, ProvenanceRecord, VisitOccurrence,
+    Measurement, MeasurementOwnership, PatientInfo,
+    ProvenanceRecord, VisitOccurrence,
 )
 from patient_portal.api.permissions import ScopedTokenPermission, get_request_org
 
@@ -680,12 +681,35 @@ class VisitDeleteView(APIView):
                 object_id=visit_id,
             )
 
-            meas_count, _ = Measurement.objects.filter(
-                visit_occurrence=visit,
-            ).delete()
+            # Ownership-aware delete: only remove measurements with no remaining owners
+            owned_ids = list(
+                MeasurementOwnership.objects.filter(
+                    visit_occurrence_id=visit_id,
+                ).values_list('measurement_id', flat=True)
+            )
+            MeasurementOwnership.objects.filter(visit_occurrence_id=visit_id).delete()
+
+            if owned_ids:
+                still_owned = set(
+                    MeasurementOwnership.objects.filter(
+                        measurement_id__in=owned_ids,
+                    ).values_list('measurement_id', flat=True)
+                )
+                orphaned = [m_id for m_id in owned_ids if m_id not in still_owned]
+                if orphaned:
+                    Measurement.objects.filter(measurement_id__in=orphaned).delete()
+            else:
+                # Fallback for measurements created before ownership tracking
+                orphaned = list(
+                    Measurement.objects.filter(
+                        visit_occurrence=visit,
+                    ).values_list('measurement_id', flat=True)
+                )
+                Measurement.objects.filter(measurement_id__in=orphaned).delete()
+
             visit.delete()
 
         return Response(
-            {'deleted_measurements': meas_count},
+            {'deleted_measurements': len(orphaned)},
             status=status.HTTP_200_OK,
         )

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -433,6 +433,7 @@ class ValuesView(APIView):
         page = paginator.paginate_queryset(measurements, request)
 
         provenance = self._load_provenance(page)
+        ownership_map = self._load_ownership(page, provenance)
         values = []
         for m in page:
             unit_str = m.unit_source_value
@@ -446,6 +447,7 @@ class ValuesView(APIView):
                     type_label = m.measurement_type_concept.concept_name
 
             prov = provenance.get(m.visit_occurrence_id, {})
+            uploads = ownership_map.get(m.measurement_id, [])
             values.append({
                 'measurement_id': m.measurement_id,
                 'value': m.value_as_number,
@@ -458,6 +460,7 @@ class ValuesView(APIView):
                 'source': type_label,
                 'lab_name': prov.get('lab_name'),
                 'report_filename': prov.get('report_filename'),
+                'uploads': uploads,
             })
 
         original_name = None
@@ -479,6 +482,40 @@ class ValuesView(APIView):
     def _load_provenance(self, measurements):
         visit_ids = {m.visit_occurrence_id for m in measurements if m.visit_occurrence_id}
         return _load_visit_provenance(visit_ids)
+
+    @staticmethod
+    def _load_ownership(measurements, existing_provenance):
+        """Return {measurement_id: [{lab_name, report_filename}, ...]} for all owning visits."""
+        m_ids = [m.measurement_id for m in measurements]
+        if not m_ids:
+            return {}
+
+        ownership_rows = MeasurementOwnership.objects.filter(
+            measurement_id__in=m_ids,
+        ).values_list('measurement_id', 'visit_occurrence_id')
+
+        extra_visit_ids = set()
+        m_to_visits = defaultdict(list)
+        for m_id, v_id in ownership_rows:
+            m_to_visits[m_id].append(v_id)
+            if v_id not in existing_provenance:
+                extra_visit_ids.add(v_id)
+
+        all_provenance = dict(existing_provenance)
+        if extra_visit_ids:
+            all_provenance.update(_load_visit_provenance(extra_visit_ids))
+
+        result = {}
+        for m_id, visit_ids in m_to_visits.items():
+            uploads = []
+            for v_id in visit_ids:
+                prov = all_provenance.get(v_id, {})
+                uploads.append({
+                    'lab_name': prov.get('lab_name'),
+                    'report_filename': prov.get('report_filename'),
+                })
+            result[m_id] = uploads
+        return result
 
 
 class MeasurementDetailView(APIView):


### PR DESCRIPTION
## Summary

Combines PRs #98, #99, #100 into a single integration PR.

### Measurement deduplication (#99)
- Add `MeasurementOwnership` model to track which visits/uploads own each measurement
- Dedup-on-write in sync endpoint: identical measurements are not duplicated, ownership is shared
- Ownership-aware delete: only removes measurements with zero remaining owners
- Backfill migration for existing measurements
- 7 dedup tests

### Multi-upload provenance UI (#100)
- Show multiple DataSourceBadge components when a measurement belongs to multiple uploads
- Add `uploads` array to lab values API response via ownership lookup
- Fix DataSourceBadge to show report filename alongside lab name
- Fix trend chart hidden when latest value is qualitative but others are numeric

### Docs (#98)
- Updated lab results dedup plan with code analysis refinements

### Other
- Update CLAUDE.md database selection rule (ctomop_test vs ctomop_dev)

## Test plan
- [ ] Upload same lab report twice — verify dedup (created_count=0, deduplicated_count=N)
- [ ] Delete one of two uploads — verify measurements preserved (still owned by other)
- [ ] Delete last upload — verify measurements removed
- [ ] Lab detail page shows multiple provenance badges for deduped measurements
- [ ] Trend chart renders when latest value is qualitative but others are numeric
- [ ] Run backend tests: `DATABASE_URL=postgresql://postgres@localhost:5432/ctomop_test .venv/bin/python manage.py test patient_portal.api.lab_results --keepdb`

Closes #98, closes #99, closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)