### PR TITLE
feat: org-level access control and disease stats page

### DIFF
--- a/docs/superpowers/plans/2026-06-20-org-disease-stats.md
+++ b/docs/superpowers/plans/2026-06-20-org-disease-stats.md
@@ -1,0 +1,906 @@
+# Org Disease Stats Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename `ProfessionalGroupAccess` → `GroupAccess`, add an `org_admin` role scoped to an org, a `get_visible_orgs` access helper, a `/api/stats/org-disease/` endpoint, and a `/stats` frontend page showing per-org disease counts.
+
+**Architecture:** The rename is a single migration; existing `doctor`/`navigator` rows are untouched (they still have `group` set). A new `omop_core/services/access.py` module provides `get_visible_orgs(user)` used by the stats view. The frontend adds a `StatsPage` component and a nav link.
+
+**Tech Stack:** Django 5, DRF, PostgreSQL, React 18, TypeScript, Tailwind, Vitest/Testing Library.
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `omop_core/models.py` | Rename class, add `org` FK, update constraints and choices |
+| `omop_core/migrations/0095_group_access.py` | Rename table, add org FK, update constraints |
+| `omop_core/services/access.py` | New — `get_visible_orgs(user)` |
+| `omop_core/authorization.py` | Update import: `ProfessionalGroupAccess` → `GroupAccess` |
+| `patient_portal/api/views.py` | Update import + queryset scoping; add `org_disease_stats` view; add `is_staff` to `UserSerializer` |
+| `patient_portal/api/serializers.py` | Add `is_staff` to `UserSerializer` fields |
+| `patient_portal/api/urls.py` | Add `stats/org-disease/` URL |
+| `patient_portal/api/lab_results/views.py` | Update import |
+| `patient_portal/api/lab_results/tests.py` | Update import + class name |
+| `patient_portal/tests.py` | Update import; add stats endpoint tests |
+| `omop_core/tests.py` | Add `get_visible_orgs` unit tests |
+| `frontend/src/types/patient.ts` | Add `is_staff?: boolean` to `User` interface |
+| `frontend/src/components/Stats/StatsPage.tsx` | New — stats page component |
+| `frontend/src/components/Stats/StatsPage.test.tsx` | New — component tests |
+| `frontend/src/App.tsx` | Add `/stats` route |
+| `frontend/src/components/Patient/PatientList.tsx` | Add Stats nav link |
+
+---
+
+## Task 1: Rename model and run migration
+
+**Files:**
+- Modify: `omop_core/models.py`
+- Create: `omop_core/migrations/0095_group_access.py` (via makemigrations)
+
+- [ ] **Step 1: Update the model in `omop_core/models.py`**
+
+Replace the entire `ProfessionalGroupAccess` class with:
+
+```python
+class GroupAccess(models.Model):
+    """Grants a professional (Identity) access to an org or a patient group."""
+    ROLE_CHOICES = [
+        ('org_admin', 'Org Admin'),
+        ('doctor',    'Doctor'),
+        ('navigator', 'Navigator'),
+    ]
+    identity = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+        related_name='group_access_grants',
+    )
+    org = models.ForeignKey(
+        'Organization', on_delete=models.CASCADE,
+        null=True, blank=True, related_name='access_grants',
+    )
+    group = models.ForeignKey(
+        PatientGroup, on_delete=models.CASCADE,
+        null=True, blank=True, related_name='access_grants',
+    )
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES)
+    expires_at = models.DateTimeField(null=True, blank=True)
+    granted_at = models.DateTimeField(auto_now_add=True)
+    granted_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL,
+        null=True, blank=True, related_name='+',
+    )
+
+    class Meta:
+        db_table = 'group_access'
+        constraints = [
+            models.CheckConstraint(
+                check=(
+                    Q(org__isnull=False, group__isnull=True) |
+                    Q(org__isnull=True, group__isnull=False)
+                ),
+                name='group_access_org_xor_group',
+            ),
+            models.UniqueConstraint(
+                fields=['identity', 'group'],
+                condition=Q(group__isnull=False),
+                name='uq_identity_group',
+            ),
+            models.UniqueConstraint(
+                fields=['identity', 'org'],
+                condition=Q(org__isnull=False),
+                name='uq_identity_org',
+            ),
+        ]
+
+    def __str__(self):
+        scope = f"org={self.org_id}" if self.org_id else f"group={self.group_id}"
+        return f"{self.identity} → {scope} ({self.role})"
+```
+
+- [ ] **Step 2: Generate the migration**
+
+```bash
+.venv/bin/python manage.py makemigrations omop_core --name group_access
+```
+
+Expected: creates `omop_core/migrations/0095_group_access.py`.
+
+- [ ] **Step 3: Edit the generated migration to rename the table instead of drop/create**
+
+Open the generated migration. Replace the `CreateModel` / `DeleteModel` operations with a `RenameModel` + `AddField` + `AlterField` + `AddConstraint` / `RemoveConstraint` sequence. The migration must preserve existing rows. Use this operations list:
+
+```python
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+from django.db.models import Q
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('omop_core', '0094_concept_name_trigram_index'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # 1. Rename the model (renames the table professional_group_access → group_access)
+        migrations.RenameModel(
+            old_name='ProfessionalGroupAccess',
+            new_name='GroupAccess',
+        ),
+        # 2. Make group nullable (was non-nullable)
+        migrations.AlterField(
+            model_name='groupaccess',
+            name='group',
+            field=models.ForeignKey(
+                blank=True, null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='access_grants',
+                to='omop_core.patientgroup',
+            ),
+        ),
+        # 3. Add org FK
+        migrations.AddField(
+            model_name='groupaccess',
+            name='org',
+            field=models.ForeignKey(
+                blank=True, null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='access_grants',
+                to='omop_core.organization',
+            ),
+        ),
+        # 4. Replace old unique constraint with the two partial ones + check constraint
+        migrations.RemoveConstraint(
+            model_name='groupaccess',
+            name='uq_identity_group',
+        ),
+        migrations.AddConstraint(
+            model_name='groupaccess',
+            constraint=models.CheckConstraint(
+                check=(
+                    Q(org__isnull=False, group__isnull=True) |
+                    Q(org__isnull=True, group__isnull=False)
+                ),
+                name='group_access_org_xor_group',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='groupaccess',
+            constraint=models.UniqueConstraint(
+                fields=['identity', 'group'],
+                condition=Q(group__isnull=False),
+                name='uq_identity_group',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='groupaccess',
+            constraint=models.UniqueConstraint(
+                fields=['identity', 'org'],
+                condition=Q(org__isnull=False),
+                name='uq_identity_org',
+            ),
+        ),
+        # 5. Update role choices (Python-only, no DB op needed — AlterField for state)
+        migrations.AlterField(
+            model_name='groupaccess',
+            name='role',
+            field=models.CharField(
+                choices=[
+                    ('org_admin', 'Org Admin'),
+                    ('doctor', 'Doctor'),
+                    ('navigator', 'Navigator'),
+                ],
+                max_length=20,
+            ),
+        ),
+    ]
+```
+
+- [ ] **Step 4: Apply the migration to local test DB**
+
+```bash
+DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" \
+  .venv/bin/python manage.py migrate omop_core
+```
+
+Expected: `OK` — no errors.
+
+- [ ] **Step 5: Update all references to `ProfessionalGroupAccess` in non-migration files**
+
+In each file, replace `ProfessionalGroupAccess` → `GroupAccess`:
+
+- `omop_core/authorization.py` line 15: `from omop_core.models import ... ProfessionalGroupAccess ...` → `GroupAccess`; line 43 and 79: variable names using the old class
+- `patient_portal/api/views.py` line 158: import; lines 174+ usage
+- `patient_portal/api/lab_results/views.py`: import
+- `patient_portal/api/lab_results/tests.py`: import + class name `ProfessionalGroupAccessTest` → `GroupAccessTest`
+- `patient_portal/tests.py` line 1564: comment only — update for clarity
+
+Run a grep to catch any remaining references:
+
+```bash
+grep -rn "ProfessionalGroupAccess" . --include="*.py" | grep -v migrations | grep -v ".pyc"
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Run the full backend test suite**
+
+```bash
+DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" \
+  .venv/bin/python manage.py test omop_core patient_portal --verbosity=2 --noinput
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add omop_core/models.py omop_core/migrations/0095_group_access.py \
+        omop_core/authorization.py patient_portal/api/views.py \
+        patient_portal/api/lab_results/views.py \
+        patient_portal/api/lab_results/tests.py patient_portal/tests.py
+git commit -m "refactor: rename ProfessionalGroupAccess → GroupAccess, add org FK and org_admin role"
+```
+
+---
+
+## Task 2: `get_visible_orgs` access helper
+
+**Files:**
+- Create: `omop_core/services/access.py`
+- Modify: `omop_core/tests.py`
+
+- [ ] **Step 1: Write the failing tests in `omop_core/tests.py`**
+
+Add at the bottom of `omop_core/tests.py`:
+
+```python
+from django.test import TestCase
+from django.utils import timezone
+from datetime import timedelta
+from omop_core.models import Organization, PatientGroup, GroupAccess
+from omop_core.services.access import get_visible_orgs
+from patient_portal.models import Identity
+
+
+class GetVisibleOrgsTest(TestCase):
+    def setUp(self):
+        self.org_a = Organization.objects.create(name='Org A', slug='org-a')
+        self.org_b = Organization.objects.create(name='Org B', slug='org-b')
+        self.group_a = PatientGroup.objects.create(
+            organization=self.org_a, name='Group A', slug='group-a'
+        )
+        self.staff_user = Identity.objects.create_user(
+            email='staff@test.com', password='x', is_staff=True
+        )
+        self.org_admin = Identity.objects.create_user(
+            email='orgadmin@test.com', password='x'
+        )
+        self.doctor = Identity.objects.create_user(
+            email='doctor@test.com', password='x'
+        )
+        self.nobody = Identity.objects.create_user(
+            email='nobody@test.com', password='x'
+        )
+        GroupAccess.objects.create(
+            identity=self.org_admin, org=self.org_a, role='org_admin'
+        )
+        GroupAccess.objects.create(
+            identity=self.doctor, group=self.group_a, role='doctor'
+        )
+
+    def test_staff_sees_all_orgs(self):
+        orgs = get_visible_orgs(self.staff_user)
+        self.assertIn(self.org_a, orgs)
+        self.assertIn(self.org_b, orgs)
+
+    def test_org_admin_sees_their_org_only(self):
+        orgs = list(get_visible_orgs(self.org_admin))
+        self.assertIn(self.org_a, orgs)
+        self.assertNotIn(self.org_b, orgs)
+
+    def test_doctor_sees_org_of_their_group(self):
+        orgs = list(get_visible_orgs(self.doctor))
+        self.assertIn(self.org_a, orgs)
+        self.assertNotIn(self.org_b, orgs)
+
+    def test_user_with_no_grants_sees_nothing(self):
+        orgs = list(get_visible_orgs(self.nobody))
+        self.assertEqual(orgs, [])
+
+    def test_expired_grant_excluded(self):
+        expired = Identity.objects.create_user(email='expired@test.com', password='x')
+        GroupAccess.objects.create(
+            identity=expired, org=self.org_a, role='org_admin',
+            expires_at=timezone.now() - timedelta(hours=1),
+        )
+        orgs = list(get_visible_orgs(expired))
+        self.assertEqual(orgs, [])
+
+    def test_active_grant_with_future_expiry_included(self):
+        future = Identity.objects.create_user(email='future@test.com', password='x')
+        GroupAccess.objects.create(
+            identity=future, org=self.org_b, role='org_admin',
+            expires_at=timezone.now() + timedelta(days=30),
+        )
+        orgs = list(get_visible_orgs(future))
+        self.assertIn(self.org_b, orgs)
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" \
+  .venv/bin/python manage.py test omop_core.tests.GetVisibleOrgsTest --verbosity=2 --noinput
+```
+
+Expected: `ImportError: cannot import name 'get_visible_orgs'`
+
+- [ ] **Step 3: Create `omop_core/services/access.py`**
+
+```python
+from django.db.models import Q, QuerySet
+from django.utils import timezone
+
+from omop_core.models import GroupAccess, Organization
+
+
+def get_visible_orgs(user) -> QuerySet:
+    """Return the orgs whose patients the user is allowed to see.
+
+    - is_staff → all orgs
+    - org_admin grant → their org(s)
+    - doctor/navigator grant → the org of each assigned group
+    - no grants → empty queryset
+    """
+    if getattr(user, 'is_staff', False):
+        return Organization.objects.all()
+
+    now = timezone.now()
+    active = GroupAccess.objects.filter(
+        identity=user,
+    ).filter(
+        Q(expires_at__isnull=True) | Q(expires_at__gt=now)
+    )
+
+    org_ids = set(
+        active.filter(role='org_admin')
+              .values_list('org_id', flat=True)
+    )
+    group_org_ids = set(
+        active.exclude(role='org_admin')
+              .values_list('group__organization_id', flat=True)
+    )
+    all_ids = org_ids | group_org_ids
+
+    if not all_ids:
+        return Organization.objects.none()
+
+    return Organization.objects.filter(id__in=all_ids)
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" \
+  .venv/bin/python manage.py test omop_core.tests.GetVisibleOrgsTest --verbosity=2 --noinput
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omop_core/services/access.py omop_core/tests.py
+git commit -m "feat: add get_visible_orgs access helper and tests"
+```
+
+---
+
+## Task 3: Stats API endpoint
+
+**Files:**
+- Modify: `patient_portal/api/views.py`
+- Modify: `patient_portal/api/serializers.py`
+- Modify: `patient_portal/api/urls.py`
+- Modify: `patient_portal/tests.py`
+
+- [ ] **Step 1: Write the failing tests in `patient_portal/tests.py`**
+
+Add a new test class at the bottom of `patient_portal/tests.py`:
+
+```python
+from omop_core.models import Organization, PatientGroup, GroupAccess, PatientInfo, Person
+from patient_portal.models import Identity
+from rest_framework.test import APIClient
+from rest_framework import status
+
+
+class OrgDiseaseStatsTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.org_a = Organization.objects.create(name='Org A', slug='org-a')
+        self.org_b = Organization.objects.create(name='Org B', slug='org-b')
+        self.group_a = PatientGroup.objects.create(
+            organization=self.org_a, name='Group A', slug='group-a'
+        )
+
+        # Create patients
+        for i, slug in enumerate(['mm', 'mm', 'breast-cancer'], start=1):
+            p = Person.objects.create(person_id=9000 + i)
+            PatientInfo.objects.create(person=p, organization=self.org_a, disease_slug=slug)
+
+        p4 = Person.objects.create(person_id=9004)
+        PatientInfo.objects.create(person=p4, organization=self.org_b, disease_slug='cll')
+
+        self.staff = Identity.objects.create_user(email='staff@t.com', password='x', is_staff=True)
+        self.org_admin = Identity.objects.create_user(email='admin@t.com', password='x')
+        self.doctor = Identity.objects.create_user(email='doc@t.com', password='x')
+        self.nobody = Identity.objects.create_user(email='none@t.com', password='x')
+
+        GroupAccess.objects.create(identity=self.org_admin, org=self.org_a, role='org_admin')
+        GroupAccess.objects.create(identity=self.doctor, group=self.group_a, role='doctor')
+
+    def _get(self, user):
+        self.client.force_authenticate(user=user)
+        return self.client.get('/api/stats/org-disease/')
+
+    def test_staff_sees_all_orgs(self):
+        resp = self._get(self.staff)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        slugs = {o['org_slug'] for o in resp.data}
+        self.assertIn('org-a', slugs)
+        self.assertIn('org-b', slugs)
+
+    def test_staff_disease_counts_correct(self):
+        resp = self._get(self.staff)
+        org_a_data = next(o for o in resp.data if o['org_slug'] == 'org-a')
+        self.assertEqual(org_a_data['total'], 3)
+        counts = {d['disease_slug']: d['count'] for d in org_a_data['disease_counts']}
+        self.assertEqual(counts['mm'], 2)
+        self.assertEqual(counts['breast-cancer'], 1)
+
+    def test_org_admin_sees_only_their_org(self):
+        resp = self._get(self.org_admin)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        slugs = {o['org_slug'] for o in resp.data}
+        self.assertIn('org-a', slugs)
+        self.assertNotIn('org-b', slugs)
+
+    def test_doctor_sees_their_group_org(self):
+        resp = self._get(self.doctor)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        slugs = {o['org_slug'] for o in resp.data}
+        self.assertIn('org-a', slugs)
+
+    def test_no_grants_returns_empty_list(self):
+        resp = self._get(self.nobody)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data, [])
+
+    def test_unauthenticated_returns_401(self):
+        self.client.logout()
+        resp = self.client.get('/api/stats/org-disease/')
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_response_shape(self):
+        resp = self._get(self.org_admin)
+        org = resp.data[0]
+        self.assertIn('org_slug', org)
+        self.assertIn('org_name', org)
+        self.assertIn('total', org)
+        self.assertIn('disease_counts', org)
+        if org['disease_counts']:
+            dc = org['disease_counts'][0]
+            self.assertIn('disease_slug', dc)
+            self.assertIn('label', dc)
+            self.assertIn('count', dc)
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" \
+  .venv/bin/python manage.py test patient_portal.tests.OrgDiseaseStatsTest --verbosity=2 --noinput
+```
+
+Expected: `404 Not Found` (URL doesn't exist yet).
+
+- [ ] **Step 3: Add `is_staff` to `UserSerializer` in `patient_portal/api/serializers.py`**
+
+Change:
+```python
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Identity
+        fields = ['id', 'sub', 'email', 'name']
+```
+
+To:
+```python
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Identity
+        fields = ['id', 'sub', 'email', 'name', 'is_staff']
+```
+
+- [ ] **Step 4: Add the `org_disease_stats` view to `patient_portal/api/views.py`**
+
+Add this import near the top of views.py (alongside other service imports):
+
+```python
+from omop_core.services.access import get_visible_orgs
+```
+
+Add the view function — a good place is just before the `auth_test` function near the bottom of the file:
+
+```python
+# Disease label lookup — human-readable names for known disease slugs.
+_DISEASE_LABELS = {
+    'mm':                    'Multiple Myeloma',
+    'MM':                    'Multiple Myeloma',
+    'er-erbb2-breast-cancer': 'ER+/HER2+ Breast Cancer',
+    'breast-cancer':          'Breast Cancer',
+    'follicular-lymphoma':    'Follicular Lymphoma',
+    'cll':                    'Chronic Lymphocytic Leukemia',
+    'lung-cancer':            'Lung Cancer',
+    'colon-cancer':           'Colon Cancer',
+}
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def org_disease_stats(request):
+    """GET /api/stats/org-disease/ — per-org disease patient counts for the requesting user."""
+    from django.db.models import Count
+
+    orgs = get_visible_orgs(request.user)
+    result = []
+    for org in orgs.order_by('name'):
+        rows = (
+            PatientInfo.objects
+            .filter(organization=org)
+            .values('disease_slug')
+            .annotate(count=Count('id'))
+            .order_by('-count')
+        )
+        disease_counts = [
+            {
+                'disease_slug': r['disease_slug'] or '',
+                'label': _DISEASE_LABELS.get(r['disease_slug'] or '', r['disease_slug'] or 'Unknown'),
+                'count': r['count'],
+            }
+            for r in rows
+        ]
+        result.append({
+            'org_slug': org.slug,
+            'org_name': org.name,
+            'total': sum(d['count'] for d in disease_counts),
+            'disease_counts': disease_counts,
+        })
+    return Response(result)
+```
+
+- [ ] **Step 5: Register the URL in `patient_portal/api/urls.py`**
+
+Add alongside the other `path(...)` entries in `urlpatterns`:
+
+```python
+from patient_portal.api.views import org_disease_stats
+
+# inside urlpatterns:
+path('stats/org-disease/', org_disease_stats, name='stats-org-disease'),
+```
+
+- [ ] **Step 6: Run tests to confirm they pass**
+
+```bash
+DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" \
+  .venv/bin/python manage.py test patient_portal.tests.OrgDiseaseStatsTest --verbosity=2 --noinput
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 7: Run full backend suite**
+
+```bash
+DATABASE_URL="postgresql://postgres@localhost:5432/ctomop_test" \
+  .venv/bin/python manage.py test omop_core patient_portal --verbosity=2 --noinput
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add patient_portal/api/views.py patient_portal/api/serializers.py \
+        patient_portal/api/urls.py patient_portal/tests.py
+git commit -m "feat: add /api/stats/org-disease/ endpoint with role-based org scoping"
+```
+
+---
+
+## Task 4: Frontend — StatsPage component
+
+**Files:**
+- Create: `frontend/src/components/Stats/StatsPage.tsx`
+- Create: `frontend/src/components/Stats/StatsPage.test.tsx`
+- Modify: `frontend/src/types/patient.ts`
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/Patient/PatientList.tsx`
+
+- [ ] **Step 1: Add `is_staff` to the `User` interface in `frontend/src/types/patient.ts`**
+
+The file currently starts with:
+```typescript
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+}
+```
+
+Change to:
+```typescript
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  is_staff?: boolean;
+}
+```
+
+- [ ] **Step 2: Write the failing frontend tests in `frontend/src/components/Stats/StatsPage.test.tsx`**
+
+```typescript
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import StatsPage from './StatsPage';
+
+vi.mock('@/api/axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import api from '@/api/axios';
+
+const mockData = [
+  {
+    org_slug: 'abc-foundation',
+    org_name: 'ABC Foundation',
+    total: 5,
+    disease_counts: [
+      { disease_slug: 'mm', label: 'Multiple Myeloma', count: 3 },
+      { disease_slug: 'breast-cancer', label: 'Breast Cancer', count: 2 },
+    ],
+  },
+];
+
+describe('StatsPage', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders org cards with disease counts', async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: mockData });
+    render(<StatsPage />);
+    await waitFor(() => expect(screen.getByText('ABC Foundation')).toBeInTheDocument());
+    expect(screen.getByText('Multiple Myeloma')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Breast Cancer')).toBeInTheDocument();
+  });
+
+  it('shows empty state when response is empty', async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] });
+    render(<StatsPage />);
+    await waitFor(() =>
+      expect(screen.getByText('No patient data available for your account.')).toBeInTheDocument()
+    );
+  });
+
+  it('shows loading state before response resolves', () => {
+    (api.get as ReturnType<typeof vi.fn>).mockReturnValueOnce(new Promise(() => {}));
+    render(<StatsPage />);
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run to confirm tests fail**
+
+```bash
+cd frontend && npm test -- --run 2>&1 | grep -E "FAIL|cannot find|StatsPage"
+```
+
+Expected: errors about missing `StatsPage` module.
+
+- [ ] **Step 4: Create `frontend/src/components/Stats/StatsPage.tsx`**
+
+```typescript
+import React, { useEffect, useState } from 'react';
+import api from '@/api/axios';
+
+interface DiseaseCount {
+  disease_slug: string;
+  label: string;
+  count: number;
+}
+
+interface OrgStats {
+  org_slug: string;
+  org_name: string;
+  total: number;
+  disease_counts: DiseaseCount[];
+}
+
+export default function StatsPage() {
+  const [data, setData] = useState<OrgStats[] | null>(null);
+
+  useEffect(() => {
+    api.get<OrgStats[]>('/api/stats/org-disease/').then(r => setData(r.data));
+  }, []);
+
+  if (data === null) {
+    return (
+      <div className="p-8 text-center text-gray-500">Loading…</div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="p-8 text-center text-gray-500">
+        No patient data available for your account.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Patient Summary by Organization</h1>
+      {data.map(org => (
+        <div key={org.org_slug} className="bg-white rounded-lg border border-gray-200 shadow-sm">
+          <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+            <h2 className="text-lg font-medium text-gray-900">{org.org_name}</h2>
+            <span className="text-sm text-gray-500">{org.total} patients</span>
+          </div>
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-6 py-2 font-medium text-gray-600">Disease</th>
+                <th className="text-right px-6 py-2 font-medium text-gray-600">Patients</th>
+              </tr>
+            </thead>
+            <tbody>
+              {org.disease_counts.map(dc => (
+                <tr key={dc.disease_slug} className="border-t border-gray-100">
+                  <td className="px-6 py-2 text-gray-800">{dc.label}</td>
+                  <td className="px-6 py-2 text-right text-gray-800">{dc.count}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t border-gray-200 bg-gray-50">
+                <td className="px-6 py-2 font-medium text-gray-700">Total</td>
+                <td className="px-6 py-2 text-right font-medium text-gray-700">{org.total}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run frontend tests to confirm they pass**
+
+```bash
+cd frontend && npm test -- --run
+```
+
+Expected: `StatsPage` tests pass.
+
+- [ ] **Step 6: Add `/stats` route to `frontend/src/App.tsx`**
+
+Add the import at the top alongside other page imports:
+
+```typescript
+import StatsPage from "@/components/Stats/StatsPage";
+```
+
+Add the route inside `<Routes>` before the catch-all `*` route:
+
+```typescript
+<Route
+  path="/stats"
+  element={
+    currentUser ? <StatsPage /> : <Navigate to="/login" replace />
+  }
+/>
+```
+
+- [ ] **Step 7: Add a Stats nav link to `frontend/src/components/Patient/PatientList.tsx`**
+
+Find the button row that has "Upload CSV" and "Upload FHIR". Add a Stats link before them (using `useNavigate` or a plain `<a>`). The file already imports from `react-router-dom`; add `useNavigate` if not already imported.
+
+Find the section with upload buttons and add:
+
+```typescript
+import { useNavigate } from 'react-router-dom';
+
+// inside the component:
+const navigate = useNavigate();
+
+// in the JSX, before the Upload buttons:
+<button
+  onClick={() => navigate('/stats')}
+  className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded hover:bg-gray-50"
+>
+  Stats
+</button>
+```
+
+- [ ] **Step 8: Run full frontend test suite**
+
+```bash
+cd frontend && npm test -- --run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Type-check and build**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: no TypeScript errors, build succeeds.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/types/patient.ts \
+        frontend/src/components/Stats/ \
+        frontend/src/App.tsx \
+        frontend/src/components/Patient/PatientList.tsx
+git commit -m "feat: add StatsPage with per-org disease count breakdown"
+```
+
+---
+
+## Task 5: Apply migration to staging DB
+
+- [ ] **Step 1: Apply migration to staging**
+
+```bash
+source .env
+DATABASE_URL="$STAGING_DATABASE_URL" .venv/bin/python manage.py migrate omop_core
+```
+
+Expected: migration 0095 applied cleanly.
+
+- [ ] **Step 2: Verify DB/model in sync on staging**
+
+```bash
+DATABASE_URL="$STAGING_DATABASE_URL" \
+  .venv/bin/python manage.py shell -c "
+from django.db import connection
+cursor = connection.cursor()
+cursor.execute(\"SELECT column_name FROM information_schema.columns WHERE table_name='group_access' ORDER BY column_name\")
+print([r[0] for r in cursor.fetchall()])
+"
+```
+
+Expected: list includes `group_id`, `org_id`, `role`, `expires_at`, `identity_id`, `granted_at`, `granted_by_id`.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feature/org-disease-stats
+```

--- a/docs/superpowers/specs/2026-06-20-org-disease-stats-design.md
+++ b/docs/superpowers/specs/2026-06-20-org-disease-stats-design.md
@@ -1,0 +1,219 @@
+# Org Disease Stats — Design Spec
+
+**Date:** 2026-06-20
+**Branch:** feature/org-disease-stats
+**Status:** Draft
+
+---
+
+## Problem
+
+There is no way for a logged-in user to see a summary of the patients they have access to. Admins and clinicians need a quick per-org breakdown of disease counts without duplicating the full analytics available in `~/analytics`.
+
+Additionally, the existing `ProfessionalGroupAccess` model only supports group-scoped roles (`doctor`, `navigator`). There is no role that grants access to an entire org's patient population without needing to enumerate every group within it.
+
+---
+
+## Roles
+
+### Existing: `Identity.is_staff` — global access
+
+No changes. Staff users already bypass org scoping in `get_request_org` and `ScopedTokenPermission`. The stats endpoint will treat `is_staff=True` as "see all orgs."
+
+### New: `org_admin` via renamed `GroupAccess` model
+
+**Rename `ProfessionalGroupAccess` → `GroupAccess`** (table: `professional_group_access` → `group_access`).
+
+Updated `ROLE_CHOICES`:
+
+| Role | Scope field | Access |
+|---|---|---|
+| `org_admin` | `org` (non-null), `group` (null) | All patients in one org |
+| `doctor` | `group` (non-null), `org` (null) | Patients in assigned group |
+| `navigator` | `group` (non-null), `org` (null) | Patients in assigned group |
+
+`doctor` and `navigator` have identical access for now — the distinction is label-only.
+
+### DB constraint
+
+A `CheckConstraint` enforces that exactly one of `org` or `group` is set:
+
+```python
+models.CheckConstraint(
+    check=(
+        Q(org__isnull=False, group__isnull=True) |
+        Q(org__isnull=True, group__isnull=False)
+    ),
+    name='group_access_org_xor_group',
+)
+```
+
+The unique constraint is updated to cover both cases:
+- `UniqueConstraint(fields=['identity', 'group'], condition=Q(group__isnull=False), name='uq_identity_group')`
+- `UniqueConstraint(fields=['identity', 'org'], condition=Q(org__isnull=False), name='uq_identity_org')`
+
+---
+
+## Backend
+
+### Model changes (`omop_core/models.py`)
+
+```python
+class GroupAccess(models.Model):
+    ROLE_CHOICES = [
+        ('org_admin', 'Org Admin'),
+        ('doctor',    'Doctor'),
+        ('navigator', 'Navigator'),
+    ]
+    identity   = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='group_access_grants')
+    org        = models.ForeignKey(Organization, on_delete=models.CASCADE, null=True, blank=True, related_name='access_grants')
+    group      = models.ForeignKey(PatientGroup,  on_delete=models.CASCADE, null=True, blank=True, related_name='access_grants')
+    role       = models.CharField(max_length=20, choices=ROLE_CHOICES)
+    expires_at = models.DateTimeField(null=True, blank=True)
+    granted_at = models.DateTimeField(auto_now_add=True)
+    granted_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True, related_name='+')
+
+    class Meta:
+        db_table = 'group_access'
+        constraints = [
+            models.CheckConstraint(
+                check=Q(org__isnull=False, group__isnull=True) | Q(org__isnull=True, group__isnull=False),
+                name='group_access_org_xor_group',
+            ),
+            models.UniqueConstraint(fields=['identity', 'group'], condition=Q(group__isnull=False), name='uq_identity_group'),
+            models.UniqueConstraint(fields=['identity', 'org'],   condition=Q(org__isnull=False),  name='uq_identity_org'),
+        ]
+```
+
+### Migration
+
+Single migration: rename table, add `org` FK, add `CheckConstraint`, update unique constraints, add `org_admin` to choices (choices are Python-only — no DB change needed for that).
+
+The existing `uq_identity_group` constraint is replaced; data migration is a no-op since all existing rows have `group` set (the old non-nullable FK) and `org=null`.
+
+### Stats endpoint
+
+**`GET /api/stats/org-disease/`**
+
+Returns a list of orgs the requesting user can see, each with a `disease_counts` dict.
+
+**Access logic** (in `patient_portal/api/views.py` or a new `stats.py`):
+
+```
+if user.is_staff:
+    orgs = Organization.objects.all()
+elif user has org_admin GroupAccess rows:
+    orgs = orgs from those rows (non-expired)
+elif user has doctor/navigator GroupAccess rows:
+    orgs = orgs of the PatientGroups in those rows (non-expired)
+else:
+    return []
+```
+
+For each org, query:
+
+```python
+PatientInfo.objects
+    .filter(organization=org)
+    .values('disease_slug')
+    .annotate(count=Count('id'))
+    .order_by('-count')
+```
+
+**Response shape:**
+
+```json
+[
+  {
+    "org_slug": "abc-foundation",
+    "org_name": "ABC Foundation",
+    "total": 123,
+    "disease_counts": [
+      {"disease_slug": "er-erbb2-breast-cancer", "label": "ER+/HER2+ Breast Cancer", "count": 123}
+    ]
+  }
+]
+```
+
+`label` is a human-readable mapping from `disease_slug` (derived in the view; falls back to the slug if unmapped).
+
+**Auth:** Session auth or OAuth token. No org scoping via `get_request_org` — the endpoint has its own access logic above.
+
+**URL:** `path('stats/org-disease/', org_disease_stats, name='stats-org-disease')` in `patient_portal/api/urls.py`.
+
+---
+
+## Frontend
+
+### Route
+
+`/stats` added to `App.tsx`, protected by `currentUser` check (same pattern as existing routes).
+
+### `StatsPage` component (`frontend/src/components/Stats/StatsPage.tsx`)
+
+- Fetches `GET /api/stats/org-disease/` on mount via axios
+- Renders one card per org
+- Each card: org name as heading, table of disease label + count, total at the bottom
+- Empty state: "No patient data available for your account"
+- Loading state: skeleton or spinner
+
+### Nav link
+
+Add a "Stats" link to the top nav in `PatientList.tsx` (where Upload CSV / Upload FHIR buttons live), visible to all logged-in users. If the endpoint returns an empty list, the page shows the empty state gracefully.
+
+### `User` type update
+
+The `User` interface in `frontend/src/types/patient.ts` gains `is_staff?: boolean` so the frontend can conditionally show/hide admin-only UI in the future. The `/api/auth/test/` or equivalent endpoint must return `is_staff` — check and add if missing.
+
+---
+
+## Access logic helper
+
+Extract into `omop_core/services/access.py`:
+
+```python
+def get_visible_orgs(user) -> QuerySet[Organization]:
+    """Return the orgs whose patients the user can see."""
+    if user.is_staff:
+        return Organization.objects.all()
+    now = timezone.now()
+    active = GroupAccess.objects.filter(
+        identity=user,
+    ).filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
+    org_ids = set(active.filter(role='org_admin').values_list('org_id', flat=True))
+    group_org_ids = set(
+        active.exclude(role='org_admin')
+              .values_list('group__organization_id', flat=True)
+    )
+    return Organization.objects.filter(id__in=org_ids | group_org_ids)
+```
+
+The stats endpoint calls `get_visible_orgs(request.user)` rather than inlining the logic.
+
+---
+
+## Testing
+
+### Backend (`patient_portal/tests.py`)
+
+- Staff user sees all orgs in the response
+- `org_admin` user sees only their org
+- `doctor`/`navigator` user sees the org of their assigned group
+- User with no `GroupAccess` rows gets an empty list
+- Expired `GroupAccess` rows are excluded
+- `CheckConstraint` prevents a row with both `org` and `group` set (DB-level test)
+
+### Frontend (`StatsPage.test.tsx`)
+
+- Renders org cards from mocked API response
+- Shows empty state when response is `[]`
+- Shows loading state before response resolves
+
+---
+
+## Out of scope
+
+- Editing `GroupAccess` rows via the UI (admin-only, managed via Django admin or management command for now)
+- Per-group breakdown within an org
+- Filtering/sorting on the stats page
+- `~/analytics` feature parity

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import PatientList from "@/components/Patient/PatientList";
 import PatientDetail from "@/components/Patient/PatientDetail";
 import UploadFHIR from "@/components/Patient/UploadFHIR";
 import UploadCSV from "@/components/Patient/UploadCSV";
+import StatsPage from "@/components/Stats/StatsPage";
 import { useAuth } from "@/hooks/useAuth";
 
 function AppRoutes() {
@@ -60,6 +61,12 @@ function AppRoutes() {
         path="/upload-csv"
         element={
           currentUser ? <UploadCSV /> : <Navigate to="/login" replace />
+        }
+      />
+      <Route
+        path="/stats"
+        element={
+          currentUser ? <StatsPage /> : <Navigate to="/login" replace />
         }
       />
 

--- a/frontend/src/components/Patient/PatientList.tsx
+++ b/frontend/src/components/Patient/PatientList.tsx
@@ -113,6 +113,12 @@ export default function PatientList() {
             </button>
           )}
           <button
+            onClick={() => navigate("/stats")}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded hover:bg-gray-50"
+          >
+            Stats
+          </button>
+          <button
             onClick={() => navigate("/upload-csv")}
             className="inline-flex items-center gap-2 rounded-md border border-input px-4 py-2 text-sm font-medium text-foreground hover:bg-accent"
           >

--- a/frontend/src/components/Stats/StatsPage.test.tsx
+++ b/frontend/src/components/Stats/StatsPage.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import StatsPage from './StatsPage';
+
+vi.mock('@/api/axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import api from '@/api/axios';
+
+const mockData = [
+  {
+    org_slug: 'abc-foundation',
+    org_name: 'ABC Foundation',
+    total: 5,
+    disease_counts: [
+      { disease_slug: 'mm', label: 'Multiple Myeloma', count: 3 },
+      { disease_slug: 'breast-cancer', label: 'Breast Cancer', count: 2 },
+    ],
+  },
+];
+
+describe('StatsPage', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders org cards with disease counts', async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: mockData });
+    render(<StatsPage />);
+    await waitFor(() => expect(screen.getByText('ABC Foundation')).toBeInTheDocument());
+    expect(screen.getByText('Multiple Myeloma')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Breast Cancer')).toBeInTheDocument();
+  });
+
+  it('shows empty state when response is empty', async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] });
+    render(<StatsPage />);
+    await waitFor(() =>
+      expect(screen.getByText('No patient data available for your account.')).toBeInTheDocument()
+    );
+  });
+
+  it('shows loading state before response resolves', () => {
+    (api.get as ReturnType<typeof vi.fn>).mockReturnValueOnce(new Promise(() => {}));
+    render(<StatsPage />);
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Stats/StatsPage.tsx
+++ b/frontend/src/components/Stats/StatsPage.tsx
@@ -16,10 +16,19 @@ interface OrgStats {
 
 export default function StatsPage() {
   const [data, setData] = useState<OrgStats[] | null>(null);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
-    api.get<OrgStats[]>('/api/stats/org-disease/').then(r => setData(r.data));
+    api.get<OrgStats[]>('/api/stats/org-disease/')
+      .then(r => setData(r.data))
+      .catch(() => setError(true));
   }, []);
+
+  if (error) {
+    return (
+      <div className="p-8 text-center text-red-500">Failed to load stats. Please try again.</div>
+    );
+  }
 
   if (data === null) {
     return (

--- a/frontend/src/components/Stats/StatsPage.tsx
+++ b/frontend/src/components/Stats/StatsPage.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import api from '@/api/axios';
+
+interface DiseaseCount {
+  disease_slug: string;
+  label: string;
+  count: number;
+}
+
+interface OrgStats {
+  org_slug: string;
+  org_name: string;
+  total: number;
+  disease_counts: DiseaseCount[];
+}
+
+export default function StatsPage() {
+  const [data, setData] = useState<OrgStats[] | null>(null);
+
+  useEffect(() => {
+    api.get<OrgStats[]>('/api/stats/org-disease/').then(r => setData(r.data));
+  }, []);
+
+  if (data === null) {
+    return (
+      <div className="p-8 text-center text-gray-500">Loading…</div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="p-8 text-center text-gray-500">
+        No patient data available for your account.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Patient Summary by Organization</h1>
+      {data.map(org => (
+        <div key={org.org_slug} className="bg-white rounded-lg border border-gray-200 shadow-sm">
+          <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+            <h2 className="text-lg font-medium text-gray-900">{org.org_name}</h2>
+            <span className="text-sm text-gray-500">{org.total} patients</span>
+          </div>
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-6 py-2 font-medium text-gray-600">Disease</th>
+                <th className="text-right px-6 py-2 font-medium text-gray-600">Patients</th>
+              </tr>
+            </thead>
+            <tbody>
+              {org.disease_counts.map(dc => (
+                <tr key={dc.disease_slug} className="border-t border-gray-100">
+                  <td className="px-6 py-2 text-gray-800">{dc.label}</td>
+                  <td className="px-6 py-2 text-right text-gray-800">{dc.count}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t border-gray-200 bg-gray-50">
+                <td className="px-6 py-2 font-medium text-gray-700">Total</td>
+                <td className="px-6 py-2 text-right font-medium text-gray-700">{org.total}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/types/patient.ts
+++ b/frontend/src/types/patient.ts
@@ -4,6 +4,7 @@ export interface User {
   email: string;
   first_name: string;
   last_name: string;
+  is_staff?: boolean;
 }
 
 export interface PatientInfo {

--- a/omop_core/authorization.py
+++ b/omop_core/authorization.py
@@ -4,15 +4,15 @@ Authorization helpers for patient data access.
 Three access paths checked in order:
 1. Self-access (Identity → PatientUser → person_id matches target)
 2. Personal representative (Identity → PersonalRepresentative → person_id, verified only)
-3. Professional group access (Identity → ProfessionalGroupAccess → group ∩ patient's groups, non-expired)
+3. Professional group access (Identity → GroupAccess → group ∩ patient's groups, non-expired)
 """
 from django.db import models
 from django.utils import timezone
 
 from .models import (
+    GroupAccess,
     PatientGroupMembership,
     PersonalRepresentative,
-    ProfessionalGroupAccess,
 )
 
 
@@ -40,7 +40,7 @@ def can_access_patient(actor_identity, target_person_id: int) -> bool:
 
     # 3. Professional group access (non-expired)
     now = timezone.now()
-    actor_groups = ProfessionalGroupAccess.objects.filter(
+    actor_groups = GroupAccess.objects.filter(
         identity=actor_identity,
     ).filter(
         models.Q(expires_at__isnull=True) | models.Q(expires_at__gt=now),
@@ -76,7 +76,7 @@ def get_actor_role(actor_identity, target_person_id: int) -> str | None:
         return 'representative'
 
     now = timezone.now()
-    grant = ProfessionalGroupAccess.objects.filter(
+    grant = GroupAccess.objects.filter(
         identity=actor_identity,
         group__memberships__person_id=target_person_id,
     ).filter(

--- a/omop_core/migrations/0095_group_access.py
+++ b/omop_core/migrations/0095_group_access.py
@@ -1,0 +1,91 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('omop_core', '0094_concept_name_trigram_index'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # 1. Rename the model (renames the table professional_group_access → group_access)
+        migrations.RenameModel(
+            old_name='ProfessionalGroupAccess',
+            new_name='GroupAccess',
+        ),
+        # 2. Make group nullable (was non-nullable)
+        migrations.AlterField(
+            model_name='groupaccess',
+            name='group',
+            field=models.ForeignKey(
+                blank=True, null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='access_grants',
+                to='omop_core.patientgroup',
+            ),
+        ),
+        # 3. Add org FK
+        migrations.AddField(
+            model_name='groupaccess',
+            name='org',
+            field=models.ForeignKey(
+                blank=True, null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='access_grants',
+                to='omop_core.organization',
+            ),
+        ),
+        # 4. Replace old unique constraint with partial ones + check constraint
+        migrations.RemoveConstraint(
+            model_name='groupaccess',
+            name='uq_identity_group',
+        ),
+        migrations.AddConstraint(
+            model_name='groupaccess',
+            constraint=models.CheckConstraint(
+                check=(
+                    Q(org__isnull=False, group__isnull=True) |
+                    Q(org__isnull=True, group__isnull=False)
+                ),
+                name='group_access_org_xor_group',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='groupaccess',
+            constraint=models.UniqueConstraint(
+                fields=['identity', 'group'],
+                condition=Q(group__isnull=False),
+                name='uq_identity_group',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='groupaccess',
+            constraint=models.UniqueConstraint(
+                fields=['identity', 'org'],
+                condition=Q(org__isnull=False),
+                name='uq_identity_org',
+            ),
+        ),
+        # 5. Update role choices (Python state only — no DB op needed)
+        migrations.AlterField(
+            model_name='groupaccess',
+            name='role',
+            field=models.CharField(
+                choices=[
+                    ('org_admin', 'Org Admin'),
+                    ('doctor', 'Doctor'),
+                    ('navigator', 'Navigator'),
+                ],
+                max_length=20,
+            ),
+        ),
+        # 6. Update db_table (RenameModel auto-renames but we need to set the explicit Meta)
+        migrations.AlterModelTable(
+            name='groupaccess',
+            table='group_access',
+        ),
+    ]

--- a/omop_core/models.py
+++ b/omop_core/models.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.db.models import Q
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.indexes import GinIndex
@@ -133,19 +134,24 @@ class PatientGroupMembership(models.Model):
         return f"Person {self.person_id} in {self.group.name}"
 
 
-class ProfessionalGroupAccess(models.Model):
-    """Grants a professional (Identity) access to a patient group."""
+class GroupAccess(models.Model):
+    """Grants a professional (Identity) access to an org or a patient group."""
     ROLE_CHOICES = [
-        ('admin', 'Admin'),
+        ('org_admin', 'Org Admin'),
+        ('doctor',    'Doctor'),
         ('navigator', 'Navigator'),
-        ('doctor', 'Doctor'),
     ]
     identity = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
         related_name='group_access_grants',
     )
+    org = models.ForeignKey(
+        'Organization', on_delete=models.CASCADE,
+        null=True, blank=True, related_name='access_grants',
+    )
     group = models.ForeignKey(
-        PatientGroup, on_delete=models.CASCADE, related_name='access_grants',
+        PatientGroup, on_delete=models.CASCADE,
+        null=True, blank=True, related_name='access_grants',
     )
     role = models.CharField(max_length=20, choices=ROLE_CHOICES)
     expires_at = models.DateTimeField(null=True, blank=True)
@@ -156,16 +162,30 @@ class ProfessionalGroupAccess(models.Model):
     )
 
     class Meta:
-        db_table = 'professional_group_access'
+        db_table = 'group_access'
         constraints = [
+            models.CheckConstraint(
+                check=(
+                    Q(org__isnull=False, group__isnull=True) |
+                    Q(org__isnull=True, group__isnull=False)
+                ),
+                name='group_access_org_xor_group',
+            ),
             models.UniqueConstraint(
                 fields=['identity', 'group'],
+                condition=Q(group__isnull=False),
                 name='uq_identity_group',
+            ),
+            models.UniqueConstraint(
+                fields=['identity', 'org'],
+                condition=Q(org__isnull=False),
+                name='uq_identity_org',
             ),
         ]
 
     def __str__(self):
-        return f"{self.identity} → {self.group.name} ({self.role})"
+        scope = f"org={self.org_id}" if self.org_id else f"group={self.group_id}"
+        return f"{self.identity} → {scope} ({self.role})"
 
 
 class PersonalRepresentative(models.Model):

--- a/omop_core/services/access.py
+++ b/omop_core/services/access.py
@@ -1,0 +1,39 @@
+from django.db.models import Q, QuerySet
+from django.utils import timezone
+
+from omop_core.models import GroupAccess, Organization
+
+
+def get_visible_orgs(user) -> QuerySet:
+    """Return the orgs whose patients the user is allowed to see.
+
+    - is_staff → all orgs
+    - org_admin grant → their org(s)
+    - doctor/navigator grant → the org of each assigned group
+    - no grants → empty queryset
+    """
+    if getattr(user, 'is_staff', False):
+        return Organization.objects.all()
+
+    now = timezone.now()
+    active = GroupAccess.objects.filter(
+        identity=user,
+    ).filter(
+        Q(expires_at__isnull=True) | Q(expires_at__gt=now)
+    )
+
+    org_ids = set(
+        active.filter(role='org_admin')
+              .values_list('org_id', flat=True)
+    )
+    group_org_ids = set(
+        active.exclude(role='org_admin')
+              .values_list('group__organization_id', flat=True)
+    )
+    group_org_ids.discard(None)
+    all_ids = org_ids | group_org_ids
+
+    if not all_ids:
+        return Organization.objects.none()
+
+    return Organization.objects.filter(id__in=all_ids)

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -484,3 +484,78 @@ class ConditionSignalTest(_OmopBase):
         co.delete()
         pi.refresh_from_db()
         self.assertIsNone(pi.disease)
+
+
+# ---------------------------------------------------------------------------
+# TEST-04: get_visible_orgs access helper
+# ---------------------------------------------------------------------------
+
+from django.utils import timezone
+from datetime import timedelta
+from omop_core.models import Organization, PatientGroup, GroupAccess
+from omop_core.services.access import get_visible_orgs
+from patient_portal.models import Identity
+
+
+class GetVisibleOrgsTest(TestCase):
+    def setUp(self):
+        self.org_a = Organization.objects.create(name='Org A', slug='org-a')
+        self.org_b = Organization.objects.create(name='Org B', slug='org-b')
+        self.group_a = PatientGroup.objects.create(
+            organization=self.org_a, name='Group A', slug='group-a'
+        )
+        self.staff_user = Identity.objects.create_user(
+            email='staff@test.com', password='x', is_staff=True
+        )
+        self.org_admin = Identity.objects.create_user(
+            email='orgadmin@test.com', password='x'
+        )
+        self.doctor = Identity.objects.create_user(
+            email='doctor@test.com', password='x'
+        )
+        self.nobody = Identity.objects.create_user(
+            email='nobody@test.com', password='x'
+        )
+        GroupAccess.objects.create(
+            identity=self.org_admin, org=self.org_a, role='org_admin'
+        )
+        GroupAccess.objects.create(
+            identity=self.doctor, group=self.group_a, role='doctor'
+        )
+
+    def test_staff_sees_all_orgs(self):
+        orgs = get_visible_orgs(self.staff_user)
+        self.assertIn(self.org_a, orgs)
+        self.assertIn(self.org_b, orgs)
+
+    def test_org_admin_sees_their_org_only(self):
+        orgs = list(get_visible_orgs(self.org_admin))
+        self.assertIn(self.org_a, orgs)
+        self.assertNotIn(self.org_b, orgs)
+
+    def test_doctor_sees_org_of_their_group(self):
+        orgs = list(get_visible_orgs(self.doctor))
+        self.assertIn(self.org_a, orgs)
+        self.assertNotIn(self.org_b, orgs)
+
+    def test_user_with_no_grants_sees_nothing(self):
+        orgs = list(get_visible_orgs(self.nobody))
+        self.assertEqual(orgs, [])
+
+    def test_expired_grant_excluded(self):
+        expired = Identity.objects.create_user(email='expired@test.com', password='x')
+        GroupAccess.objects.create(
+            identity=expired, org=self.org_a, role='org_admin',
+            expires_at=timezone.now() - timedelta(hours=1),
+        )
+        orgs = list(get_visible_orgs(expired))
+        self.assertEqual(orgs, [])
+
+    def test_active_grant_with_future_expiry_included(self):
+        future = Identity.objects.create_user(email='future@test.com', password='x')
+        GroupAccess.objects.create(
+            identity=future, org=self.org_b, role='org_admin',
+            expires_at=timezone.now() + timedelta(days=30),
+        )
+        orgs = list(get_visible_orgs(future))
+        self.assertIn(self.org_b, orgs)

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -559,3 +559,11 @@ class GetVisibleOrgsTest(TestCase):
         )
         orgs = list(get_visible_orgs(future))
         self.assertIn(self.org_b, orgs)
+
+    def test_xor_constraint_prevents_both_org_and_group_set(self):
+        from django.db import IntegrityError, transaction
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                GroupAccess.objects.create(
+                    identity=self.nobody, org=self.org_a, group=self.group_a, role='org_admin'
+                )

--- a/patient_portal/api/lab_results/tests.py
+++ b/patient_portal/api/lab_results/tests.py
@@ -739,13 +739,13 @@ class PersonalRepresentativeAccessTest(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
 
-class ProfessionalGroupAccessTest(TestCase):
-    """Tests for ProfessionalGroupAccess expires_at enforcement."""
+class GroupAccessTest(TestCase):
+    """Tests for GroupAccess expires_at enforcement."""
 
     def setUp(self):
         from omop_core.models import (
             Organization, PatientGroup, PatientGroupMembership,
-            ProfessionalGroupAccess,
+            GroupAccess,
         )
         from django.utils import timezone
         from datetime import timedelta
@@ -772,7 +772,7 @@ class ProfessionalGroupAccessTest(TestCase):
             value_as_number=11.0,
         )
 
-        self.grant = ProfessionalGroupAccess.objects.create(
+        self.grant = GroupAccess.objects.create(
             identity=self.doctor,
             group=self.group,
             role='doctor',
@@ -1329,7 +1329,7 @@ class ResolvePersonIdOrgBypassTest(TestCase):
     """
     Verify that an org-scoped token cannot access a patient from a different
     org even when can_access_patient() would return True (e.g. via
-    ProfessionalGroupAccess that spans organisations).
+    GroupAccess that spans organisations).
 
     Before the fix, _resolve_person_id only ran the org check when
     can_access_patient() returned False.  A cross-org group grant therefore
@@ -1337,7 +1337,7 @@ class ResolvePersonIdOrgBypassTest(TestCase):
     """
 
     def setUp(self):
-        from omop_core.models import Organization, ApplicationOrganization, PatientGroupMembership, ProfessionalGroupAccess
+        from omop_core.models import Organization, ApplicationOrganization, PatientGroupMembership, GroupAccess
         from oauth2_provider.models import Application, AccessToken
         from django.utils import timezone
         from datetime import timedelta
@@ -1374,14 +1374,14 @@ class ResolvePersonIdOrgBypassTest(TestCase):
         self.person_in_b = Person.objects.create(person_id=18002)
         PatientInfo.objects.create(person=self.person_in_b, organization=self.org_b)
 
-        # Give the provider a ProfessionalGroupAccess that covers the org-B patient.
+        # Give the provider a GroupAccess that covers the org-B patient.
         # This simulates a cross-org group grant that must not bypass org isolation.
         from omop_core.models import PatientGroup
         self.group = PatientGroup.objects.create(
             name='Cross-org group', slug='cross-org-group', organization=self.org_b,
         )
         PatientGroupMembership.objects.create(group=self.group, person_id=self.person_in_b.person_id)
-        ProfessionalGroupAccess.objects.create(
+        GroupAccess.objects.create(
             identity=self.provider,
             group=self.group,
             role='navigator',
@@ -1391,7 +1391,7 @@ class ResolvePersonIdOrgBypassTest(TestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.token.token}')
 
     def test_org_token_denied_for_patient_in_other_org_even_with_group_access(self):
-        """Org-A token cannot read org-B patient even if ProfessionalGroupAccess covers them."""
+        """Org-A token cannot read org-B patient even if GroupAccess covers them."""
         resp = self.client.get(f'/api/lab-results/summary/?person_id={self.person_in_b.person_id}')
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -77,7 +77,7 @@ def _resolve_person_id(request):
             )
         # Verify caller has access to this patient.
         # Org-scoped tokens are checked FIRST, before can_access_patient.
-        # ProfessionalGroupAccess can span organisations, so allowing
+        # GroupAccess can span organisations, so allowing
         # can_access_patient() to short-circuit the org check would let a
         # cross-org group grant bypass tenant isolation.
         if not (request.user and request.user.is_authenticated):

--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -15,7 +15,7 @@ from django.utils.timezone import localdate
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = Identity
-        fields = ['id', 'sub', 'email', 'name']
+        fields = ['id', 'sub', 'email', 'name', 'is_staff']
 
 
 class PatientListSerializer(serializers.ModelSerializer):

--- a/patient_portal/api/urls.py
+++ b/patient_portal/api/urls.py
@@ -15,6 +15,8 @@ from .views import (
     SurveyViewSet, PatientSurveyResponseViewSet,
     # Controlled vocabulary + OMOP concept lookup
     vocabulary_list, concept_lookup,
+    # Stats
+    org_disease_stats,
 )
 
 router = DefaultRouter()
@@ -53,4 +55,5 @@ urlpatterns = [
     path('auth/test/', auth_test, name='auth_test'),
     path('vocabularies/<str:model_name>/', vocabulary_list, name='vocabulary-list'),
     path('concepts/lookup/', concept_lookup, name='concept-lookup'),
+    path('stats/org-disease/', org_disease_stats, name='stats-org-disease'),
 ]

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -36,6 +36,7 @@ from omop_core.services.mappings import get_gender_concept, LAB_FIELD_TO_LOINC
 from omop_core.services.pk import next_pk
 from omop_core.services.rxnav_service import resolve_drug as _rxnav_resolve_drug
 from omop_core.services.concept_cache import concept_by_id as _cc_by_id, concept_by_loinc as _cc_by_loinc, concept_by_name_ilike as _cc_by_name
+from omop_core.services.access import get_visible_orgs
 from datetime import datetime
 from django.utils.timezone import localdate
 import csv
@@ -2105,6 +2106,52 @@ def health_check(request):
         'service': 'ctomop',
         'database': db_status,
     }, status=http_status)
+
+
+# Disease label lookup — human-readable names for known disease slugs.
+_DISEASE_LABELS = {
+    'mm':                     'Multiple Myeloma',
+    'MM':                     'Multiple Myeloma',
+    'er-erbb2-breast-cancer': 'ER+/HER2+ Breast Cancer',
+    'breast-cancer':           'Breast Cancer',
+    'follicular-lymphoma':     'Follicular Lymphoma',
+    'cll':                    'Chronic Lymphocytic Leukemia',
+    'lung-cancer':             'Lung Cancer',
+    'colon-cancer':            'Colon Cancer',
+}
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def org_disease_stats(request):
+    """GET /api/stats/org-disease/ — per-org disease patient counts for the requesting user."""
+    from django.db.models import Count
+
+    orgs = get_visible_orgs(request.user)
+    result = []
+    for org in orgs.order_by('name'):
+        rows = (
+            PatientInfo.objects
+            .filter(organization=org)
+            .values('disease_slug')
+            .annotate(count=Count('id'))
+            .order_by('-count')
+        )
+        disease_counts = [
+            {
+                'disease_slug': r['disease_slug'] or '',
+                'label': _DISEASE_LABELS.get(r['disease_slug'] or '', r['disease_slug'] or 'Unknown'),
+                'count': r['count'],
+            }
+            for r in rows
+        ]
+        result.append({
+            'org_slug': org.slug,
+            'org_name': org.name,
+            'total': sum(d['count'] for d in disease_counts),
+            'disease_counts': disease_counts,
+        })
+    return Response(result)
 
 
 @csrf_exempt

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -152,10 +152,10 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
         )):
             # Session / partner-auth users: scope to only the patients they can
             # access — their own record (PatientUser) and any patients in their
-            # professional groups (ProfessionalGroupAccess). Doctors/admins with
+            # professional groups (GroupAccess). Doctors/admins with
             # group access see their whole panel; is_staff bypasses this entirely.
             from patient_portal.models import PatientUser
-            from omop_core.models import PatientGroupMembership, ProfessionalGroupAccess
+            from omop_core.models import PatientGroupMembership, GroupAccess
             from django.utils import timezone
             from django.db.models import Q
 
@@ -171,7 +171,7 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
 
             # Professional group access (non-expired grants)
             now = timezone.now()
-            actor_group_ids = ProfessionalGroupAccess.objects.filter(
+            actor_group_ids = GroupAccess.objects.filter(
                 identity=self.request.user,
             ).filter(
                 Q(expires_at__isnull=True) | Q(expires_at__gt=now),

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -6080,3 +6080,86 @@ class TherapyConceptIdTest(TestCase):
         """later_therapy_ids is either None or a list."""
         pi = self._refresh(self.person_krd)
         self.assertIn(pi.later_therapy_ids, [None, []])
+
+
+class OrgDiseaseStatsTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        from omop_core.models import Organization, PatientGroup, GroupAccess
+        self.org_a = Organization.objects.create(name='Org A', slug='org-a')
+        self.org_b = Organization.objects.create(name='Org B', slug='org-b')
+        self.group_a = PatientGroup.objects.create(
+            organization=self.org_a, name='Group A', slug='group-a'
+        )
+
+        # Create patients in org_a
+        for i, slug in enumerate(['mm', 'mm', 'breast-cancer'], start=1):
+            p = Person.objects.create(person_id=9000 + i)
+            PatientInfo.objects.create(person=p, organization=self.org_a, disease_slug=slug)
+
+        # Create patient in org_b
+        p4 = Person.objects.create(person_id=9004)
+        PatientInfo.objects.create(person=p4, organization=self.org_b, disease_slug='cll')
+
+        self.staff = Identity.objects.create_user(email='staff@t.com', password='x', is_staff=True)
+        self.org_admin = Identity.objects.create_user(email='admin@t.com', password='x')
+        self.doctor = Identity.objects.create_user(email='doc@t.com', password='x')
+        self.nobody = Identity.objects.create_user(email='none@t.com', password='x')
+
+        GroupAccess.objects.create(identity=self.org_admin, org=self.org_a, role='org_admin')
+        GroupAccess.objects.create(identity=self.doctor, group=self.group_a, role='doctor')
+
+    def _get(self, user):
+        self.client.force_authenticate(user=user)
+        return self.client.get('/api/stats/org-disease/')
+
+    def test_staff_sees_all_orgs(self):
+        resp = self._get(self.staff)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        slugs = {o['org_slug'] for o in resp.data}
+        self.assertIn('org-a', slugs)
+        self.assertIn('org-b', slugs)
+
+    def test_staff_disease_counts_correct(self):
+        resp = self._get(self.staff)
+        org_a_data = next(o for o in resp.data if o['org_slug'] == 'org-a')
+        self.assertEqual(org_a_data['total'], 3)
+        counts = {d['disease_slug']: d['count'] for d in org_a_data['disease_counts']}
+        self.assertEqual(counts['mm'], 2)
+        self.assertEqual(counts['breast-cancer'], 1)
+
+    def test_org_admin_sees_only_their_org(self):
+        resp = self._get(self.org_admin)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        slugs = {o['org_slug'] for o in resp.data}
+        self.assertIn('org-a', slugs)
+        self.assertNotIn('org-b', slugs)
+
+    def test_doctor_sees_their_group_org(self):
+        resp = self._get(self.doctor)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        slugs = {o['org_slug'] for o in resp.data}
+        self.assertIn('org-a', slugs)
+
+    def test_no_grants_returns_empty_list(self):
+        resp = self._get(self.nobody)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data, [])
+
+    def test_unauthenticated_returns_401(self):
+        self.client.logout()
+        resp = self.client.get('/api/stats/org-disease/')
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_response_shape(self):
+        resp = self._get(self.org_admin)
+        org = resp.data[0]
+        self.assertIn('org_slug', org)
+        self.assertIn('org_name', org)
+        self.assertIn('total', org)
+        self.assertIn('disease_counts', org)
+        if org['disease_counts']:
+            dc = org['disease_counts'][0]
+            self.assertIn('disease_slug', dc)
+            self.assertIn('label', dc)
+            self.assertIn('count', dc)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -1561,7 +1561,7 @@ class _SmartBase(TestCase):
 
         # Organization + ApplicationOrganization so get_request_org() returns an org
         # (without this, access checks fall through to can_access_patient which rejects
-        # foundation_user because it has no PatientUser/ProfessionalGroupAccess).
+        # foundation_user because it has no PatientUser/GroupAccess).
         from omop_core.models import Organization, ApplicationOrganization
         cls.organization = Organization.objects.create(
             name='SMART Test Org',


### PR DESCRIPTION
## Summary

- Renames `ProfessionalGroupAccess` → `GroupAccess` (migration 0095 with `RenameModel` — existing rows preserved). Adds nullable `org` FK alongside existing nullable `group` FK, enforced XOR at DB level via `CheckConstraint`. Adds `org_admin` role for org-wide access.
- Adds `omop_core/services/access.py` with `get_visible_orgs(user)` — returns orgs visible to the user based on `is_staff`, `org_admin` grants, or `doctor`/`navigator` group grants. Respects `expires_at`.
- Adds `GET /api/stats/org-disease/` — per-org disease patient counts scoped to the requesting user's access level. Requires authentication (401 for anonymous). Adds `is_staff` to `UserSerializer`.
- Adds frontend `StatsPage` at `/stats` showing per-org cards with disease breakdown tables. Loading, empty, and error states handled. Stats button added to PatientList nav.

## Test plan

- [ ] 488 backend tests pass (`omop_core` + `patient_portal`)
- [ ] 38 frontend tests pass, TypeScript build clean
- [ ] Staff user sees all orgs; `org_admin` sees only their org; `doctor`/`navigator` sees their group's org; unauthenticated gets 401
- [ ] XOR constraint test confirms DB rejects rows with both `org` and `group` set
- [ ] Migration 0095 applied cleanly to staging (`group_access` table verified)
- [ ] `/stats` page renders org cards and shows error state on network failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)