### PR TITLE
fix: disease selection persists after save (issues #110, #113)

### DIFF
--- a/frontend/src/federation/patientInfoApi.test.tsx
+++ b/frontend/src/federation/patientInfoApi.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for usePatchPatientInfo — issue #113
+ *
+ * After a successful PATCH the mutation must update the React Query cache
+ * via setQueryData (not invalidateQueries).  invalidateQueries triggers a
+ * refetch that returns the DB state, which can have disease=null when
+ * refresh_patient_info wiped it — causing PatientInfoInner to reset editedInfo
+ * and revert the disease tab label back to "Disease Specific".
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { AxiosInstance } from "axios";
+import { usePatchPatientInfo } from "./patientInfoApi";
+
+function createMockClient() {
+  return {
+    patch: vi.fn(),
+  } as unknown as AxiosInstance;
+}
+
+let qc: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+});
+
+describe("usePatchPatientInfo — cache update strategy (issue #113)", () => {
+  it("updates the cache with the PATCH response instead of invalidating the query", async () => {
+    const client = createMockClient();
+    const patchResponse = { disease: "Follicular Lymphoma", id: 1 };
+    (client.patch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: patchResponse,
+    });
+
+    // Seed existing cache data so setQueryData has something to merge into
+    qc.setQueryData(["patient-info", "me"], {
+      patient_info: { disease: null, id: 1 },
+      user: { email: "test@test.com" },
+      patient_name: "Test Patient",
+    });
+
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const setDataSpy = vi.spyOn(qc, "setQueryData");
+
+    const { result } = renderHook(
+      () => usePatchPatientInfo(client, "/api"),
+      { wrapper },
+    );
+
+    result.current.mutate({ disease: "Follicular Lymphoma" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Must NOT invalidate (that would refetch and potentially return null disease)
+    expect(invalidateSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["patient-info", "me"] }),
+    );
+
+    // MUST update the cache directly so the mutation result is visible immediately
+    expect(setDataSpy).toHaveBeenCalledWith(
+      ["patient-info", "me"],
+      expect.any(Function),
+    );
+  });
+
+  it("merges PATCH response fields into the existing patient_info cache entry", async () => {
+    const client = createMockClient();
+    (client.patch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { disease: "Follicular Lymphoma", stage: "II", id: 1 },
+    });
+
+    const initial = {
+      patient_info: { disease: null, stage: null, weight_kg: 65, id: 1 },
+      user: { email: "test@test.com" },
+      patient_name: "Test Patient",
+    };
+    qc.setQueryData(["patient-info", "me"], initial);
+
+    const { result } = renderHook(
+      () => usePatchPatientInfo(client, "/api"),
+      { wrapper },
+    );
+
+    result.current.mutate({ disease: "Follicular Lymphoma", stage: "II" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = qc.getQueryData<typeof initial>(["patient-info", "me"]);
+    // Updated fields from PATCH response
+    expect(cached?.patient_info.disease).toBe("Follicular Lymphoma");
+    expect(cached?.patient_info.stage).toBe("II");
+    // Pre-existing unrelated field must be preserved
+    expect(cached?.patient_info.weight_kg).toBe(65);
+  });
+
+  it("does not include previous_values in the merged patient_info", async () => {
+    const client = createMockClient();
+    (client.patch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        disease: "Multiple Myeloma",
+        id: 1,
+        previous_values: { disease: null },
+      },
+    });
+
+    qc.setQueryData(["patient-info", "me"], {
+      patient_info: { disease: null, id: 1 },
+      user: {},
+      patient_name: "",
+    });
+
+    const { result } = renderHook(
+      () => usePatchPatientInfo(client, "/api"),
+      { wrapper },
+    );
+
+    result.current.mutate({ disease: "Multiple Myeloma" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = qc.getQueryData<{ patient_info: Record<string, unknown> }>(
+      ["patient-info", "me"],
+    );
+    expect(cached?.patient_info.disease).toBe("Multiple Myeloma");
+    // previous_values must not leak into patient_info
+    expect(cached?.patient_info.previous_values).toBeUndefined();
+  });
+});

--- a/frontend/src/federation/patientInfoApi.ts
+++ b/frontend/src/federation/patientInfoApi.ts
@@ -29,8 +29,18 @@ export function usePatchPatientInfo(apiClient?: AxiosInstance, apiBasePath = "")
       );
       return resp.data;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: KEYS.me });
