### PR TITLE
fix: OMOP ViewSet access control, tenant isolation bypass, FHIR transaction boundary

### DIFF
--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -75,7 +75,11 @@ class PatientInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = PatientInfo
         fields = '__all__'
-        read_only_fields = []
+        # organization and person must never be client-writable: they are
+        # set server-side from the auth token / FHIR upload respectively.
+        # A client supplying either field in a PATCH would bypass tenant
+        # isolation (organization) or reassign the record to another patient.
+        read_only_fields = ('organization', 'person', 'created_at', 'updated_at')
 
     def get_patient_name(self, obj):
         if obj.person:

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -2060,6 +2060,28 @@ class _OmopFilterMixin:
             from omop_core.models import PatientInfo
             allowed = PatientInfo.objects.filter(organization=org).values_list('person_id', flat=True)
             qs = qs.filter(person_id__in=allowed)
+        elif not (self.request.user and (
+            getattr(self.request.user, 'is_superuser', False) or
+            getattr(self.request.user, 'is_staff', False)
+        )):
+            # Session / partner-auth (Firebase, SAML): no org token.
+            # Enforce per-patient access using can_access_patient.
+            from omop_core.authorization import can_access_patient
+            from patient_portal.models import PatientUser
+            if person_id:
+                try:
+                    pid = int(person_id)
+                except (ValueError, TypeError):
+                    return qs.none()
+                if not can_access_patient(self.request.user, pid):
+                    return qs.none()
+            else:
+                # No explicit person_id — restrict to the user's own records only.
+                try:
+                    own_pid = PatientUser.objects.get(identity=self.request.user).person_id
+                    qs = qs.filter(person_id=own_pid)
+                except PatientUser.DoesNotExist:
+                    return qs.none()
         return qs
 
 
@@ -2088,6 +2110,13 @@ class _ProvenanceMixin:
                     raise NotFound('Person not found.')
                 if not PatientInfo.objects.filter(person=person, organization=org).exists():
                     raise PermissionDenied('Person does not belong to your organization.')
+        elif not (self.request.user.is_superuser or getattr(self.request.user, 'is_staff', False)):
+            person = serializer.validated_data.get('person')
+            if person:
+                from omop_core.authorization import can_access_patient
+                from rest_framework.exceptions import PermissionDenied
+                if not can_access_patient(self.request.user, person.person_id):
+                    raise PermissionDenied('Access denied.')
 
         obj = serializer.save()
         self._prov(obj)
@@ -2101,6 +2130,13 @@ class _ProvenanceMixin:
                 raise NotFound('Person not found.')
             if not PatientInfo.objects.filter(person=person, organization=org).exists():
                 raise PermissionDenied('Person does not belong to your organization.')
+        elif not (self.request.user.is_superuser or getattr(self.request.user, 'is_staff', False)):
+            person = serializer.validated_data.get('person') or serializer.instance.person
+            if person:
+                from omop_core.authorization import can_access_patient
+                from rest_framework.exceptions import PermissionDenied
+                if not can_access_patient(self.request.user, person.person_id):
+                    raise PermissionDenied('Access denied.')
         obj = serializer.save()
         self._prov(obj)
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -145,6 +145,47 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
         org = get_request_org(self.request)
         if org is not None:
             qs = qs.filter(organization=org)
+        elif not (self.request.user and (
+            getattr(self.request.user, 'is_superuser', False) or
+            getattr(self.request.user, 'is_staff', False)
+        )):
+            # Session / partner-auth users: scope to only the patients they can
+            # access — their own record (PatientUser) and any patients in their
+            # professional groups (ProfessionalGroupAccess). Doctors/admins with
+            # group access see their whole panel; is_staff bypasses this entirely.
+            from patient_portal.models import PatientUser
+            from omop_core.models import PatientGroupMembership, ProfessionalGroupAccess
+            from django.utils import timezone
+            from django.db.models import Q
+
+            accessible_pids = set()
+
+            # Self-access
+            try:
+                accessible_pids.add(
+                    PatientUser.objects.get(identity=self.request.user).person_id
+                )
+            except PatientUser.DoesNotExist:
+                pass
+
+            # Professional group access (non-expired grants)
+            now = timezone.now()
+            actor_group_ids = ProfessionalGroupAccess.objects.filter(
+                identity=self.request.user,
+            ).filter(
+                Q(expires_at__isnull=True) | Q(expires_at__gt=now),
+            ).values_list('group_id', flat=True)
+
+            if actor_group_ids:
+                group_pids = PatientGroupMembership.objects.filter(
+                    group_id__in=actor_group_ids
+                ).values_list('person_id', flat=True)
+                accessible_pids.update(group_pids)
+
+            if not accessible_pids:
+                return qs.none()
+
+            qs = qs.filter(person_id__in=accessible_pids)
         return qs
 
     def get_serializer_class(self):
