### PR TITLE
fix: make migration 0085 AddField ops idempotent

### DIFF
--- a/omop_core/migrations/0085_scteligibility_patientinfo_sct_date_and_more.py
+++ b/omop_core/migrations/0085_scteligibility_patientinfo_sct_date_and_more.py
@@ -115,20 +115,42 @@ class Migration(migrations.Migration):
                 ),
             ],
         ),
-        migrations.AddField(
-            model_name="patientinfo",
-            name="sct_date",
-            field=models.DateField(blank=True, null=True),
+        # Add sct_date to PatientInfo — idempotent (column may already exist in production)
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="patientinfo",
+                    name="sct_date",
+                    field=models.DateField(blank=True, null=True),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql='ALTER TABLE "patient_info" ADD COLUMN IF NOT EXISTS "sct_date" date NULL;',
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
         ),
-        migrations.AddField(
-            model_name="patientinfo",
-            name="sct_eligibility",
-            field=models.JSONField(
-                blank=True,
-                default=list,
-                help_text="Multi-select from SctEligibility vocabulary",
-                null=True,
-            ),
+        # Add sct_eligibility to PatientInfo — idempotent (column may already exist in production)
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="patientinfo",
+                    name="sct_eligibility",
+                    field=models.JSONField(
+                        blank=True,
+                        default=list,
+                        help_text="Multi-select from SctEligibility vocabulary",
+                        null=True,
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql='ALTER TABLE "patient_info" ADD COLUMN IF NOT EXISTS "sct_eligibility" jsonb NULL;',
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
         ),
         migrations.RunPython(backfill_sct_eligibility, reverse_noop),
     ]


### PR DESCRIPTION
## Summary

- Production DB already had sct_date and sct_eligibility columns on patient_info from a prior partial deploy (same root cause as the vocabulary_sct_eligibility DuplicateTable fixed in #127)
- Wraps both AddField operations in SeparateDatabaseAndState so the database side uses ADD COLUMN IF NOT EXISTS - safe whether columns exist or not
- Deploy was crashing with: ProgrammingError: column sct_date of relation patient_info already exists

## Test plan

- Run migrate against staging DB - should apply cleanly with no errors
- Run migrate against a fresh DB - should still create the columns normally
- Backend test suite passes

Generated with Claude Code