### PR TITLE
fix: resolve _resolve_person_id org-bypass and unauthenticated fallthrough

### DIFF
--- a/patient_portal/api/lab_results/sync.py
+++ b/patient_portal/api/lab_results/sync.py
@@ -216,7 +216,7 @@ class SyncView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-        # Legacy org-scoped check (OAuth2 service clients)
+        # Org-scope enforcement for OAuth2 service clients
         org = get_request_org(request)
         if org is not None:
             from omop_core.models import PatientInfo

--- a/patient_portal/api/lab_results/tests.py
+++ b/patient_portal/api/lab_results/tests.py
@@ -1406,3 +1406,10 @@ class ResolvePersonIdOrgBypassTest(TestCase):
             f'/api/lab-results/values/?person_id={self.person_in_b.person_id}&concept_code=718-7'
         )
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_org_token_allowed_on_trend_endpoint_for_own_org_patient(self):
+        """Org-A token can access the trend endpoint for an org-A patient."""
+        resp = self.client.get(
+            f'/api/lab-results/values/?person_id={self.person_in_a.person_id}&concept_code=718-7'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)

--- a/patient_portal/api/lab_results/tests.py
+++ b/patient_portal/api/lab_results/tests.py
@@ -1319,3 +1319,90 @@ class ResolvePersonIdEmailFallbackTest(TestCase):
         resp = client.get('/api/lab-results/summary/')
         # Two patients with same email, no org scope, non-superuser → 404
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_person_id — org isolation cannot be bypassed via can_access_patient
+# ---------------------------------------------------------------------------
+
+class ResolvePersonIdOrgBypassTest(TestCase):
+    """
+    Verify that an org-scoped token cannot access a patient from a different
+    org even when can_access_patient() would return True (e.g. via
+    ProfessionalGroupAccess that spans organisations).
+
+    Before the fix, _resolve_person_id only ran the org check when
+    can_access_patient() returned False.  A cross-org group grant therefore
+    caused the org check to be skipped entirely, granting access.
+    """
+
+    def setUp(self):
+        from omop_core.models import Organization, ApplicationOrganization, PatientGroupMembership, ProfessionalGroupAccess
+        from oauth2_provider.models import Application, AccessToken
+        from django.utils import timezone
+        from datetime import timedelta
+        _setup_vocab()
+
+        # Two orgs
+        self.org_a = Organization.objects.create(name='Org A', slug='rp-org-a')
+        self.org_b = Organization.objects.create(name='Org B', slug='rp-org-b')
+
+        # Provider user whose token is scoped to org-A
+        self.provider = Identity.objects.create_user(email='provider@test.com', password='x')
+
+        self.app = Application.objects.create(
+            name='Org A App',
+            user=self.provider,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        ApplicationOrganization.objects.create(application=self.app, organization=self.org_a)
+
+        self.token = AccessToken.objects.create(
+            user=self.provider,
+            application=self.app,
+            token='rp-bypass-test-token',
+            expires=timezone.now() + timedelta(hours=1),
+            scope='patient/*.read',
+        )
+
+        # Patient in org-A (accessible)
+        self.person_in_a = Person.objects.create(person_id=18001)
+        PatientInfo.objects.create(person=self.person_in_a, organization=self.org_a)
+
+        # Patient in org-B (must NOT be accessible via org-A token)
+        self.person_in_b = Person.objects.create(person_id=18002)
+        PatientInfo.objects.create(person=self.person_in_b, organization=self.org_b)
+
+        # Give the provider a ProfessionalGroupAccess that covers the org-B patient.
+        # This simulates a cross-org group grant that must not bypass org isolation.
+        from omop_core.models import PatientGroup
+        self.group = PatientGroup.objects.create(
+            name='Cross-org group', slug='cross-org-group', organization=self.org_b,
+        )
+        PatientGroupMembership.objects.create(group=self.group, person_id=self.person_in_b.person_id)
+        ProfessionalGroupAccess.objects.create(
+            identity=self.provider,
+            group=self.group,
+            role='navigator',
+        )
+
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.token.token}')
+
+    def test_org_token_denied_for_patient_in_other_org_even_with_group_access(self):
+        """Org-A token cannot read org-B patient even if ProfessionalGroupAccess covers them."""
+        resp = self.client.get(f'/api/lab-results/summary/?person_id={self.person_in_b.person_id}')
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_org_token_allowed_for_patient_in_own_org(self):
+        """Org-A token can read org-A patient normally."""
+        resp = self.client.get(f'/api/lab-results/summary/?person_id={self.person_in_a.person_id}')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_org_token_denied_on_trend_endpoint_for_other_org_patient(self):
+        """Same isolation applies to the trend endpoint."""
+        resp = self.client.get(
+            f'/api/lab-results/values/?person_id={self.person_in_b.person_id}&concept_code=718-7'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -75,22 +75,34 @@ def _resolve_person_id(request):
                 {'detail': 'person_id must be an integer.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        # Verify caller has access to this patient
+        # Verify caller has access to this patient.
+        # Org-scoped tokens are checked FIRST, before can_access_patient.
+        # ProfessionalGroupAccess can span organisations, so allowing
+        # can_access_patient() to short-circuit the org check would let a
+        # cross-org group grant bypass tenant isolation.
         if request.user and request.user.is_authenticated:
-            own_pid = None
-            try:
-                own_pid = PatientUser.objects.get(identity=request.user).person_id
-            except PatientUser.DoesNotExist:
-                pass
-            if pid != own_pid and not can_access_patient(request.user, pid):
-                org = get_request_org(request)
-                if org is None or not PatientInfo.objects.filter(
+            org = get_request_org(request)
+            if org is not None:
+                # Org-scoped path: membership in the org is the only check.
+                if not PatientInfo.objects.filter(
                     person_id=pid, organization=org,
                 ).exists():
                     return None, Response(
                         {'detail': 'Access denied.'},
                         status=status.HTTP_403_FORBIDDEN,
                     )
+                return pid, None
+            # Non-org path: self-access or individual access grant.
+            own_pid = None
+            try:
+                own_pid = PatientUser.objects.get(identity=request.user).person_id
+            except PatientUser.DoesNotExist:
+                pass
+            if pid != own_pid and not can_access_patient(request.user, pid):
+                return None, Response(
+                    {'detail': 'Access denied.'},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
         return pid, None
 
     if not request.user or not request.user.is_authenticated:
@@ -220,14 +232,6 @@ class ResultsSummaryView(APIView):
         person_id, err = _resolve_person_id(request)
         if err:
             return err
-
-        org = get_request_org(request)
-        if org is not None:
-            if not PatientInfo.objects.filter(person_id=person_id, organization=org).exists():
-                return Response(
-                    {'detail': 'Person not found in your organization.'},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
 
         summaries = self._get_concept_summaries(person_id)
 
@@ -398,14 +402,6 @@ class ValuesView(APIView):
                 {'detail': 'concept_code query parameter is required.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-
-        org = get_request_org(request)
-        if org is not None:
-            if not PatientInfo.objects.filter(person_id=person_id, organization=org).exists():
-                return Response(
-                    {'detail': 'Person not found in your organization.'},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
 
         concept = Concept.objects.filter(
             concept_code=concept_code,

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -80,29 +80,35 @@ def _resolve_person_id(request):
         # ProfessionalGroupAccess can span organisations, so allowing
         # can_access_patient() to short-circuit the org check would let a
         # cross-org group grant bypass tenant isolation.
-        if request.user and request.user.is_authenticated:
-            org = get_request_org(request)
-            if org is not None:
-                # Org-scoped path: membership in the org is the only check.
-                if not PatientInfo.objects.filter(
-                    person_id=pid, organization=org,
-                ).exists():
-                    return None, Response(
-                        {'detail': 'Access denied.'},
-                        status=status.HTTP_403_FORBIDDEN,
-                    )
-                return pid, None
-            # Non-org path: self-access or individual access grant.
-            own_pid = None
-            try:
-                own_pid = PatientUser.objects.get(identity=request.user).person_id
-            except PatientUser.DoesNotExist:
-                pass
-            if pid != own_pid and not can_access_patient(request.user, pid):
+        if not (request.user and request.user.is_authenticated):
+            return None, Response(
+                {'detail': 'Authentication required.'},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        org = get_request_org(request)
+        if org is not None:
+            # Org-scoped path: membership in the org is the only check.
+            # Note: patients with organization=NULL (bootstrap/unassigned) are
+            # intentionally unreachable via org-scoped tokens.
+            if not PatientInfo.objects.filter(
+                person_id=pid, organization=org,
+            ).exists():
                 return None, Response(
                     {'detail': 'Access denied.'},
                     status=status.HTTP_403_FORBIDDEN,
                 )
+            return pid, None
+        # Non-org path: self-access or individual access grant.
+        own_pid = None
+        try:
+            own_pid = PatientUser.objects.get(identity=request.user).person_id
+        except PatientUser.DoesNotExist:
+            pass
+        if pid != own_pid and not can_access_patient(request.user, pid):
+            return None, Response(
+                {'detail': 'Access denied.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         return pid, None
 
     if not request.user or not request.user.is_authenticated:


### PR DESCRIPTION
## Summary

- **Security (high):** `_resolve_person_id` was only running the org-isolation check when `can_access_patient()` returned False. An org-A token holder with a `ProfessionalGroupAccess` grant covering an org-B patient could cause `can_access_patient()` to return True, which skipped the org check entirely — granting cross-tenant access. Fixed by moving the org check to run first and unconditionally for org-scoped tokens.
- **Security (critical, defence-in-depth):** When `?person_id=X` is provided but the caller is unauthenticated, the auth guard was inside an `if authenticated:` block, so unauthenticated callers fell through to `(pid, None)` with no checks at all. Added an explicit 401 response.
- **Removed duplicate org checks** from `ResultsSummaryView` and `ValuesView` that were an accidental safety net (now consolidated in `_resolve_person_id`).
- Fixed a misleading `# Legacy org-scoped check` comment in `SyncView` — it is a mandatory tenant-isolation control, not legacy code.
- Added a symmetric allowed-path test for the ValuesView (trend endpoint) in `ResolvePersonIdOrgBypassTest`.

## Test plan

- [ ] `ResolvePersonIdOrgBypassTest` — 4 tests (denied cross-org on summary, allowed own-org on summary, denied cross-org on trend, allowed own-org on trend)
- [ ] Full backend suite: `DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" .venv/bin/python manage.py test omop_core patient_portal --verbosity=0 --noinput` → 460 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)