@@ -256,6 +297,7 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
         # Capture previous values for fields being changed (exclude provenance meta-fields).
         # Use {field}_id for FK fields so we get a serializable PK, not a model object.
         _prov_meta = {'source', 'source_user_id', 'modification_reason'}
+        _read_only = set(PatientInfoSerializer.Meta.read_only_fields)
         def _prev_val(obj, field):
             fk_id = f'{field}_id'
             if hasattr(obj, fk_id):
@@ -264,7 +306,7 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
         previous_values = {
             field: _prev_val(patient_info, field)
             for field in request.data
-            if field not in _prov_meta and hasattr(patient_info, field)
+            if field not in _prov_meta and field not in _read_only and hasattr(patient_info, field)
         }
 
         serializer = PatientInfoSerializer(patient_info, data=request.data, partial=True)
@@ -654,10 +696,9 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                             year_of_birth=year_of_birth,
                         ).first()
                     if person is None:
-                        last_person = Person.objects.all().order_by('-person_id').first()
-                        person_id = last_person.person_id + 1 if last_person else 1000
+                        from omop_core.services.pk import next_pk as _next_pk
                         person = Person.objects.create(
-                            person_id=person_id,
+                            person_id=_next_pk(Person, 'person_id'),
                             gender_concept=gender_concept,
                             year_of_birth=year_of_birth or datetime.now().year - 50,
                             month_of_birth=month_of_birth,
@@ -1811,7 +1852,8 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                 except Exception as e:
                     _last_exc = e
                     _err_hash = hashlib.sha256(str(fhir_patient_id).encode()).hexdigest()[:12]
-                    errors.append(f"Patient (id_hash={_err_hash}): {str(e)}")
+                    logger.exception("FHIR upload error for patient id_hash=%s", _err_hash)
+                    errors.append(f"Patient (id_hash={_err_hash}): processing failed")
                 finally:
                     # Roll back if the transaction was opened but never committed
                     # (i.e. an exception occurred during OMOP writes).
@@ -1856,12 +1898,21 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
             errors = []
             
             org = get_request_org(request)
+            _is_privileged = request.user and (
+                getattr(request.user, 'is_superuser', False) or
+                getattr(request.user, 'is_staff', False)
+            )
             for person_id in person_ids:
                 try:
                     person = Person.objects.get(person_id=person_id)
                     if org is not None and not PatientInfo.objects.filter(person=person, organization=org).exists():
                         errors.append("Person not found.")
                         continue
+                    elif org is None and not _is_privileged:
+                        from omop_core.authorization import can_access_patient
+                        if not can_access_patient(request.user, person_id):
+                            errors.append("Person not found.")
+                            continue
                     # Delete PatientInfo
                     PatientInfo.objects.filter(person=person).delete()
                     # Delete associated Identity if exists (via PatientUser)
@@ -2046,6 +2097,10 @@ class PersonViewSet(viewsets.GenericViewSet):
         if org is not None:
             if not PatientInfo.objects.filter(person=person, organization=org).exists():
                 return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
+        elif not (getattr(request.user, 'is_superuser', False) or getattr(request.user, 'is_staff', False)):
+            from omop_core.authorization import can_access_patient
+            if not can_access_patient(request.user, person.person_id):
+                return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
         changed = []
         for field, (kind, placeholders) in _PERSON_PATCHABLE_FIELDS.items():
@@ -2146,13 +2201,14 @@ class _ProvenanceMixin:
                     raise NotFound('Person not found.')
                 if not PatientInfo.objects.filter(person=person, organization=org).exists():
                     raise PermissionDenied('Person does not belong to your organization.')
-        elif not (self.request.user.is_superuser or getattr(self.request.user, 'is_staff', False)):
+        elif not (getattr(self.request.user, 'is_superuser', False) or getattr(self.request.user, 'is_staff', False)):
+            from omop_core.authorization import can_access_patient
+            from rest_framework.exceptions import PermissionDenied
             person = serializer.validated_data.get('person')
-            if person:
-                from omop_core.authorization import can_access_patient
-                from rest_framework.exceptions import PermissionDenied
-                if not can_access_patient(self.request.user, person.person_id):
-                    raise PermissionDenied('Access denied.')
+            if not person:
+                raise PermissionDenied('person is required.')
+            if not can_access_patient(self.request.user, person.person_id):
+                raise PermissionDenied('Access denied.')
 
         obj = serializer.save()
         self._prov(obj)
@@ -2166,13 +2222,14 @@ class _ProvenanceMixin:
                 raise NotFound('Person not found.')
             if not PatientInfo.objects.filter(person=person, organization=org).exists():
                 raise PermissionDenied('Person does not belong to your organization.')
-        elif not (self.request.user.is_superuser or getattr(self.request.user, 'is_staff', False)):
+        elif not (getattr(self.request.user, 'is_superuser', False) or getattr(self.request.user, 'is_staff', False)):
+            from omop_core.authorization import can_access_patient
+            from rest_framework.exceptions import PermissionDenied
             person = serializer.validated_data.get('person') or serializer.instance.person
-            if person:
-                from omop_core.authorization import can_access_patient
-                from rest_framework.exceptions import PermissionDenied
-                if not can_access_patient(self.request.user, person.person_id):
-                    raise PermissionDenied('Access denied.')
+            if not person:
+                raise PermissionDenied('person is required.')
+            if not can_access_patient(self.request.user, person.person_id):
+                raise PermissionDenied('Access denied.')
         obj = serializer.save()
         self._prov(obj)
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -5,7 +5,7 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from patient_portal.models import Identity
 from django.contrib.auth import logout, login, authenticate
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 from django.utils import timezone
@@ -626,6 +626,24 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                     given_name = ' '.join(name.get('given', [])) if name.get('given') else ''
                     family_name = name.get('family', '')
                     
+                    # Suppress signal-triggered PatientInfo refreshes for all OMOP
+                    # writes below. Use __enter__/__exit__ explicitly so the finally
+                    # block guarantees cleanup even on BaseException (e.g. KeyboardInterrupt),
+                    # without requiring 1000 lines of re-indentation.
+                    from omop_core.signals import suppress_patient_info_refresh as _suppress_cm_fn
+                    _suppress_cm = _suppress_cm_fn()
+                    _suppress_cm.__enter__()
+
+                    # Wrap all per-patient DB writes — including Person creation — in a
+                    # savepoint so a failure mid-patient rolls back fully rather than
+                    # leaving orphaned rows. _atomic_entered tracks whether __enter__
+                    # was called so the finally block can roll back exactly once.
+                    _atomic_cm = transaction.atomic()
+                    _atomic_entered = False
+                    _last_exc = None
+                    _atomic_cm.__enter__()
+                    _atomic_entered = True
+
                     # Upsert Person: match on name + birth year to avoid duplicates on re-upload
                     person = None
                     person_is_new = False
@@ -660,14 +678,6 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                                 'name': full_name,
                             },
                         )
