### PR TITLE
perf: suppress PatientInfo refresh during OMOP writes (~60x speedup)

### DIFF
--- a/omop_core/management/commands/load_fhir_bundle.py
+++ b/omop_core/management/commands/load_fhir_bundle.py
@@ -3,12 +3,9 @@ Load a FHIR R4 Bundle JSON file directly into the database.
 
 Reuses the upload_fhir view logic via a mocked DRF request — no HTTP needed.
 
-Key optimisation: the upload_fhir view calls refresh_patient_info once per
-patient, AND post_save signals on every OMOP table call it again for every
-row written (~60 calls per patient over a remote DB = very slow).
-
-This command suppresses all those mid-load refreshes and does a single batch
-refresh at the end, cutting the per-patient overhead from ~60 round-trips to 1.
+Signal suppression (deferred PatientInfo refresh) is handled inside upload_fhir
+via suppress_patient_info_refresh(). Each patient gets exactly one refresh call
+at the end of its processing block, not one per OMOP row written.
 
 Usage:
     python manage.py load_fhir_bundle data/mm_patients_400.json
@@ -16,38 +13,14 @@ Usage:
 """
 import io
 import json
-from contextlib import contextmanager
 from pathlib import Path
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 
 
-@contextmanager
-def _suppress_patient_info_refresh():
-    """
-    Temporarily replace refresh_patient_info with a no-op in views.py.
-    The signals already honour _skip_patient_info_refresh; we patch the
-    explicit call in the view here.
-    """
-    import patient_portal.api.views as views_module
-    from omop_core.services.patient_info_service import refresh_patient_info as real_refresh
-
-    _collected_persons = []
-
-    def _noop_refresh(person):
-        _collected_persons.append(person)
-        return None  # view ignores the return value after the patch block
-
-    views_module.refresh_patient_info = _noop_refresh
-    try:
-        yield _collected_persons
-    finally:
-        views_module.refresh_patient_info = real_refresh
-
-
 class Command(BaseCommand):
-    help = "Load a FHIR R4 Bundle JSON file into the database (deferred refresh)"
+    help = "Load a FHIR R4 Bundle JSON file into the database"
 
     def add_arguments(self, parser):
         parser.add_argument("bundle_path", type=str, help="Path to FHIR bundle JSON file")
@@ -59,11 +32,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        # Patch _skip_patient_info_refresh onto saves via monkey-patching Model.save
-        # is complex; instead we rely on the no-op patch above for the explicit call
-        # and set _skip_patient_info_refresh on OMOP instances via signal suppression.
-        self._setup_signal_suppression()
-
         bundle_path = Path(options["bundle_path"])
         if not bundle_path.exists():
             raise CommandError(f"File not found: {bundle_path}")
@@ -91,45 +59,31 @@ class Command(BaseCommand):
 
         total_created = 0
         total_errors = []
-        all_persons = []
 
-        with _suppress_patient_info_refresh() as collected_persons:
-            for batch_num, batch_start in enumerate(range(0, len(patient_ids), batch_size), 1):
-                batch_pids = set(patient_ids[batch_start: batch_start + batch_size])
-                batch_entries = [
-                    e for e in entries
-                    if (e["resource"]["resourceType"] == "Patient" and e["resource"]["id"] in batch_pids)
-                    or e["resource"].get("subject", {}).get("reference", "").replace("Patient/", "") in batch_pids
-                ]
+        for batch_num, batch_start in enumerate(range(0, len(patient_ids), batch_size), 1):
+            batch_pids = set(patient_ids[batch_start: batch_start + batch_size])
+            batch_entries = [
+                e for e in entries
+                if (e["resource"]["resourceType"] == "Patient" and e["resource"]["id"] in batch_pids)
+                or e["resource"].get("subject", {}).get("reference", "").replace("Patient/", "") in batch_pids
+            ]
 
-                batch_json = json.dumps(
-                    {"resourceType": "Bundle", "type": "collection", "entry": batch_entries}
-                ).encode()
+            batch_json = json.dumps(
+                {"resourceType": "Bundle", "type": "collection", "entry": batch_entries}
+            ).encode()
 
-                self.stdout.write(
-                    f"  Batch {batch_num}/{total_batches}: {len(batch_pids)} patients ...",
-                    ending="",
-                )
-                self.stdout.flush()
+            self.stdout.write(
+                f"  Batch {batch_num}/{total_batches}: {len(batch_pids)} patients ...",
+                ending="",
+            )
+            self.stdout.flush()
 
-                result = self._run_batch(batch_json, user)
-                created = result.get("created_count", 0)
-                errors = result.get("errors", [])
-                total_created += created
-                total_errors.extend(errors)
-                self.stdout.write(f" created={created} errors={len(errors)}")
-
-            all_persons = list({p.person_id: p for p in collected_persons}.values())
-
-        # Single batch refresh — one call per unique person
-        self.stdout.write(f"\nRefreshing PatientInfo for {len(all_persons)} persons ...")
-        from omop_core.services.patient_info_service import refresh_patient_info
-        from omop_core.services.lot_service import infer_lot_for_person
-        for i, person in enumerate(all_persons, 1):
-            refresh_patient_info(person)
-            infer_lot_for_person(person)
-            if i % 25 == 0:
-                self.stdout.write(f"  {i}/{len(all_persons)} refreshed ...")
+            result = self._run_batch(batch_json, user)
+            created = result.get("created_count", 0)
+            errors = result.get("errors", [])
+            total_created += created
+            total_errors.extend(errors)
+            self.stdout.write(f" created={created} errors={len(errors)}")
 
         self.stdout.write(self.style.SUCCESS(
             f"\nDone. Created: {total_created}, errors: {len(total_errors)}"
@@ -138,21 +92,6 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("Errors (first 20):"))
             for e in total_errors[:20]:
                 self.stdout.write(f"  {e}")
-
-    def _setup_signal_suppression(self):
-        """Monkey-patch Model.save to set _skip_patient_info_refresh on OMOP instances."""
-        from omop_core.models import (
-            ConditionOccurrence, DrugExposure, Measurement,
-            Observation, ProcedureOccurrence,
-        )
-        for model in (ConditionOccurrence, DrugExposure, Measurement, Observation, ProcedureOccurrence):
-            original_save = model.save
-
-            def _patched_save(self, *args, _orig=original_save, **kwargs):
-                self._skip_patient_info_refresh = True
-                return _orig(self, *args, **kwargs)
-
-            model.save = _patched_save
 
     def _run_batch(self, batch_json_bytes, user):
         from django.core.files.uploadedfile import InMemoryUploadedFile

--- a/omop_core/signals.py
+++ b/omop_core/signals.py
@@ -43,12 +43,15 @@ def suppress_patient_info_refresh():
 
     Use around bulk OMOP writes and call refresh_patient_info() explicitly
     once at the end to keep PatientInfo in sync with a single DB round-trip.
+
+    Re-entrant safe: nested calls preserve the outer suppression state.
     """
