### PR TITLE
fix(pk): self-heal OMOP sequences against legacy MAX(id)+1 writers

### DIFF
--- a/omop_core/services/pk.py
+++ b/omop_core/services/pk.py
@@ -1,4 +1,12 @@
-"""PostgreSQL sequence-based PK generation for OMOP tables."""
+"""PostgreSQL sequence-based PK generation for OMOP tables.
+
+Some legacy write paths (patient_portal/api/views.py, lot_inference_service,
+omop_write_service) assign PKs as ``MAX(id)+1`` with an explicit value, which
+does NOT advance the table's sequence. That strands the sequence behind the
+table max, so a later ``nextval`` here would hand out an already-used id and
+hit a duplicate-key error. To stay robust against those writers, every
+allocation first self-heals the sequence to ``>= MAX(pk)`` before drawing.
+"""
 from django.db import connection
 
 _SEQ_NAME_TEMPLATE = '{table}_{pk_field}_seq'
@@ -10,11 +18,28 @@ def _seq_name(model, pk_field):
     )
 
 
+def _reseed_to_max(cur, model, pk_field, seq):
+    """Advance ``seq`` so the next value exceeds both its current position and
+    ``MAX(pk)`` — making sequence allocation immune to legacy MAX(id)+1 writers
+    that bypass the sequence. (Identifiers come from model meta, not user input.)
+    """
+    table = connection.ops.quote_name(model._meta.db_table)
+    col = connection.ops.quote_name(pk_field)
+    qseq = connection.ops.quote_name(seq)
+    cur.execute(
+        f"SELECT setval(%s, GREATEST("
+        f"(SELECT last_value FROM {qseq}), "
+        f"(SELECT COALESCE(MAX({col}), 0) FROM {table})), true)",
+        [seq],
+    )
+
+
 def next_pk(model, pk_field):
     """Return the next PK value from the table's sequence."""
     seq = _seq_name(model, pk_field)
     with connection.cursor() as cur:
         cur.execute("SET LOCAL statement_timeout = '5s'")
+        _reseed_to_max(cur, model, pk_field, seq)
         cur.execute("SELECT nextval(%s)", [seq])
         return cur.fetchone()[0]
 
@@ -26,6 +51,7 @@ def next_pk_batch(model, pk_field, count):
     seq = _seq_name(model, pk_field)
     with connection.cursor() as cur:
         cur.execute("SET LOCAL statement_timeout = '5s'")
+        _reseed_to_max(cur, model, pk_field, seq)
         cur.execute(
             "SELECT nextval(%s) FROM generate_series(1, %s)",
             [seq, count],

--- a/patient_portal/api/fhir/tests.py
+++ b/patient_portal/api/fhir/tests.py
@@ -71,7 +71,13 @@ SAMPLE_BUNDLE = {
 class FhirSyncTests(TestCase):
     def setUp(self):
         _ensure_pk_sequences()
-        self.user = Identity.objects.create_user(email='fhirsync@test.com', password='test')
+        # POST /api/fhir/sync/ is privileged since the ScopedTokenPermission role
+        # change (a5e0ac6): only service-token / staff / superuser may write —
+        # plain patient identities get 403. The connector calls it with a service
+        # token; these tests exercise the request.user person-resolution path, so
+        # authenticate as staff to retain write access.
+        self.user = Identity.objects.create_user(
+            email='fhirsync@test.com', password='test', is_staff=True)
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
 
@@ -198,7 +204,7 @@ class FhirSyncTests(TestCase):
             return {"resourceType": "Bundle", "type": "collection", "entry": entries}
 
         def run(email, n):
-            user = Identity.objects.create_user(email=email, password="test")
+            user = Identity.objects.create_user(email=email, password="test", is_staff=True)
             client = APIClient()
             client.force_authenticate(user=user)
             with CaptureQueriesContext(connection) as ctx:

--- a/patient_portal/api/fhir/tests.py
+++ b/patient_portal/api/fhir/tests.py
@@ -78,6 +78,34 @@ class FhirSyncTests(TestCase):
     def _sync(self):
         return self.client.post('/api/fhir/sync/', {'bundle': SAMPLE_BUNDLE}, format='json')
 
+    def test_next_pk_batch_self_heals_after_legacy_explicit_pk_insert(self):
+        """Legacy MAX(id)+1 writers (views.py, lot_inference) set explicit PKs
+        without advancing the sequence; the sequence-based sync path must not
+        then hand out an already-used id (the duplicate-key 500 we hit in prod)."""
+        from omop_core.services.pk import next_pk_batch
+
+        self.assertEqual(self._sync().status_code, 201)
+        existing = ConditionOccurrence.objects.first()
+        self.assertIsNotNone(existing)
+
+        # Simulate the legacy path: explicit PK far ahead, sequence NOT advanced.
+        stranded_id = existing.condition_occurrence_id + 500
+        legacy = ConditionOccurrence(
+            condition_occurrence_id=stranded_id,
+            person=existing.person,
+            condition_concept=existing.condition_concept,
+            condition_start_date=existing.condition_start_date,
+            condition_type_concept=existing.condition_type_concept,
+            condition_source_value='legacy',
+        )
+        legacy._skip_patient_info_refresh = True
+        legacy.save()
+
+        # Sequence is now behind the table max → next_pk_batch must self-heal.
+        ids = next_pk_batch(ConditionOccurrence, 'condition_occurrence_id', 3)
+        self.assertTrue(all(i > stranded_id for i in ids), ids)
+        self.assertEqual(len(set(ids)), 3)
+
     def test_rejects_non_bundle(self):
         resp = self.client.post('/api/fhir/sync/', {'bundle': {'resourceType': 'Patient'}}, format='json')
         self.assertEqual(resp.status_code, 400)


### PR DESCRIPTION
## Problem
`/api/fhir/sync/` was returning intermittent 500s in staging:
`duplicate key value violates unique constraint "condition_occurrence_pkey"`.

**Root cause:** legacy write paths (`patient_portal/api/views.py`,
`lot_inference_service`, `omop_write_service`) assign OMOP PKs as `MAX(id)+1`
with an explicit value and **never advance the table's Postgres sequence**. The
FHIR sync path allocates via `nextval`, so once a legacy writer runs (e.g. the
demo/breast-cancer import creating conditions for sample patients), the sequence
is stranded behind the table max and `nextval` hands out an already-used id.

## Fix
`next_pk` / `next_pk_batch` now `setval` the sequence to
`GREATEST(last_value, MAX(pk))` before drawing, making sequence allocation
immune to the legacy writers without rewriting them. Adds a regression test that
strands the sequence with an explicit-PK insert and asserts the next batch skips
past it.

Residual narrow race remains if a legacy `MAX(id)+1` writer commits between the
reseed and `nextval`; the durable cure is to migrate those writers to `next_pk`
(follow-up).

## Also (test-only)
a5e0ac6's `ScopedTokenPermission` role change made POST `/api/fhir/sync/`
privileged (service-token / staff / superuser), which left the fhir sync tests
red on dev (403). Authenticated those tests as staff — the connector calls the
endpoint with a service token; no production behaviour change.

## Tests
- `patient_portal/api/fhir/tests.py` — **7 passed** (incl. new self-heal regression test)
- Verified the regression test fails without the fix.

> Note: `patient_portal SmartServiceClientWriteTest.test_cross_org_write_rejected`
> fails on clean `dev` too (multi-tenant isolation HKI-SEC-04, tracked separately) —
> pre-existing, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)