### PR TITLE
feat: canonicalize 'myeloma' disease title to 'multiple myeloma'

### DIFF
--- a/omop_core/management/commands/seed_test_patients.py
+++ b/omop_core/management/commands/seed_test_patients.py
@@ -77,6 +77,42 @@ TEST_PATIENTS = [
         ),
     ),
 
+    # ── Multiple Myeloma — ht-phr local-stack demo login (demo@healthtree.org,
+    #    "Diana Demo"). person_id 9008 is the patient the host FindTrials page
+    #    resolves for the demo account; seeded here with the canonical disease
+    #    title so the trial-match demo is reproducible without manual DB edits.
+    dict(
+        person_id=9008,
+        person_defaults=dict(year_of_birth=1968, gender_source_value='F'),
+        pi=dict(
+            disease='multiple myeloma',
+            patient_age=56,
+            gender='F',
+            country='US',
+            prior_therapy='More than two lines of therapy',
+            first_line_therapy='VRd',
+            first_line_outcome='CR',
+            second_line_therapy='Daratumumab',
+            second_line_outcome='PD',
+            later_therapy='Pomalidomide',
+            later_outcome='PD',
+            progression='active',
+            stage='III',
+            ecog_performance_status=1,
+            karnofsky_performance_score=80,
+            hemoglobin_level='9.8',
+            platelet_count=120000,
+            creatinine_clearance_rate=58,
+            no_hiv_status=True,
+            no_hepatitis_b_status=True,
+            no_hepatitis_c_status=True,
+            no_other_active_malignancies=True,
+            monoclonal_protein_serum='2.0',
+            kappa_flc=165,
+            lambda_flc=6,
+        ),
+    ),
+
     # ── Follicular Lymphoma — treatment-naive, should match TEST-FL-001
     dict(
         person_id=9003,

--- a/omop_core/migrations/0089_canonicalize_myeloma_disease.py
+++ b/omop_core/migrations/0089_canonicalize_myeloma_disease.py
@@ -1,0 +1,74 @@
+from django.db import migrations
+
+# Raw disease titles that EXACT's matcher does not recognise, mapped to the
+# canonical titles it gates on (ADR 0001). Mirrors _DISEASE_ALIASES in
+# omop_core/services/patient_info_service.py, kept self-contained here so the
+# migration is stable even if the service mapping later changes. Keyed by the
+# lowercased disease string; only exact matches are remapped.
+_DISEASE_ALIASES = {
+    'myeloma': 'multiple myeloma',
+}
+
+
+def _slugify_disease(name: str) -> str:
+    import re
+    slug = re.sub(r'[^a-z0-9]+', '-', name.lower()).strip('-')
+    return slug[:100]
+
+
+def canonicalize_disease(apps, schema_editor):
+    """Canonicalize existing PatientInfo.disease (and disease_slug) values.
+
+    Only rows whose disease, lowercased and trimmed, exactly matches an alias key
+    are touched; every other row passes through untouched (preserve, don't drop).
+    The matching read-model derivation now applies the same aliases on refresh
+    (patient_info_service._canonicalize_disease), so refreshed rows stay consistent.
+    """
+    import logging
+    logger = logging.getLogger(__name__)
+
+    PatientInfo = apps.get_model('omop_core', 'PatientInfo')
+    rows_to_update = []
+    remapped: dict = {}
+
+    qs = PatientInfo.objects.exclude(disease__isnull=True).exclude(disease='')
+    for pi in qs.iterator():
+        canonical = _DISEASE_ALIASES.get((pi.disease or '').strip().lower())
+        if canonical is None or canonical == pi.disease:
+            continue
+        remapped[pi.disease] = remapped.get(pi.disease, 0) + 1
+        pi.disease = canonical
+        pi.disease_slug = _slugify_disease(canonical)
+        rows_to_update.append(pi)
+
+    if rows_to_update:
+        PatientInfo.objects.bulk_update(
+            rows_to_update, ['disease', 'disease_slug'], batch_size=500
+        )
+
+    if remapped:
+        logger.warning(
+            "canonicalize_disease: remapped %d PatientInfo row(s) to canonical "
+            "disease titles: %s",
+            sum(remapped.values()),
+            remapped,
+        )
+
+
+def reverse_canonicalize_disease(apps, schema_editor):
+    # The original (pre-canonical) disease strings cannot be recovered after
+    # remapping — multiple raw forms collapse onto one canonical title. Rolling
+    # back leaves the canonical values in place. Manual correction is required
+    # if the original strings must be restored.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('omop_core', '0088_add_person_actor_identity'),
+    ]
+
+    operations = [
+        migrations.RunPython(canonicalize_disease, reverse_canonicalize_disease),
+    ]