-                    
-                    # Suppress signal-triggered PatientInfo refreshes for all OMOP
-                    # writes below. Use __enter__/__exit__ explicitly so the finally
-                    # block guarantees cleanup even on BaseException (e.g. KeyboardInterrupt),
-                    # without requiring 1000 lines of re-indentation.
-                    from omop_core.signals import suppress_patient_info_refresh as _suppress_cm_fn
-                    _suppress_cm = _suppress_cm_fn()
-                    _suppress_cm.__enter__()
 
                     # Extract disease, stage, and histologic type from Condition
                     disease = 'Breast Cancer'
@@ -1574,7 +1584,9 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                             logger.warning(f"Could not write DrugExposure/Episode for LOT {lot_num}: {_e}")
 
                     # --- OMOP-first: refresh PatientInfo from OMOP tables ---
-                    # Release suppression before the single intentional refresh.
+                    # Release suppression so the single intentional refresh can run.
+                    # We stay inside the atomic block so that a refresh failure rolls
+                    # back all OMOP writes for this patient.
                     _suppress_cm.__exit__(None, None, None)
                     logger.debug("TIMING patient=%s phase=drug_exposures elapsed=%.1fs", _timing_hash, _time.monotonic() - _pt_start)
                     patient_info = refresh_patient_info(person)
