### PR TITLE
fix: make WHITENOISE_ROOT configurable via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN cd frontend && npm run build && cd ..
 # Collect Django static files
 RUN python manage.py collectstatic --noinput --clear || true
 
+ENV WHITENOISE_ROOT=/app/frontend/build
+
 # Expose port
 EXPOSE 8000
 

--- a/Dockerfile.gcp
+++ b/Dockerfile.gcp
@@ -35,6 +35,8 @@ COPY --from=backend /usr/local/bin /usr/local/bin
 COPY --from=backend /app /app
 COPY --from=frontend /app/frontend/dist/remote /app/frontend/dist/remote
 
+ENV WHITENOISE_ROOT=/app/frontend/dist/remote
+
 EXPOSE 8080
 
 CMD ["gunicorn", "ctomop.wsgi:application", \

--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -180,11 +180,14 @@ STATICFILES_DIRS = []
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-# Serve Vite build output (assets/, index.html, etc.) at the root URL via WhiteNoise.
-# Vite outputs to frontend/build/ with assets at /assets/... (no /static/ prefix).
-frontend_build = BASE_DIR / 'frontend' / 'build'
-if frontend_build.exists():
-    WHITENOISE_ROOT = frontend_build
+_whitenoise_root = os.environ.get('WHITENOISE_ROOT', '')
+if _whitenoise_root:
+    WHITENOISE_ROOT = Path(_whitenoise_root)
+else:
+    for _candidate in (BASE_DIR / 'frontend' / 'dist' / 'remote', BASE_DIR / 'frontend' / 'build'):
+        if _candidate.exists():
+            WHITENOISE_ROOT = _candidate
+            break
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
## Summary
- `WHITENOISE_ROOT` is now read from the environment, removing the hardcoded path mismatch between `Dockerfile` (SPA → `frontend/build`) and `Dockerfile.gcp` (federation → `frontend/dist/remote`)
- When the env var is unset, auto-detects by checking `frontend/dist/remote` first, then `frontend/build`

## Changes
- **settings.py**: `WHITENOISE_ROOT` from `os.environ`, with fallback auto-detection
- **Dockerfile**: `ENV WHITENOISE_ROOT=/app/frontend/build`
- **Dockerfile.gcp**: `ENV WHITENOISE_ROOT=/app/frontend/dist/remote`

## Context
`Dockerfile.gcp` builds `npm run build:remote` → `frontend/dist/remote/`, but settings.py hardcoded `frontend/build/`. This caused `remoteEntry.js` to 500 on staging (TemplateDoesNotExist fallthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)