--- a/omop_core/services/patient_info_service.py
+++ b/omop_core/services/patient_info_service.py
@@ -286,6 +286,26 @@ def _get_location_data(person: Person) -> dict:
     return data
 
 
+# Clinical-interpretation aliases: raw OMOP condition concept names that EXACT's
+# matcher does not recognise, mapped to the canonical disease titles it gates on
+# (ADR 0001 — CTOMOP owns the canonical disease title that SoC / ht-phr / EXACT all
+# read). Keyed by lowercased concept name; only exact matches are remapped, so
+# unrelated conditions pass through untouched.
+_DISEASE_ALIASES = {
+    'myeloma': 'multiple myeloma',
+}
+
+
+def _canonicalize_disease(name: str) -> str:
+    """Map a raw OMOP condition concept name to EXACT's canonical disease title.
+
+    Unrecognised names are returned unchanged (preserve, don't drop).
+    """
+    if not name:
+        return name
+    return _DISEASE_ALIASES.get(name.strip().lower(), name)
+
+
 def _get_disease_data(person: Person) -> dict:
     data = {}
 
@@ -306,7 +326,7 @@ def _get_disease_data(person: Person) -> dict:
     ).order_by('-condition_start_date').first()
 
     if cancer_condition:
-        data['disease'] = cancer_condition.condition_concept.concept_name
+        data['disease'] = _canonicalize_disease(cancer_condition.condition_concept.concept_name)
         if cancer_condition.condition_start_date:
             data['diagnosis_date'] = cancer_condition.condition_start_date
 

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -246,6 +246,37 @@ class RefreshPatientInfoDiseaseTest(_OmopBase):
         self.assertNotIn(' ', pi.disease_slug)
 
 
+class CanonicalizeDiseaseTest(_OmopBase):
+    """Raw OMOP concept names are mapped to EXACT's canonical disease titles."""
+
+    PERSON_ID = 90225
+
+    def test_canonicalize_helper_maps_known_aliases(self):
+        from omop_core.services.patient_info_service import _canonicalize_disease
+        self.assertEqual(_canonicalize_disease('myeloma'), 'multiple myeloma')
+        self.assertEqual(_canonicalize_disease('Myeloma'), 'multiple myeloma')
+        self.assertEqual(_canonicalize_disease('  MYELOMA  '), 'multiple myeloma')
+
+    def test_canonicalize_helper_passes_through_unknown(self):
+        from omop_core.services.patient_info_service import _canonicalize_disease
+        self.assertEqual(_canonicalize_disease('breast cancer'), 'breast cancer')
+        self.assertEqual(_canonicalize_disease(''), '')
+        self.assertIsNone(_canonicalize_disease(None))
+
+    def test_refresh_canonicalizes_bare_myeloma_condition(self):
+        myeloma_concept = _concept(90002, 'myeloma', self.dom_cond, self.vocab, self.cc)
+        ConditionOccurrence.objects.create(
+            condition_occurrence_id=92204,
+            person=self.person,
+            condition_concept=myeloma_concept,
+            condition_start_date=date(2022, 3, 1),
+            condition_type_concept=self.type_concept,
+        )
+        pi = refresh_patient_info(self.person)
+        self.assertEqual(pi.disease, 'multiple myeloma')
+        self.assertEqual(pi.disease_slug, 'multiple-myeloma')
+
+
 class RefreshPatientInfoLabsFromMeasurementTest(_OmopBase):
     """Labs are derived from Measurement records using source_value fallback."""
 


### PR DESCRIPTION
## Summary
- Canonicalize the raw OMOP condition name `myeloma` to the title `multiple myeloma` that EXACT's matcher gates on (ADR 0001 — CTOMOP owns the canonical disease title SoC/ht-phr/EXACT all read).
- Apply the alias in the PatientInfo derivation path (`patient_info_service`), so FHIR/OMOP-derived rows get the canonical title and the auto-derived `multiple-myeloma` slug.
- Data migration `0089` backfills existing `PatientInfo` rows (preserve-not-drop: only exact `myeloma` matches are remapped; unrecognized values pass through; remap count logged at WARNING; reverse is a documented no-op since originals aren't recoverable).
- Seed: add demo patient 9008 ("Diana Demo", `multiple myeloma`) mirroring the relapsed/refractory MM profile — this is the ht-phr local-stack demo login (demo@healthtree.org). The seed writes the canonical title directly.

## Test plan
- [x] `manage.py makemigrations --check` clean
- [x] Migration `0089` exercised on live row 9008 (myeloma → multiple myeloma, slug multiple-myeloma, WARNING log emitted)
- [x] 3 new `CanonicalizeDiseaseTest` cases + 29 existing omop_core tests pass