### PR TITLE
fix(pk): self-heal OMOP sequences + repair ScopedTokenPermission test fallout

### DIFF
--- a/omop_core/services/pk.py
+++ b/omop_core/services/pk.py
@@ -1,4 +1,12 @@
-"""PostgreSQL sequence-based PK generation for OMOP tables."""
+"""PostgreSQL sequence-based PK generation for OMOP tables.
+
+Some legacy write paths (patient_portal/api/views.py, lot_inference_service,
+omop_write_service) assign PKs as ``MAX(id)+1`` with an explicit value, which
+does NOT advance the table's sequence. That strands the sequence behind the
+table max, so a later ``nextval`` here would hand out an already-used id and
+hit a duplicate-key error. To stay robust against those writers, every
+allocation first self-heals the sequence to ``>= MAX(pk)`` before drawing.
+"""
 from django.db import connection
 
 _SEQ_NAME_TEMPLATE = '{table}_{pk_field}_seq'
@@ -10,11 +18,28 @@ def _seq_name(model, pk_field):
     )
 
 
+def _reseed_to_max(cur, model, pk_field, seq):
+    """Advance ``seq`` so the next value exceeds both its current position and
+    ``MAX(pk)`` — making sequence allocation immune to legacy MAX(id)+1 writers
+    that bypass the sequence. (Identifiers come from model meta, not user input.)
+    """
+    table = connection.ops.quote_name(model._meta.db_table)
+    col = connection.ops.quote_name(pk_field)
+    qseq = connection.ops.quote_name(seq)
+    cur.execute(
+        f"SELECT setval(%s, GREATEST("
+        f"(SELECT last_value FROM {qseq}), "
+        f"(SELECT COALESCE(MAX({col}), 0) FROM {table})), true)",
+        [seq],
+    )
+
+
 def next_pk(model, pk_field):
     """Return the next PK value from the table's sequence."""
     seq = _seq_name(model, pk_field)
     with connection.cursor() as cur:
         cur.execute("SET LOCAL statement_timeout = '5s'")
+        _reseed_to_max(cur, model, pk_field, seq)
         cur.execute("SELECT nextval(%s)", [seq])
         return cur.fetchone()[0]
 
@@ -26,6 +51,7 @@ def next_pk_batch(model, pk_field, count):
     seq = _seq_name(model, pk_field)
     with connection.cursor() as cur:
         cur.execute("SET LOCAL statement_timeout = '5s'")
