### PR TITLE
fhir/sync: faithful wearable ingest — per-reading timestamps + daily-rollup upsert

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -117,3 +117,59 @@
 - `patient_portal/api/lab_results/sync.py:49-56`
 - Superseded by findings #6 and #7 in the backend review above.
 
+---
+
+## Wearable support
+
+Backend items for the `phr-mobile-bridge` HealthKit → OMOP sync app. Item IDs (B0–B6)
+match `phr-mobile-bridge/docs/wearable-sync-plan.md §13`. `POST /api/fhir/sync/`
+already handles identity resolution, per-reading `measurement_datetime`, and
+daily-aggregate upsert (B1 resolved, B2 done — see PR #171).
+
+### B0 — Build the connector service
+- **Status:** not built (blocks the production write path). App side is done.
+- **Why:** `ScopedTokenPermission` rejects a patient's own token on POST to
+  `/api/fhir/sync/` (403). A native app can't safely hold a service token, so a
+  trusted server must verify the patient's Firebase token and forward to promop
+  with the service token + the patient's `actor_iss`/`actor_sub`. Mirrors hk-labs.
+- **Contract:** `phr-mobile-bridge/docs/connector-contract.md` (bundle passthrough).
+- **Action:** Stand up a thin Firebase-authed ingress (or extend hk-labs) that
+  relays to `/api/fhir/sync/`; **must verify the Firebase token and bind body
+  `actor_iss`/`actor_sub` to the verified `(iss, sub)`** (reject mismatch). Provision
+  the connector↔promop service token; set per-env base URLs.
+- **Alternative:** grant patients an OAuth2 `patient/*.write` scope on
+  `/api/fhir/sync/` so the app posts directly — removes the connector but widens
+  promop's write surface. Decide vs B0 (`connector-contract.md §5`).
+
+### Provenance — `/api/fhir/sync/` records EHR_SYNC, plan expects PATIENT_SELF
+- **Status:** discrepancy. `_bulk_insert` hardcodes `source='EHR_SYNC'`
+  (`patient_portal/api/fhir/sync.py`). The wearable plan tags self-entered data
+  `PATIENT_SELF` (and `DOCUMENT_EXTRACTION` for Clinical Records).
+- **Action:** Let the caller signal provenance (e.g. a `source`/`source_type`
+  field or per-resource mapping) and record it instead of a hardcoded value;
+  decide whether the connector or the app sets it.
+
+### B3 — Clinical Record types beyond the first-cut scope
+- **Status:** not started. `/api/fhir/sync/` ingests Patient / Observation /
+  Condition / MedicationStatement|MedicationRequest only.
+- **Action:** Add (or define app-side downconversion for) AllergyIntolerance,
+  Immunization, Procedure, and DiagnosticReport wrappers from HealthKit Clinical
+  Records. Gates `wearable-sync-plan.md §5.4`.
+
+### B4 — HealthKit deletions → delete path
+- **Status:** not started. The sync ingest has no delete semantics; the app
+  currently only logs deletions.
+- **Action:** Define a granular delete path (likely connector + scoped OMOP
+  delete by identity + concept/date) so removing a HealthKit sample propagates.
+
+### B5 — Per-environment config & service-token provisioning
+- **Status:** dev only (local `SERVICE_AUTH_TOKEN`). 
+- **Action:** Provision connector↔promop service tokens and stable HTTPS base
+  URLs for dev/staging/prod; confirm Firebase project reuse (same `iss` as ht-phr).
+
+### B6 — Consent representation
+- **Status:** not started. App has no per-category consent yet; nothing recorded
+  server-side.
+- **Action:** Decide whether per-category consent is local-only or recorded in a
+  promop `PatientConsent` model, and wire it if server-side.
+

--- a/patient_portal/api/fhir/sync.py
+++ b/patient_portal/api/fhir/sync.py
@@ -87,6 +87,24 @@ def _parse_date(value):
         return None
 
 
+def _parse_datetime(value):
+    """FHIR dateTime → aware datetime, or None for date-only values.
+
+    Preserves sub-daily timestamps (e.g. per-reading heart rate) so they land in
+    Measurement.measurement_datetime instead of being truncated to a date.
+    """
+    if not isinstance(value, str) or len(value) <= 10:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        from django.utils import timezone as _tz
+        dt = _tz.make_aware(dt, _tz.utc)
+    return dt
+
+
 def _codings(codeable):
     return (codeable or {}).get('coding', []) or []
 
@@ -257,19 +275,22 @@ class FhirSyncView(APIView):
     # Batched ingestion
     # ------------------------------------------------------------------ #
     def _ingest_observations(self, person, observations, ehr_type, cache, source_user_id, org):
+        # Dedup includes measurement_datetime so distinct sub-daily readings
+        # (e.g. per-reading heart rate) coexist while exact re-syncs collapse.
         existing = {
-            (d, cid, sv, _norm_num(v))
-            for d, cid, sv, v in Measurement.objects.filter(person=person).values_list(
-                'measurement_date', 'measurement_concept_id', 'measurement_source_value',
-                'value_as_number')
+            (d, dt, cid, sv, _norm_num(v))
+            for d, dt, cid, sv, v in Measurement.objects.filter(person=person).values_list(
+                'measurement_date', 'measurement_datetime', 'measurement_concept_id',
+                'measurement_source_value', 'value_as_number')
         }
         seen = set(existing)
         rows = []
         for obs in observations:
-            obs_date = _parse_date(obs.get('effectiveDateTime')) or _parse_date(
-                (obs.get('effectivePeriod') or {}).get('start'))
+            effective = obs.get('effectiveDateTime') or (obs.get('effectivePeriod') or {}).get('start')
+            obs_date = _parse_date(effective)
             if obs_date is None:
                 continue
+            obs_dt = _parse_datetime(effective)
             concept = self._lookup(obs.get('code'), cache)
             cid = concept.concept_id if concept else 0
             sv = _source_text(obs.get('code'))[:50]
@@ -278,7 +299,7 @@ class FhirSyncView(APIView):
             unit = qty.get('unit') or qty.get('code')
             value_string = obs.get('valueString') or _source_text(obs.get('valueCodeableConcept'))
 
-            key = (obs_date, cid, sv, _norm_num(value_number))
+            key = (obs_date, obs_dt, cid, sv, _norm_num(value_number))
             if key in seen:
                 continue
             seen.add(key)
@@ -286,6 +307,7 @@ class FhirSyncView(APIView):
                 person=person,
                 measurement_concept_id=cid,
                 measurement_date=obs_date,
+                measurement_datetime=obs_dt,
                 measurement_type_concept=ehr_type,
                 value_as_number=value_number,
                 value_as_string=(value_string or '')[:60],

--- a/patient_portal/api/fhir/sync.py
+++ b/patient_portal/api/fhir/sync.py
@@ -33,6 +33,7 @@ from omop_core.models import (
     Concept, ConditionOccurrence, DrugExposure, Measurement, Person, ProvenanceRecord,
 )
 from omop_core.services.pk import next_pk_batch
+from omop_core.signals import suppress_patient_info_refresh
 from patient_portal.api.permissions import ScopedTokenPermission, get_request_org
 # Reuse the proven HK-Labs concept-fallback machinery.
 from patient_portal.api.lab_results.sync import HK_LABS_VOCAB_ID, _ensure_hk_deps
@@ -126,6 +127,20 @@ def _source_text(codeable):
 def _norm_num(value):
     """Normalize a measurement value to a comparable form for dedup (float | None)."""
     return float(value) if value is not None else None
+
+
+# Observation.extension marker the phr-mobile-bridge sets on daily aggregates
+# (steps, active energy, daily HR avg, …). Such rows are upserted by
+# (person, concept, date) so a changed daily value replaces the prior row
+# instead of stacking — while unmarked clinical readings keep value-level dedup.
+AGGREGATION_EXT_URL = 'https://healthkey.ai/fhir/aggregation'
+
+
+def _is_daily_rollup(obs):
+    for ext in obs.get('extension') or []:
+        if ext.get('url') == AGGREGATION_EXT_URL and ext.get('valueCode') == 'daily':
+            return True
+    return False
 
 
 class FhirSyncRequestSerializer(serializers.Serializer):
@@ -275,6 +290,33 @@ class FhirSyncView(APIView):
     # Batched ingestion
     # ------------------------------------------------------------------ #
     def _ingest_observations(self, person, observations, ehr_type, cache, source_user_id, org):
+        # Daily rollups (steps/energy/daily-avg) upsert by (person, concept, date);
+        # everything else dedups on (date, datetime, concept, source, value).
+        rollups = [o for o in observations if _is_daily_rollup(o)]
+        discrete = [o for o in observations if not _is_daily_rollup(o)]
+        ids = self._insert_discrete_observations(
+            person, discrete, ehr_type, cache, source_user_id, org)
+        if rollups:
+            ids += self._upsert_rollup_observations(
+                person, rollups, ehr_type, cache, source_user_id, org)
+        return ids
+
+    def _parse_obs(self, obs, cache):
+        """Pull the fields one Observation maps onto a Measurement."""
+        effective = obs.get('effectiveDateTime') or (obs.get('effectivePeriod') or {}).get('start')
+        concept = self._lookup(obs.get('code'), cache)
+        qty = obs.get('valueQuantity') or {}
+        return {
+            'date': _parse_date(effective),
+            'dt': _parse_datetime(effective),
+            'cid': concept.concept_id if concept else 0,
+            'sv': _source_text(obs.get('code'))[:50],
+            'value': qty.get('value'),
+            'unit': (qty.get('unit') or qty.get('code') or '')[:50],
+            'vstr': (obs.get('valueString') or _source_text(obs.get('valueCodeableConcept')) or '')[:60],
+        }
+
+    def _insert_discrete_observations(self, person, observations, ehr_type, cache, source_user_id, org):
         # Dedup includes measurement_datetime so distinct sub-daily readings
         # (e.g. per-reading heart rate) coexist while exact re-syncs collapse.
         existing = {
@@ -286,35 +328,85 @@ class FhirSyncView(APIView):
         seen = set(existing)
         rows = []
         for obs in observations:
-            effective = obs.get('effectiveDateTime') or (obs.get('effectivePeriod') or {}).get('start')
-            obs_date = _parse_date(effective)
-            if obs_date is None:
+            o = self._parse_obs(obs, cache)
+            if o['date'] is None:
                 continue
-            obs_dt = _parse_datetime(effective)
-            concept = self._lookup(obs.get('code'), cache)
-            cid = concept.concept_id if concept else 0
-            sv = _source_text(obs.get('code'))[:50]
-            qty = obs.get('valueQuantity') or {}
-            value_number = qty.get('value')
-            unit = qty.get('unit') or qty.get('code')
-            value_string = obs.get('valueString') or _source_text(obs.get('valueCodeableConcept'))
-
-            key = (obs_date, obs_dt, cid, sv, _norm_num(value_number))
+            key = (o['date'], o['dt'], o['cid'], o['sv'], _norm_num(o['value']))
             if key in seen:
                 continue
             seen.add(key)
             rows.append(Measurement(
                 person=person,
-                measurement_concept_id=cid,
-                measurement_date=obs_date,
-                measurement_datetime=obs_dt,
+                measurement_concept_id=o['cid'],
+                measurement_date=o['date'],
+                measurement_datetime=o['dt'],
                 measurement_type_concept=ehr_type,
-                value_as_number=value_number,
-                value_as_string=(value_string or '')[:60],
-                measurement_source_value=sv,
-                unit_source_value=(unit or '')[:50],
+                value_as_number=o['value'],
+                value_as_string=o['vstr'],
+                measurement_source_value=o['sv'],
+                unit_source_value=o['unit'],
             ))
         return self._bulk_insert(Measurement, 'measurement_id', rows, source_user_id, person, org)
+
+    def _upsert_rollup_observations(self, person, observations, ehr_type, cache, source_user_id, org):
+        """Replace any prior row for (person, concept, date) with the new daily
+        value, collapsing stale stacked rows — so a changed daily aggregate
+        updates in place instead of accumulating duplicates."""
+        desired = {}  # (cid, date) -> parsed obs; last in the bundle wins
+        for obs in observations:
+            o = self._parse_obs(obs, cache)
+            if o['date'] is not None:
+                desired[(o['cid'], o['date'])] = o
+        if not desired:
+            return []
+
+        meas_ct = ContentType.objects.get_for_model(Measurement)
+        touched, new_rows = [], []
+        with suppress_patient_info_refresh():
+            for (cid, obs_date), o in desired.items():
+                existing = list(Measurement.objects.filter(
+                    person=person, measurement_concept_id=cid, measurement_date=obs_date,
+                ).order_by('measurement_id'))
+                if not existing:
+                    new_rows.append(Measurement(
+                        person=person,
+                        measurement_concept_id=cid,
+                        measurement_date=obs_date,
+                        measurement_datetime=o['dt'],
+                        measurement_type_concept=ehr_type,
+                        value_as_number=o['value'],
+                        value_as_string=o['vstr'],
+                        measurement_source_value=o['sv'],
+                        unit_source_value=o['unit'],
+                    ))
+                    continue
+
+                keep, extras = existing[0], existing[1:]
+                if extras:  # collapse historical stacked rows for this concept/day
+                    extra_ids = [m.measurement_id for m in extras]
+                    ProvenanceRecord.objects.filter(
+                        content_type=meas_ct, object_id__in=extra_ids).delete()
+                    Measurement.objects.filter(measurement_id__in=extra_ids).delete()
+
+                changed = (
+                    _norm_num(keep.value_as_number) != _norm_num(o['value'])
+                    or keep.measurement_datetime != o['dt']
+                    or keep.value_as_string != o['vstr']
+                    or keep.unit_source_value != o['unit']
+                )
+                if changed:
+                    keep.value_as_number = o['value']
+                    keep.measurement_datetime = o['dt']
+                    keep.value_as_string = o['vstr']
+                    keep.unit_source_value = o['unit']
+                    keep._skip_patient_info_refresh = True
+                    keep.save(update_fields=['value_as_number', 'measurement_datetime',
+                                             'value_as_string', 'unit_source_value'])
+                if changed or extras:
+                    touched.append(keep.measurement_id)
+            inserted = self._bulk_insert(
+                Measurement, 'measurement_id', new_rows, source_user_id, person, org)
+        return touched + inserted
 
     def _ingest_conditions(self, person, conditions, ehr_type, no_match, cache, source_user_id, org):
         existing = set(ConditionOccurrence.objects.filter(person=person).values_list(

--- a/patient_portal/api/fhir/tests.py
+++ b/patient_portal/api/fhir/tests.py
@@ -164,6 +164,44 @@ class FhirSyncTests(TestCase):
         self.assertEqual(second['drug_exposure_ids'], [])
         self.assertEqual(Measurement.objects.filter(person_id=first['person_id']).count(), 1)
 
+    def test_daily_rollup_upserts_by_person_concept_date(self):
+        """An Observation flagged as a daily rollup replaces the prior
+        (person, concept, date) row when its value changes, and collapses any
+        stale stacked rows — instead of accumulating a row per changed value."""
+        AGG_EXT = [{"url": "https://healthkey.ai/fhir/aggregation", "valueCode": "daily"}]
+
+        def steps(value, ext):
+            entry = {"resource": {
+                "resourceType": "Observation",
+                "subject": {"reference": "Patient/p1"},
+                "code": {"coding": [{"system": "http://loinc.org", "code": "41950-7",
+                                     "display": "Steps 24h"}]},
+                "effectiveDateTime": "2026-04-01T00:00:00Z",
+                "valueQuantity": {"value": value, "unit": "{steps}"},
+            }}
+            if ext:
+                entry["resource"]["extension"] = AGG_EXT
+            return {"resourceType": "Bundle", "type": "collection", "entry": [entry]}
+
+        # Seed two stale stacked rows the old value-dedup behaviour would have left.
+        self.assertEqual(self.client.post('/api/fhir/sync/', {'bundle': steps(5000, False)},
+                                          format='json').status_code, 201)
+        pid = self.client.post('/api/fhir/sync/', {'bundle': steps(8000, False)},
+                               format='json').json()['person_id']
+        self.assertEqual(Measurement.objects.filter(
+            person_id=pid, measurement_source_value='Steps 24h').count(), 2)
+
+        # Rollup sync with a new value → collapses to a single row at that value.
+        self.client.post('/api/fhir/sync/', {'bundle': steps(9500, True)}, format='json')
+        rows = Measurement.objects.filter(person_id=pid, measurement_source_value='Steps 24h')
+        self.assertEqual(rows.count(), 1, "stacked rows collapsed to one")
+        self.assertEqual(float(rows.first().value_as_number), 9500.0)
+
+        # Re-sync identical rollup → idempotent (no new rows, nothing reported).
+        again = self.client.post('/api/fhir/sync/', {'bundle': steps(9500, True)}, format='json')
+        self.assertEqual(again.json()['measurement_ids'], [])
+        self.assertEqual(rows.count(), 1)
+
     def test_per_reading_timestamps_coexist_and_resync_is_idempotent(self):
         """Multiple same-day Observations with distinct effectiveDateTime times
         (e.g. per-reading heart rate) land as separate rows with

--- a/patient_portal/api/fhir/tests.py
+++ b/patient_portal/api/fhir/tests.py
@@ -164,6 +164,41 @@ class FhirSyncTests(TestCase):
         self.assertEqual(second['drug_exposure_ids'], [])
         self.assertEqual(Measurement.objects.filter(person_id=first['person_id']).count(), 1)
 
+    def test_per_reading_timestamps_coexist_and_resync_is_idempotent(self):
+        """Multiple same-day Observations with distinct effectiveDateTime times
+        (e.g. per-reading heart rate) land as separate rows with
+        measurement_datetime set; re-syncing the identical bundle adds nothing."""
+        def hr(time, value):
+            return {"resource": {
+                "resourceType": "Observation",
+                "subject": {"reference": "Patient/p1"},
+                "code": {"coding": [{"system": "http://loinc.org", "code": "8867-4",
+                                     "display": "Heart rate"}]},
+                "effectiveDateTime": time,
+                "valueQuantity": {"value": value, "unit": "/min"},
+            }}
+        bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+            hr("2026-03-01T08:00:00Z", 62),
+            hr("2026-03-01T12:30:00Z", 88),
+            hr("2026-03-01T20:15:00Z", 71),
+        ]}
+
+        first = self.client.post('/api/fhir/sync/', {'bundle': bundle}, format='json')
+        self.assertEqual(first.status_code, 201, first.content)
+        pid = first.json()['person_id']
+
+        rows = Measurement.objects.filter(person_id=pid).order_by('measurement_datetime')
+        self.assertEqual(rows.count(), 3, "distinct same-day times kept as separate rows")
+        self.assertTrue(all(r.measurement_datetime is not None for r in rows),
+                        "effectiveDateTime persisted to measurement_datetime")
+        self.assertEqual([r.measurement_datetime.hour for r in rows], [8, 12, 20])
+        self.assertTrue(all(r.measurement_date.isoformat() == '2026-03-01' for r in rows))
+
+        # Re-sync the identical bundle → idempotent (dedup includes datetime).
+        second = self.client.post('/api/fhir/sync/', {'bundle': bundle}, format='json')
+        self.assertEqual(second.json()['measurement_ids'], [])
+        self.assertEqual(Measurement.objects.filter(person_id=pid).count(), 3)
+
     def test_medication_request_maps_to_drug_exposure(self):
         # Epic R4 returns MedicationRequest (authoredOn), not MedicationStatement.
         bundle = {


### PR DESCRIPTION
Two related fidelity fixes for `POST /api/fhir/sync/` so the phr-mobile-bridge HealthKit sync round-trips losslessly (closes both halves of plan item **B2**).

## 1. Persist `measurement_datetime` for sub-daily readings
Previously `effectiveDateTime` was truncated to a date and `measurement_datetime` left null, so per-reading vitals (e.g. heart rate) lost their time-of-day and same-day same-value readings collapsed.
- Add `_parse_datetime()`; populate `Measurement.measurement_datetime` (date-only values stay null).
- Include `measurement_datetime` in the discrete dedup key, so distinct sub-daily timestamps coexist while an identical re-sync stays idempotent.

## 2. Upsert daily aggregates by `(person, concept, date)`
Daily rollups (steps, active energy, daily HR average) change value as more samples arrive for a day; value-level dedup stacked a new row each re-sync, accumulating stale aggregates.
- The app flags daily aggregates with an Observation extension (`url=https://healthkey.ai/fhir/aggregation`, `valueCode=daily`).
- Flagged observations upsert by `(person, concept, date)`: prior row updated in place, stale stacked rows for that concept/day collapsed (with provenance). Unmarked clinical readings keep value-level dedup — legitimate multiple same-day readings (BP, glucose, per-reading HR) are untouched.
- Upsert writes run under `suppress_patient_info_refresh()` to avoid per-row PatientInfo rebuilds, matching the bulk-insert path.

## Notes
- `measurement_datetime` column already exists — **no migration**.
- `patient_portal.api.fhir` suite green (9 tests; 2 new covering timestamps and rollup upsert).
- App side (extension marker, per-reading HR, timestamped bundle) is in the `phr-mobile-bridge` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)