@@ -1769,7 +1781,12 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                     patient_info.save()
                     if prov_source:
                         _record_provenance(patient_info, prov_source, prov_user_id, modification_reason=prov_reason, organization=get_request_org(request))
-                    
+
+                    # Commit all writes for this patient. Mark _atomic_entered=False
+                    # so the finally block knows the transaction was cleanly committed.
+                    _atomic_cm.__exit__(None, None, None)
+                    _atomic_entered = False
+
                     patients_result.append({
                         'person_id': person.person_id,
                         'patient_info_id': patient_info.pk,
@@ -1792,15 +1809,28 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                                 _fhir_id_hash, _pt_total)
                     
                 except Exception as e:
+                    _last_exc = e
                     _err_hash = hashlib.sha256(str(fhir_patient_id).encode()).hexdigest()[:12]
                     errors.append(f"Patient (id_hash={_err_hash}): {str(e)}")
                 finally:
+                    # Roll back if the transaction was opened but never committed
+                    # (i.e. an exception occurred during OMOP writes).
+                    if _atomic_entered:
+                        try:
+                            _atomic_cm.__exit__(
+                                type(_last_exc) if _last_exc else None,
+                                _last_exc,
+                                _last_exc.__traceback__ if _last_exc else None,
+                            )
+                        except Exception:
+                            pass
                     # Guarantee suppression is cleared even on BaseException.
-                    # Safe to call on an already-exited context manager (re-entrant safe).
+                    # Use bare except to handle NameError (assigned before entry) and
+                    # any error from calling __exit__ a second time on success path.
                     try:
                         _suppress_cm.__exit__(None, None, None)
-                    except NameError:
-                        pass  # exception raised before _suppress_cm was assigned
+                    except Exception:
+                        pass
             
             return Response({
                 'success': True,

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -253,10 +253,16 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Capture previous values for fields being changed (exclude provenance meta-fields)
+        # Capture previous values for fields being changed (exclude provenance meta-fields).
+        # Use {field}_id for FK fields so we get a serializable PK, not a model object.
         _prov_meta = {'source', 'source_user_id', 'modification_reason'}
+        def _prev_val(obj, field):
+            fk_id = f'{field}_id'
+            if hasattr(obj, fk_id):
+                return getattr(obj, fk_id, None)
+            return getattr(obj, field, None)
         previous_values = {
-            field: getattr(patient_info, field, None)
+            field: _prev_val(patient_info, field)
             for field in request.data
             if field not in _prov_meta and hasattr(patient_info, field)
         }

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -5636,3 +5636,58 @@ class PatientInfoOrganizationReadOnlyTest(TestCase):
         # organization is present in the response (readable)
         pi_data = resp.data.get('patient_info', resp.data)
         self.assertIn('organization', pi_data)
+
+
+# ---------------------------------------------------------------------------
+# Per-patient transaction boundary in upload_fhir (issue #149)
+# ---------------------------------------------------------------------------
+
+class FhirUploadTransactionTest(FhirUploadBase):
+    """
+    Verify that a mid-patient failure rolls back all DB writes for that
+    patient so no orphaned Person / OMOP rows persist.
+    """
+
+    def test_failed_patient_leaves_no_orphaned_rows(self):
+        """
+        If refresh_patient_info raises mid-patient, the Person and all OMOP
+        rows written before the error must be rolled back.
+        """
+        from unittest.mock import patch
+        from omop_core.services.patient_info_service import refresh_patient_info
+
+        person_id_before = (
+            Person.objects.order_by('-person_id').values_list('person_id', flat=True).first() or 0
+        )
+
+        bundle = _make_fhir_bundle()
+        bundle_bytes = json.dumps(bundle).encode('utf-8')
+        fhir_file = io.BytesIO(bundle_bytes)
+        fhir_file.name = 'bundle.json'
+
+        with patch(
+            'patient_portal.api.views.refresh_patient_info',
+            side_effect=RuntimeError('simulated mid-patient failure'),
+        ):
+            resp = self.client.post(
+                '/api/patient-info/upload_fhir/',
+                {'file': fhir_file},
+                format='multipart',
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        # The error is recorded, not a 500
+        self.assertGreater(len(resp.data.get('errors', [])), 0)
+
+        # No new Person row should have been committed
+        new_persons = Person.objects.filter(person_id__gt=person_id_before).count()
+        self.assertEqual(new_persons, 0, "Partial patient rows were not rolled back")
+
+    def test_successful_patient_commits_rows(self):
+        """Successful uploads still persist rows after the transaction fix."""
+        resp = self._upload_bundle()
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreater(resp.data.get('created_count', 0), 0)
+        self.assertIsNotNone(
+            Person.objects.filter(family_name='Smith', given_name='Jane').first()
+        )

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -5482,3 +5482,106 @@ class PatientInfoIDORTest(TestCase):
             f'/api/patient-info/{self.person_b.person_id}/'
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+
+# ---------------------------------------------------------------------------
+# OMOP ViewSet row-level access (issue #135)
+# ---------------------------------------------------------------------------
+
+class OmopViewSetAccessTest(TestCase):
+    """
+    Verify that _OmopFilterMixin enforces per-patient access for session /
+    partner-auth users (org is None path) on the OMOP clinical ViewSets.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+
+        # Patient A — the attacker
+        cls.person_a = Person.objects.create(person_id=88901, family_name='Attacker', given_name='Alice')
+        PatientInfo.objects.create(person=cls.person_a)
+        cls.identity_a = Identity.objects.create_user(email='attacker@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_a, person=cls.person_a)
+
+        # Patient B — the victim
+        cls.person_b = Person.objects.create(person_id=88902, family_name='Victim', given_name='Bob')
+        PatientInfo.objects.create(person=cls.person_b)
+        cls.identity_b = Identity.objects.create_user(email='victim@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_b, person=cls.person_b)
+
+        # A measurement belonging to patient B
+        cls.measurement = Measurement.objects.create(
+            measurement_id=998877,
+            person=cls.person_b,
+            measurement_concept_id=0,
+            measurement_type_concept_id=0,
+            measurement_date=date(2024, 1, 1),
+        )
+
+        # A condition belonging to patient B
+        cls.condition = ConditionOccurrence.objects.create(
+            condition_occurrence_id=998877,
+            person=cls.person_b,
+            condition_concept_id=0,
+            condition_type_concept_id=0,
+            condition_start_date=date(2024, 1, 1),
+        )
+
+        cls.superuser = Identity.objects.create_superuser(email='su2@test.com', password='pw')
+
+    def _client_as(self, identity):
+        c = APIClient()
+        c.force_authenticate(user=identity)
+        return c
+
+    # --- List filtered by person_id ---
+
+    def test_patient_cannot_list_other_measurements(self):
+        """GET /api/measurements/?person_id=B as patient A returns empty list."""
+        resp = self._client_as(self.identity_a).get(
+            f'/api/measurements/?person_id={self.person_b.person_id}'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len((resp.data if isinstance(resp.data, list) else resp.data.get('results', resp.data))), 0)
+
+    def test_patient_can_list_own_measurements(self):
+        """GET /api/measurements/?person_id=A as patient A returns their records."""
+        Measurement.objects.create(
+            measurement_id=998878,
+            person=self.person_a,
+            measurement_concept_id=0,
+            measurement_type_concept_id=0,
+            measurement_date=date(2024, 1, 1),
+        )
+        resp = self._client_as(self.identity_a).get(
+            f'/api/measurements/?person_id={self.person_a.person_id}'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        results = (resp.data if isinstance(resp.data, list) else resp.data.get('results', resp.data))
+        self.assertGreater(len(results), 0)
+
+    def test_patient_cannot_list_other_conditions(self):
+        """GET /api/conditions/?person_id=B as patient A returns empty list."""
+        resp = self._client_as(self.identity_a).get(
+            f'/api/conditions/?person_id={self.person_b.person_id}'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len((resp.data if isinstance(resp.data, list) else resp.data.get('results', resp.data))), 0)
+
+    def test_list_without_person_id_returns_own_records_only(self):
+        """GET /api/measurements/ (no person_id) as patient A returns only their records."""
+        resp = self._client_as(self.identity_a).get('/api/measurements/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        results = (resp.data if isinstance(resp.data, list) else resp.data.get('results', resp.data))
+        person_ids = {r['person'] for r in results}
+        self.assertNotIn(self.person_b.person_id, person_ids)
+
+    def test_superuser_can_list_any_patient_measurements(self):
+        """Superusers retain unrestricted access."""
+        resp = self._client_as(self.superuser).get(
+            f'/api/measurements/?person_id={self.person_b.person_id}'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        results = (resp.data if isinstance(resp.data, list) else resp.data.get('results', resp.data))
+        self.assertGreater(len(results), 0)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -5585,3 +5585,54 @@ class OmopViewSetAccessTest(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         results = (resp.data if isinstance(resp.data, list) else resp.data.get('results', resp.data))
         self.assertGreater(len(results), 0)
+
+
+# ---------------------------------------------------------------------------
+# Mass-assignable organization field (issue #139)
+# ---------------------------------------------------------------------------
+
+class PatientInfoOrganizationReadOnlyTest(TestCase):
+    """
+    Verify that a client cannot PATCH organization or person onto a
+    PatientInfo record — these fields must be silently ignored (read-only).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import Organization
+        from patient_portal.models import PatientUser
+
+        cls.org_a = Organization.objects.create(name='Org A', slug='org-a-139')
+        cls.org_b = Organization.objects.create(name='Org B', slug='org-b-139')
+
+        cls.person = Person.objects.create(person_id=89001, family_name='Test', given_name='User')
+        cls.patient = PatientInfo.objects.create(person=cls.person, organization=cls.org_a)
+        cls.identity = Identity.objects.create_user(email='orgtest@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity, person=cls.person)
+
+        cls.other_person = Person.objects.create(person_id=89002, family_name='Other', given_name='Person')
+        PatientInfo.objects.create(person=cls.other_person, organization=cls.org_b)
+
+    def _client(self):
+        c = APIClient()
+        c.force_authenticate(user=self.identity)
+        return c
+
+    def test_patch_cannot_change_organization(self):
+        """PATCH {organization: org_b} must not change the record's org."""
+        resp = self._client().patch(
+            f'/api/patient-info/{self.person.person_id}/',
+            {'organization': self.org_b.id},
+            format='json',
+        )
+        self.assertIn(resp.status_code, [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST])
+        self.patient.refresh_from_db()
+        self.assertEqual(self.patient.organization_id, self.org_a.id)
+
+    def test_organization_field_is_read_only_in_response(self):
+        """organization appears in the GET response but cannot be changed via PATCH."""
+        resp = self._client().get(f'/api/patient-info/{self.person.person_id}/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        # organization is present in the response (readable)
+        pi_data = resp.data.get('patient_info', resp.data)
+        self.assertIn('organization', pi_data)


### PR DESCRIPTION
## Summary

Three security/data-integrity fixes from the platform audit:

- **CRITICAL #135** — OMOP clinical ViewSets lacked row-level access checks for session/partner-auth users. Added can_access_patient() in _OmopFilterMixin and _ProvenanceMixin so patients can only see their own records.

- **HIGH #139** — PatientInfoSerializer left organization and person FK fields client-writable via __all__. Fixed by adding read_only_fields = ('organization', 'person', 'created_at', 'updated_at').

- **HIGH #149** — upload_fhir per-patient loop had no transaction boundary. Wrapped entire per-patient block (including Person creation) in transaction.atomic() savepoint so failures roll back all writes atomically.

## Test plan

- FhirUploadTransactionTest (2 tests): rollback on failure, commit on success
- OmopViewSetAccessTest (5 tests): cross-patient blocked, own-record allowed, superuser unrestricted
- PatientInfoOrganizationReadOnlyTest (2 tests): PATCH cannot change organization

All 9 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)