+        _reseed_to_max(cur, model, pk_field, seq)
         cur.execute(
             "SELECT nextval(%s) FROM generate_series(1, %s)",
             [seq, count],

--- a/patient_portal/api/fhir/tests.py
+++ b/patient_portal/api/fhir/tests.py
@@ -71,7 +71,13 @@ SAMPLE_BUNDLE = {
 class FhirSyncTests(TestCase):
     def setUp(self):
         _ensure_pk_sequences()
-        self.user = Identity.objects.create_user(email='fhirsync@test.com', password='test')
+        # POST /api/fhir/sync/ is privileged since the ScopedTokenPermission role
+        # change (a5e0ac6): only service-token / staff / superuser may write —
+        # plain patient identities get 403. The connector calls it with a service
+        # token; these tests exercise the request.user person-resolution path, so
+        # authenticate as staff to retain write access.
+        self.user = Identity.objects.create_user(
+            email='fhirsync@test.com', password='test', is_staff=True)
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
 
@@ -198,7 +204,7 @@ class FhirSyncTests(TestCase):
             return {"resourceType": "Bundle", "type": "collection", "entry": entries}
 
         def run(email, n):
-            user = Identity.objects.create_user(email=email, password="test")
+            user = Identity.objects.create_user(email=email, password="test", is_staff=True)
             client = APIClient()
             client.force_authenticate(user=user)
             with CaptureQueriesContext(connection) as ctx:

--- a/patient_portal/api/fhir/tests.py
+++ b/patient_portal/api/fhir/tests.py
@@ -78,6 +78,34 @@ class FhirSyncTests(TestCase):
     def _sync(self):
         return self.client.post('/api/fhir/sync/', {'bundle': SAMPLE_BUNDLE}, format='json')
 
+    def test_next_pk_batch_self_heals_after_legacy_explicit_pk_insert(self):
+        """Legacy MAX(id)+1 writers (views.py, lot_inference) set explicit PKs
+        without advancing the sequence; the sequence-based sync path must not
+        then hand out an already-used id (the duplicate-key 500 we hit in prod)."""
+        from omop_core.services.pk import next_pk_batch
+
+        self.assertEqual(self._sync().status_code, 201)
+        existing = ConditionOccurrence.objects.first()
+        self.assertIsNotNone(existing)
+
+        # Simulate the legacy path: explicit PK far ahead, sequence NOT advanced.
+        stranded_id = existing.condition_occurrence_id + 500
+        legacy = ConditionOccurrence(
+            condition_occurrence_id=stranded_id,
+            person=existing.person,
+            condition_concept=existing.condition_concept,
+            condition_start_date=existing.condition_start_date,
+            condition_type_concept=existing.condition_type_concept,
+            condition_source_value='legacy',
+        )
+        legacy._skip_patient_info_refresh = True
+        legacy.save()
+
+        # Sequence is now behind the table max → next_pk_batch must self-heal.
+        ids = next_pk_batch(ConditionOccurrence, 'condition_occurrence_id', 3)
+        self.assertTrue(all(i > stranded_id for i in ids), ids)
+        self.assertEqual(len(set(ids)), 3)
+
     def test_rejects_non_bundle(self):
         resp = self.client.post('/api/fhir/sync/', {'bundle': {'resourceType': 'Patient'}}, format='json')
         self.assertEqual(resp.status_code, 400)

--- a/patient_portal/api/lab_results/tests.py
+++ b/patient_portal/api/lab_results/tests.py
@@ -337,7 +337,9 @@ class ValuesViewTest(TestCase):
 class MeasurementDetailViewTest(TestCase):
     def setUp(self):
         _setup_vocab()
-        self.user = Identity.objects.create_user(email='measuser@test.com', password='test')
+        # DELETE is privileged since the ScopedTokenPermission role change; this
+        # suite verifies delete behaviour, so the caller is staff.
+        self.user = Identity.objects.create_user(email='measuser@test.com', password='test', is_staff=True)
         self.person = Person.objects.create(person_id=4001)
         PatientInfo.objects.create(person=self.person)
         PatientUser.objects.create(identity=self.user, person=self.person)
@@ -467,7 +469,9 @@ class AutoProvisionTest(TestCase):
 class VisitDeleteViewTest(TestCase):
     def setUp(self):
         _setup_vocab()
-        self.user = Identity.objects.create_user(email='visitdel@test.com', password='test')
+        # DELETE is privileged since the ScopedTokenPermission role change; this
+        # suite verifies delete behaviour, so the caller is staff.
+        self.user = Identity.objects.create_user(email='visitdel@test.com', password='test', is_staff=True)
         self.person = Person.objects.create(person_id=5001)
         PatientInfo.objects.create(person=self.person)
         PatientUser.objects.create(identity=self.user, person=self.person)
@@ -582,8 +586,10 @@ class SyncOnBehalfOfTest(TestCase):
             }],
             'source_type': 'document_extraction',
         }, format='json')
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('actor_iss and actor_sub required', resp.data['detail'])
+        # Since the ScopedTokenPermission role change a non-superuser/non-service
+        # caller is denied at the permission layer (before the actor-field
+        # validation is even reached).
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_on_behalf_of_superuser_without_actor_fields_succeeds(self):
         resp = self.client.post('/api/lab-results/sync/', {
@@ -891,6 +897,10 @@ class FirebaseAuthedSyncTest(TestCase):
             defaults={'email': 'patient@example.com'},
         )[0]
         self.firebase_user.set_unusable_password()
+        # POST sync is privileged since the ScopedTokenPermission role change;
+        # this suite exercises the request.user (non-service) person-resolution
+        # path, so the firebase identity is staff to retain write access.
+        self.firebase_user.is_staff = True
         self.firebase_user.save()
 
         self.person = Person.objects.create(person_id=9001)
@@ -967,6 +977,7 @@ class FirebaseAuthedSyncTest(TestCase):
             defaults={'email': 'emailmatch@example.com'},
         )[0]
         new_user.set_unusable_password()
+        new_user.is_staff = True  # privileged caller; see setUp note
         new_user.save()
         person2 = Person.objects.create(person_id=9002)
         PatientInfo.objects.create(person=person2, email='emailmatch@example.com')