+    onSuccess: (result: Record<string, unknown>) => {
+      // Update the cache with the PATCH response fields rather than invalidating.
+      // Invalidating would trigger a refetch that returns the DB state — which can
+      // differ from the user's selection when OMOP post-save signals run between
+      // the serializer.save() and the GET response (e.g. disease gets cleared by
+      // refresh_patient_info and not restored correctly).  Merging the PATCH result
+      // directly avoids a round-trip and keeps editedInfo in sync with the cache.
+      queryClient.setQueryData(KEYS.me, (old: PatientInfoData | undefined) => {
+        if (!old) return old;
+        const { previous_values: _pv, ...fields } = result;
+        return { ...old, patient_info: { ...old.patient_info, ...fields } };
+      });
     },
   });
 }

--- a/omop_core/services/omop_write_service.py
+++ b/omop_core/services/omop_write_service.py
@@ -118,7 +118,7 @@ def _sync_condition(person, patient_info, today: date, changed_data: dict = None
     last = ConditionOccurrence.objects.order_by('-condition_occurrence_id').first()
     new_id = (last.condition_occurrence_id + 1) if last else 1
 
-    ConditionOccurrence.objects.create(
+    co = ConditionOccurrence(
         condition_occurrence_id=new_id,
         person=person,
         condition_concept=condition_concept,
@@ -126,6 +126,12 @@ def _sync_condition(person, patient_info, today: date, changed_data: dict = None
         condition_type_concept=type_concept,
         condition_source_value=source_value,
     )
+    # Skip the post_save signal that calls refresh_patient_info — the PatientInfo
+    # disease field was already saved correctly by the serializer; re-deriving it
+    # from OMOP immediately would overwrite the user's selection with the OMOP
+    # concept name (which may differ in casing or be unresolved).
+    co._skip_patient_info_refresh = True
+    co.save()
 
 
 def _sync_demographics(person, patient_info, changed_data: dict = None) -> None:

--- a/omop_core/services/omop_write_service.py
+++ b/omop_core/services/omop_write_service.py
@@ -132,6 +132,7 @@ def _sync_condition(person, patient_info, today: date, changed_data: dict = None
     # concept name (which may differ in casing or be unresolved).
     co._skip_patient_info_refresh = True
     co.save()
+    del co._skip_patient_info_refresh
 
 
 def _sync_demographics(person, patient_info, changed_data: dict = None) -> None:

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -3796,3 +3796,127 @@ class PersonIdEnumerationTest(FhirUploadBase):
         self.assertEqual(resp.data['deleted_count'], 1)
         self.assertEqual(resp.data['errors'], [])
         self.assertFalse(P.objects.filter(person_id=78901).exists())
+
+
+# ---------------------------------------------------------------------------
+# Disease persistence tests — issues #110 / #113
+# ---------------------------------------------------------------------------
+
+class DiseasePersistenceTest(_SmartBase):
+    """PATCH /api/patient-info/{person_id}/ must preserve PatientInfo.disease.
+
+    When the user saves a disease selection the serializer writes it directly to
+    PatientInfo.  _sync_condition then creates a ConditionOccurrence to mirror
+    that change in the OMOP tables.  That post_save would normally trigger
+    refresh_patient_info → _clear_derived_fields → disease wiped.
+
+    The fix sets _skip_patient_info_refresh = True on the new ConditionOccurrence
+    so the user's selection survives the round-trip.
+    """
+
+    PERSON_ID = 95001
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # Fresh person and empty PatientInfo for this class
+        cls.dp_person = Person.objects.create(
+            person_id=cls.PERSON_ID,
+            given_name='Disease',
+            family_name='PersistTest',
+            year_of_birth=1975,
+            gender_source_value='female',
+            race_source_value='unknown',
+            ethnicity_source_value='unknown',
+        )
+        PatientInfo.objects.get_or_create(person=cls.dp_person)
+
+    # ------------------------------------------------------------------ #
+    # Issue #110: disease persists across a PATCH + DB re-fetch cycle     #
+    # ------------------------------------------------------------------ #
+
+    def test_disease_survives_patch_for_follicular_lymphoma(self):
+        """PATCH disease='Follicular Lymphoma' stays in DB after sync_to_omop."""
+        resp = self.write_client.patch(
+            f'/api/patient-info/{self.PERSON_ID}/',
+            {'disease': 'Follicular Lymphoma'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 200, resp.data)
+
+        pi = PatientInfo.objects.get(person=self.dp_person)
+        self.assertEqual(
+            pi.disease, 'Follicular Lymphoma',
+            'PatientInfo.disease was overwritten after PATCH — refresh_patient_info '
+            'must not run from _sync_condition (issue #110)',
+        )
+
+    def test_disease_survives_patch_for_cll(self):
+        """PATCH disease='Chronic Lymphocytic Leukemia (CLL)' stays in DB."""
+        resp = self.write_client.patch(
+            f'/api/patient-info/{self.PERSON_ID}/',
+            {'disease': 'Chronic Lymphocytic Leukemia (CLL)'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 200, resp.data)
+
+        pi = PatientInfo.objects.get(person=self.dp_person)
+        self.assertEqual(
+            pi.disease, 'Chronic Lymphocytic Leukemia (CLL)',
+            'PatientInfo.disease was overwritten after PATCH — '
+            'CLL selection must persist (issue #110)',
+        )
+
+    def test_disease_survives_patch_for_multiple_myeloma(self):
+        """PATCH disease='Multiple Myeloma' stays in DB."""
+        resp = self.write_client.patch(
+            f'/api/patient-info/{self.PERSON_ID}/',
+            {'disease': 'Multiple Myeloma'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 200, resp.data)
+
+        pi = PatientInfo.objects.get(person=self.dp_person)
+        self.assertEqual(pi.disease, 'Multiple Myeloma')
+
+    def test_get_after_patch_returns_saved_disease(self):
+        """GET /api/patient-info/{id}/ after PATCH returns the saved disease value.
+
+        Simulates the navigation-away-and-back scenario from issue #110.
+        """
+        self.write_client.patch(
+            f'/api/patient-info/{self.PERSON_ID}/',
+            {'disease': 'Follicular Lymphoma'},
+            format='json',
+        )
+
+        get_resp = self.read_client.get(f'/api/patient-info/{self.PERSON_ID}/')
+        self.assertEqual(get_resp.status_code, 200)
+        self.assertEqual(
+            get_resp.data['patient_info']['disease'], 'Follicular Lymphoma',
+            'GET after PATCH returned wrong disease — field was overwritten server-side '
+            '(issue #110)',
+        )
+
+    # ------------------------------------------------------------------ #
+    # Issue #113: _skip_patient_info_refresh flag prevents OMOP overwrite #
+    # ------------------------------------------------------------------ #
+
+    def test_disease_survives_sync_to_omop(self):
+        """disease persists after sync_to_omop runs _sync_condition directly."""
+        from omop_core.services.omop_write_service import sync_to_omop
+        from datetime import date
+
+        pi = PatientInfo.objects.get(person=self.dp_person)
+        pi.disease = 'Follicular Lymphoma'
+        pi.save(update_fields=['disease'])
+
+        # Call sync_to_omop directly — this runs _sync_condition internally
+        sync_to_omop(pi, {'disease'}, changed_data={'disease': 'Follicular Lymphoma'})
+
+        pi.refresh_from_db()
+        self.assertEqual(
+            pi.disease, 'Follicular Lymphoma',
+            'sync_to_omop wiped PatientInfo.disease — _skip_patient_info_refresh '
+            'not set on ConditionOccurrence (issue #113)',
+        )

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -3903,7 +3903,11 @@ class DiseasePersistenceTest(_SmartBase):
     # ------------------------------------------------------------------ #
 
     def test_disease_survives_sync_to_omop(self):
-        """disease persists after sync_to_omop runs _sync_condition directly."""
+        """disease persists after sync_to_omop runs _sync_condition directly.
+
+        We verify this by checking that PatientInfo.disease is unchanged
+        immediately after sync_to_omop runs (no extra DB write occurred).
+        """
         from omop_core.services.omop_write_service import sync_to_omop
         from datetime import date
 


### PR DESCRIPTION
## Summary

- Root cause: _sync_condition created a ConditionOccurrence which fired post_save -> refresh_patient_info -> _clear_derived_fields wiped PatientInfo.disease -> OMOP concept re-derive returned wrong/null value
- Fix 1 (backend): set _skip_patient_info_refresh=True on the ConditionOccurrence in _sync_condition so the serializer-saved disease is preserved
- Fix 2 (federation UI): replace queryClient.invalidateQueries with setQueryData in usePatchPatientInfo — eliminates the refetch that returned disease=null and caused PatientInfoInner to reset editedInfo 2s after selection

## Test plan

- DiseasePersistenceTest: 5 backend tests covering FL, CLL, MM, GET-after-PATCH, direct sync_to_omop call
- patientInfoApi.test.tsx: 3 frontend tests (no invalidateQueries, correct cache merge, previous_values exclusion)
- Full suite: 331 backend + 19 frontend, all green

Generated with Claude Code