### PR TITLE
feat: rename Patient Info to Health Profile, fix layout

### DIFF
--- a/frontend/src/federation/LabResults.tsx
+++ b/frontend/src/federation/LabResults.tsx
@@ -82,7 +82,7 @@ function ResultDetail({
         {category && (
           <p className="text-xs uppercase tracking-wide text-muted-foreground">{category}</p>
         )}
-        <h2 className="text-xl font-bold text-foreground">{testName}</h2>
+        <h2 className="text-lg font-medium text-foreground/70">{testName}</h2>
         {data?.vocabulary_id === "LOINC" && (
           <p className="text-xs text-muted-foreground">
             LOINC {data.concept_code} · {data.concept_name}
@@ -111,7 +111,7 @@ function ResultDetail({
       )}
 
       <div>
-        <h3 className="mb-2 text-sm font-semibold text-foreground">History</h3>
+        <h3 className="mb-2 text-sm font-medium text-foreground/70">History</h3>
         {values.length === 0 ? (
           <Card>
             <CardContent className="p-6 text-center">
@@ -338,7 +338,7 @@ function SummaryList({
       <h2 className="text-lg font-medium text-foreground/70">Lab Results</h2>
       {categoryGroups.map(([category, groupCards]) => (
         <div key={category}>
-          <h3 className="mb-2 text-sm font-semibold text-foreground/70">
+          <h3 className="mb-2 text-sm font-medium text-foreground/70">
             {category}
           </h3>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/frontend/src/federation/PatientInfo.tsx
+++ b/frontend/src/federation/PatientInfo.tsx
@@ -59,7 +59,7 @@ function PatientInfoSkeleton() {
           <div key={i} className="h-4 w-16 animate-pulse rounded bg-muted" />
         ))}
       </div>
-      <div className="space-y-10 rounded-2xl bg-background px-8 py-8 shadow-sm">
+      <div className="space-y-10 pt-2">
         <div>
           <div className="mb-2 h-6 w-20 animate-pulse rounded bg-muted" />
           <div className="mb-7 h-3.5 w-64 animate-pulse rounded bg-muted" />
@@ -245,7 +245,7 @@ function PatientInfoInner({ readOnly, onPatientUpdated }: Pick<PatientInfoProps,
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-foreground">Patient Info</h1>
+        <h1 className="text-lg font-medium text-foreground/70">Health Profile</h1>
         <SaveStatusIndicator status={saveStatus} onRetry={doSave} />
       </div>
 
@@ -268,13 +268,13 @@ function PatientInfoInner({ readOnly, onPatientUpdated }: Pick<PatientInfoProps,
         </nav>
       </div>
 
-      <div className="rounded-2xl bg-background shadow-sm">
-        <div className="px-8 pb-6 pt-8">
-          <h2 className="text-xl font-bold text-foreground">{tabLabels[activeTab]}</h2>
+      <div>
+        <div className="pb-4 pt-2">
+          <h2 className="text-base font-medium text-foreground/70">{tabLabels[activeTab]}</h2>
           <p className="mt-1 text-sm text-muted-foreground">{tabDescriptions[activeTab]}</p>
         </div>
 
-        <div className="px-8 pb-10">
+        <div>
           {activeTab === 0 && (
             <GeneralTab
               formData={editedInfo}


### PR DESCRIPTION
## Summary
- Rename page title from "Patient Info" to "Health Profile"
- Normalize all federation heading styles to `font-medium text-foreground/70` for consistency with ht-phr host
- Remove card wrapper (`rounded-2xl shadow-sm`) from PatientInfo tab content — eliminates excess margin between tabs and first content item, aligns content left edge with tab labels
- Update LabResults detail heading and History/category h3 styles to match

## Test plan
- [ ] Verify Health Profile page shows "Health Profile" as title
- [ ] Verify tab content aligns left with the first tab label (no rightward shift)
- [ ] Verify reduced gap between tab bar and first form field
- [ ] Verify Lab Results detail view headings are consistent
- [ ] Verify skeleton loading state matches new layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)