@@ -1001,7 +1012,9 @@ class ServiceTokenSyncFallbackTest(TestCase):
         PatientUser.objects.create(identity=self.patient, person=self.person)
 
         self.client = APIClient()
-        self.client.force_authenticate(user=self.service_user)
+        # Production path: hk-labs calls this with a service token (request.auth
+        # == "service-token"), which ScopedTokenPermission grants full access.
+        self.client.force_authenticate(user=self.service_user, token="service-token")
 
     def test_service_token_resolves_person_from_actor_fields(self):
         resp = self.client.post('/api/lab-results/sync/', {
@@ -1043,7 +1056,13 @@ class ServiceTokenSyncFallbackTest(TestCase):
 
 
 class SyncNonSuperuserTest(TestCase):
-    """Test sync endpoint with a non-superuser identity using self-access (PatientUser link)."""
+    """A non-superuser/non-service identity is denied POST sync entirely.
+
+    Since the ScopedTokenPermission role change, write access requires a service
+    token or staff/superuser; a plain patient identity (even for its own person)
+    is rejected at the permission layer. Service-side ingest is covered by
+    ServiceTokenSyncFallbackTest / SyncOnBehalfOfTest.
+    """
 
     def setUp(self):
         _setup_vocab()
@@ -1071,10 +1090,10 @@ class SyncNonSuperuserTest(TestCase):
             'source_type': 'patient_self_report',
         }
 
-    def test_sync_own_data_succeeds(self):
+    def test_sync_own_data_denied(self):
+        # Own person, but a non-privileged caller can no longer POST sync.
         resp = self.client.post('/api/lab-results/sync/', self._payload(), format='json')
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(resp.data['count'], 1)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_sync_other_person_denied(self):
         other = Person.objects.create(person_id=2002)
@@ -1083,8 +1102,10 @@ class SyncNonSuperuserTest(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_sync_nonexistent_person_denied(self):
+        # Permission denial (403) now precedes the person lookup that previously
+        # produced a 404 for a non-privileged caller.
         resp = self.client.post('/api/lab-results/sync/', self._payload(person_id=9999), format='json')
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class DedupSyncTest(TestCase):


### PR DESCRIPTION
Supersedes #107 (closed) — that PR's commits are included here. Full
`omop_core patient_portal` suite is green (326 tests); CI passing.

## 1. Root cause fix — OMOP PK sequence self-heal
`/api/fhir/sync/` was returning intermittent 500s in staging:
`duplicate key value violates unique constraint "condition_occurrence_pkey"`.

Legacy write paths (`patient_portal/api/views.py`, `lot_inference_service`,
`omop_write_service`) assign OMOP PKs as `MAX(id)+1` with an explicit value and
**never advance the table's Postgres sequence**. The FHIR/lab sync paths allocate
via `nextval`, so once a legacy writer runs, the sequence is stranded behind the
table max and `nextval` hands out an already-used id.

**Fix:** `next_pk` / `next_pk_batch` now `setval` the sequence to
`GREATEST(last_value, MAX(pk))` before drawing — immune to the legacy writers
without rewriting them. Regression test strands the sequence with an explicit-PK
insert and asserts the next batch skips past it (verified it fails without the fix).

Residual narrow race remains if a legacy `MAX(id)+1` writer commits between the
reseed and `nextval`; the durable cure is migrating those writers to `next_pk`
(follow-up).

## 2. ScopedTokenPermission test fallout (a5e0ac6)
a5e0ac6 made POST sync / DELETE privileged (service-token / staff / superuser
only; plain patient identities get 403) but left 20 integration tests red on
`dev` (it only added permission unit tests). Repaired by intent:

**fhir** (`patient_portal/api/fhir/tests.py`)
- sync tests authenticate as staff (connector uses a service token in prod).

**lab_results** (`patient_portal/api/lab_results/tests.py`)
- `ServiceTokenSyncFallbackTest` → `token="service-token"` (real hk-labs path).
- `FirebaseAuthedSyncTest`, `MeasurementDetailViewTest`, `VisitDeleteViewTest` →
  caller is staff; these verify business logic, assertions unchanged.
- `SyncNonSuperuserTest`, `SyncOnBehalfOfTest` (non-su) → assert 403; these verify
  access control, now denied at the permission layer.

No production behaviour change — only test auth/expectations.

## Tests
`python manage.py test omop_core patient_portal` → **326 passed** (Django runner,
matching CI). Backend + frontend CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)