+    was_active = getattr(_suppress, 'active', False)
     _suppress.active = True
     try:
         yield
     finally:
-        _suppress.active = False
+        _suppress.active = was_active
 
 
 def _refresh_for_instance(instance):

--- a/omop_core/signals.py
+++ b/omop_core/signals.py
@@ -6,13 +6,22 @@ ProcedureOccurrence triggers refresh_patient_info(person), keeping PatientInfo i
 sync without requiring direct writes to the denormalized table.
 
 Signal suppression during bulk uploads:
-  Use bulk_create() (signals are not fired) OR set the `_skip_patient_info_refresh`
-  flag on the instance before saving:
+  Option 1 — context manager (preferred for bulk operations like upload_fhir):
+      from omop_core.signals import suppress_patient_info_refresh
+      with suppress_patient_info_refresh():
+          # all OMOP writes here — signals fire but refresh is skipped
+          ...
+      refresh_patient_info(person)  # single refresh at the end
+
+  Option 2 — per-instance flag:
       instance._skip_patient_info_refresh = True
       instance.save()
 """
 
 import logging
+import threading
+from contextlib import contextmanager
+
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
@@ -23,9 +32,29 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+# Thread-local flag — suppresses all signal-triggered refreshes for the
+# current thread without affecting other concurrent requests.
+_suppress = threading.local()
+
+
+@contextmanager
+def suppress_patient_info_refresh():
+    """Suppress signal-triggered PatientInfo refreshes for the current thread.
+
+    Use around bulk OMOP writes and call refresh_patient_info() explicitly
+    once at the end to keep PatientInfo in sync with a single DB round-trip.
+    """
+    _suppress.active = True
+    try:
+        yield
+    finally:
+        _suppress.active = False
+
 
 def _refresh_for_instance(instance):
     """Call refresh_patient_info for the person linked to an OMOP event instance."""
+    if getattr(_suppress, 'active', False):
+        return
     if getattr(instance, '_skip_patient_info_refresh', False):
         return
     try:

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -715,6 +715,10 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                                     _record_provenance(_co, prov_source, prov_user_id, modification_reason=prov_reason, organization=get_request_org(request))
 
                     # Process observations and create Measurement records
+                    # Suppress signal-triggered PatientInfo refreshes for all OMOP
+                    # writes below — a single explicit refresh happens at the end.
+                    from omop_core.signals import _suppress as _omop_suppress
+                    _omop_suppress.active = True
                     logger.info("TIMING patient=%s phase=person_setup elapsed=%.1fs", fhir_patient_id[:8], _time.monotonic() - _pt_start)
                     from omop_core.models import Measurement
                     last_measurement = Measurement.objects.all().order_by('-measurement_id').first()
@@ -1544,6 +1548,8 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                             logger.warning(f"Could not write DrugExposure/Episode for LOT {lot_num}: {_e}")
 
                     # --- OMOP-first: refresh PatientInfo from OMOP tables ---
+                    # Re-enable signals before the single intentional refresh.
+                    _omop_suppress.active = False
                     logger.info("TIMING patient=%s phase=drug_exposures elapsed=%.1fs", fhir_patient_id[:8], _time.monotonic() - _pt_start)
                     patient_info = refresh_patient_info(person)
                     infer_lot_for_person(person)
@@ -1760,6 +1766,11 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                                 _fhir_id_hash, _pt_total)
                     
                 except Exception as e:
+                    # Always clear suppression so it doesn't bleed into the next patient.
+                    try:
+                        _omop_suppress.active = False
+                    except NameError:
+                        pass
                     _err_hash = hashlib.sha256(str(fhir_patient_id).encode()).hexdigest()[:12]
                     errors.append(f"Patient (id_hash={_err_hash}): {str(e)}")
             

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -640,12 +640,20 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                             },
                         )
                     
+                    # Suppress signal-triggered PatientInfo refreshes for all OMOP
+                    # writes below. Use __enter__/__exit__ explicitly so the finally
+                    # block guarantees cleanup even on BaseException (e.g. KeyboardInterrupt),
+                    # without requiring 1000 lines of re-indentation.
+                    from omop_core.signals import suppress_patient_info_refresh as _suppress_cm_fn
+                    _suppress_cm = _suppress_cm_fn()
+                    _suppress_cm.__enter__()
+
                     # Extract disease, stage, and histologic type from Condition
                     disease = 'Breast Cancer'
                     stage = ''
                     histologic_type = ''
                     condition_date = None
-                    
+
                     for condition in data['conditions']:
                         # Get histologic type from code
                         code = condition.get('code', {})
@@ -715,11 +723,8 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                                     _record_provenance(_co, prov_source, prov_user_id, modification_reason=prov_reason, organization=get_request_org(request))
 
                     # Process observations and create Measurement records
-                    # Suppress signal-triggered PatientInfo refreshes for all OMOP
-                    # writes below — a single explicit refresh happens at the end.
-                    from omop_core.signals import _suppress as _omop_suppress
-                    _omop_suppress.active = True
-                    logger.info("TIMING patient=%s phase=person_setup elapsed=%.1fs", fhir_patient_id[:8], _time.monotonic() - _pt_start)
+                    _timing_hash = hashlib.sha256(str(fhir_patient_id).encode()).hexdigest()[:12]
+                    logger.debug("TIMING patient=%s phase=person_setup elapsed=%.1fs", _timing_hash, _time.monotonic() - _pt_start)
                     from omop_core.models import Measurement
                     last_measurement = Measurement.objects.all().order_by('-measurement_id').first()
                     measurement_id = last_measurement.measurement_id + 1 if last_measurement else 1
@@ -1443,7 +1448,7 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                                 later_discontinuation_reason = disc_obs['value']
                     
                     # --- Write DrugExposure records for each therapy line ---
-                    logger.info("TIMING patient=%s phase=measurements elapsed=%.1fs", fhir_patient_id[:8], _time.monotonic() - _pt_start)
+                    logger.debug("TIMING patient=%s phase=measurements elapsed=%.1fs", _timing_hash, _time.monotonic() - _pt_start)
                     last_drug = DrugExposure.objects.all().order_by('-drug_exposure_id').first()
                     drug_exposure_id = last_drug.drug_exposure_id + 1 if last_drug else 1
                     last_episode = Episode.objects.all().order_by('-episode_id').first()
@@ -1548,9 +1553,9 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                             logger.warning(f"Could not write DrugExposure/Episode for LOT {lot_num}: {_e}")
 
                     # --- OMOP-first: refresh PatientInfo from OMOP tables ---
-                    # Re-enable signals before the single intentional refresh.
-                    _omop_suppress.active = False
-                    logger.info("TIMING patient=%s phase=drug_exposures elapsed=%.1fs", fhir_patient_id[:8], _time.monotonic() - _pt_start)
+                    # Release suppression before the single intentional refresh.
+                    _suppress_cm.__exit__(None, None, None)
+                    logger.debug("TIMING patient=%s phase=drug_exposures elapsed=%.1fs", _timing_hash, _time.monotonic() - _pt_start)
                     patient_info = refresh_patient_info(person)
                     infer_lot_for_person(person)
 
@@ -1766,13 +1771,15 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                                 _fhir_id_hash, _pt_total)
                     
                 except Exception as e:
-                    # Always clear suppression so it doesn't bleed into the next patient.
-                    try:
-                        _omop_suppress.active = False
-                    except NameError:
-                        pass
                     _err_hash = hashlib.sha256(str(fhir_patient_id).encode()).hexdigest()[:12]
                     errors.append(f"Patient (id_hash={_err_hash}): {str(e)}")
+                finally:
+                    # Guarantee suppression is cleared even on BaseException.
+                    # Safe to call on an already-exited context manager (re-entrant safe).
+                    try:
+                        _suppress_cm.__exit__(None, None, None)
+                    except NameError:
+                        pass  # exception raised before _suppress_cm was assigned
             
             return Response({
                 'success': True,


### PR DESCRIPTION
## Summary

- **Root cause**: `post_save` signals on `ConditionOccurrence`, `DrugExposure`, `Measurement`, `Observation`, `ProcedureOccurrence` each triggered `refresh_patient_info` — ~60 calls per patient. At 150ms/round-trip on a remote DB, this caused measurements phase alone to take ~169s/patient.
- **Fix**: Thread-local suppression flag in `signals.py` (public `suppress_patient_info_refresh()` context manager). The `upload_fhir` view activates suppression before the first OMOP write and deactivates it just before the single intentional `refresh_patient_info` call at the end. Net result: 1 refresh per patient instead of ~60.
- **`load_fhir_bundle.py`**: Removed two now-dead suppression mechanisms (`_setup_signal_suppression` monkey-patch + `views_module` noop patch). Suppression is handled entirely inside `upload_fhir`.

## Changes

- `omop_core/signals.py` — Add `suppress_patient_info_refresh()` context manager (thread-local, re-entrant safe)
- `patient_portal/api/views.py` — Wrap per-patient OMOP writes in suppression; use `__enter__`/`__exit__` to avoid re-indenting 1000 lines; `finally` block guarantees cleanup; hash patient IDs in TIMING debug logs (HIPAA)
- `omop_core/management/commands/load_fhir_bundle.py` — Remove dead suppression code; simplify to batch loop calling `_run_batch`

## Test plan

- [ ] Run `load_fhir_bundle` on a batch of 10 patients via Render shell — verify measurements phase < 5s/patient (vs ~169s before)
- [ ] Verify `PatientInfo` fields are correctly populated after load (single refresh fires at end)
- [ ] Run backend test suite: `DATABASE_URL=... python manage.py test omop_core patient_portal --verbosity=2 --noinput`

🤖 Generated with [Claude Code](https://claude.com/claude-code)