### PR TITLE
feat: merge Stats into Org Admin

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,6 @@ import PatientList from "@/components/Patient/PatientList";
 import PatientDetail from "@/components/Patient/PatientDetail";
 import UploadFHIR from "@/components/Patient/UploadFHIR";
 import UploadCSV from "@/components/Patient/UploadCSV";
-import StatsPage from "@/components/Stats/StatsPage";
 import OrgAdminPage from "@/components/OrgAdmin/OrgAdminPage";
 import UserProfilePage from "@/components/User/UserProfilePage";
 import { useAuth } from "@/hooks/useAuth";
@@ -65,12 +64,7 @@ function AppRoutes() {
           currentUser ? <UploadCSV /> : <Navigate to="/login" replace />
         }
       />
-      <Route
-        path="/stats"
-        element={
-          currentUser ? <StatsPage /> : <Navigate to="/login" replace />
-        }
-      />
+      <Route path="/stats" element={<Navigate to="/org-admin" replace />} />
       <Route
         path="/org-admin"
         element={

--- a/frontend/src/components/OrgAdmin/OrgAdminPage.tsx
+++ b/frontend/src/components/OrgAdmin/OrgAdminPage.tsx
@@ -13,10 +13,16 @@ interface Org {
   created_at: string;
 }
 
+interface OrgStats {
+  org_slug: string;
+  total: number;
+}
+
 export default function OrgAdminPage() {
   const navigate = useNavigate();
   const { currentUser } = useAuth();
   const [orgs, setOrgs] = useState<Org[] | null>(null);
+  const [statsMap, setStatsMap] = useState<Record<string, number>>({});
   const [error, setError] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -25,12 +31,18 @@ export default function OrgAdminPage() {
   const [createError, setCreateError] = useState<string | null>(null);
 
   const fetchOrgs = () => {
-    api.get<Org[]>('/orgs/')
-      .then(r => setOrgs(r.data))
-      .catch((err) => {
-        console.error('Failed to load organizations:', err);
-        setError('Failed to load organizations.');
-      });
+    Promise.all([
+      api.get<Org[]>('/orgs/'),
+      api.get<OrgStats[]>('/stats/org-disease/').catch(() => ({ data: [] as OrgStats[] })),
+    ]).then(([orgsRes, statsRes]) => {
+      setOrgs(orgsRes.data);
+      const map: Record<string, number> = {};
+      for (const s of statsRes.data) map[s.org_slug] = s.total;
+      setStatsMap(map);
+    }).catch((err) => {
+      console.error('Failed to load organizations:', err);
+      setError('Failed to load organizations.');
+    });
   };
 
   useEffect(() => {
@@ -141,7 +153,7 @@ export default function OrgAdminPage() {
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>
                 <th className="text-left px-4 py-3 font-medium text-gray-600">Name</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Slug</th>
+                <th className="text-right px-4 py-3 font-medium text-gray-600">Patients</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-600">Status</th>
                 <th className="px-4 py-3"></th>
               </tr>
@@ -150,7 +162,7 @@ export default function OrgAdminPage() {
               {orgs.map(org => (
                 <tr key={org.id} className="hover:bg-gray-50">
                   <td className="px-4 py-3 font-medium text-gray-900">{org.name}</td>
-                  <td className="px-4 py-3 text-gray-500">{org.slug}</td>
+                  <td className="px-4 py-3 text-right text-gray-700">{statsMap[org.slug] ?? 0}</td>
                   <td className="px-4 py-3">
                     <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
                       org.is_active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'

--- a/frontend/src/components/OrgAdmin/OrgDetail.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.tsx
@@ -44,13 +44,27 @@ interface AccessGrant {
   granted_at: string;
 }
 
-type Section = 'settings' | 'trusts' | 'admins' | 'invitations';
+interface DiseaseCount {
+  disease_slug: string;
+  label: string;
+  count: number;
+}
+
+interface OrgStatsData {
+  org_slug: string;
+  org_name: string;
+  total: number;
+  disease_counts: DiseaseCount[];
+}
+
+type Section = 'settings' | 'trusts' | 'admins' | 'invitations' | 'stats';
 
 export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const [org, setOrg] = useState<Org | null>(null);
   const [trusts, setTrusts] = useState<Trust[]>([]);
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [accessGrants, setAccessGrants] = useState<AccessGrant[]>([]);
+  const [orgStats, setOrgStats] = useState<OrgStatsData | null>(null);
   const [activeSection, setActiveSection] = useState<Section>('settings');
   const [error, setError] = useState<string | null>(null);
 
@@ -75,11 +89,12 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
 
   const fetchAll = async () => {
     try {
-      const [orgRes, trustRes, invRes, accessRes] = await Promise.all([
+      const [orgRes, trustRes, invRes, accessRes, statsRes] = await Promise.all([
         api.get<Org>(`${base}/`),
         api.get<Trust[]>(`${base}/trusts/`),
         api.get<Invitation[]>(`${base}/invitations/`),
         api.get<AccessGrant[]>(`${base}/access/`),
+        api.get<OrgStatsData[]>('/stats/org-disease/').catch(() => ({ data: [] as OrgStatsData[] })),
       ]);
       setOrg(orgRes.data);
       setOrgName(orgRes.data.name);
@@ -87,6 +102,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
       setTrusts(trustRes.data);
       setInvitations(invRes.data);
       setAccessGrants(accessRes.data);
+      setOrgStats(statsRes.data.find((s: OrgStatsData) => s.org_slug === slug) ?? null);
     } catch {
       setError('Failed to load org details.');
     }
@@ -176,6 +192,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
 
   const sections: { key: Section; label: string }[] = [
     { key: 'settings', label: 'Settings' },
+    { key: 'stats', label: 'Stats' },
     { key: 'trusts', label: 'Access Rules' },
     { key: 'admins', label: 'Admins' },
     { key: 'invitations', label: 'Invitations' },
@@ -241,6 +258,38 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
           >
             Save
           </button>
+        </div>
+      )}
+
+      {/* Stats */}
+      {activeSection === 'stats' && (
+        <div>
+          {!orgStats ? (
+            <p className="text-sm text-gray-500">No patient data available for this organization.</p>
+          ) : (
+            <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="text-left px-4 py-2 font-medium text-gray-600">Disease</th>
+                  <th className="text-right px-4 py-2 font-medium text-gray-600">Patients</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orgStats.disease_counts.map(dc => (
+                  <tr key={dc.disease_slug} className="border-t border-gray-100">
+                    <td className="px-4 py-2 text-gray-800">{dc.label}</td>
+                    <td className="px-4 py-2 text-right text-gray-800">{dc.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t border-gray-200 bg-gray-50">
+                  <td className="px-4 py-2 font-medium text-gray-700">Total</td>
+                  <td className="px-4 py-2 text-right font-medium text-gray-700">{orgStats.total}</td>
+                </tr>
+              </tfoot>
+            </table>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/Patient/PatientList.tsx
+++ b/frontend/src/components/Patient/PatientList.tsx
@@ -121,7 +121,7 @@ export default function PatientList() {
             </button>
           )}
           <button
-            onClick={() => navigate("/stats")}
+            onClick={() => navigate("/org-admin")}
             className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded hover:bg-gray-50"
           >
             Stats

--- a/frontend/src/components/PatientInfo/tabs/TreatmentTab.tsx
+++ b/frontend/src/components/PatientInfo/tabs/TreatmentTab.tsx
@@ -108,7 +108,7 @@ export default function TreatmentTab({ formData, onChange, diseaseType }: Props)
         <div className="grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
           <div className="sm:col-span-2">
             <Field label="Later Line Therapy" name="later_therapy" type="select"
-              value={formData?.later_therapy}
+              value={typeof formData?.later_therapy === 'string' ? formData.later_therapy.split(';')[0].trim() : formData?.later_therapy}
               options={getTherapyOptions(diseaseType, 'later', bcFirstLineOptions, bcSecondLineOptions, bcLaterLineOptions)}
               onChange={onChange}
               vocabSource={breastSource ? bcLaterLineSource : null} />

--- a/omop_core/migrations/0097_org_management.py
+++ b/omop_core/migrations/0097_org_management.py
@@ -142,7 +142,7 @@ class Migration(migrations.Migration):
                 "db_table": "org_trust",
                 "constraints": [
                     models.CheckConstraint(
-                        condition=models.Q(
+                        check=models.Q(
                             models.Q(
                                 ("trusted_domain", ""), ("trusted_org__isnull", False)
                             ),

--- a/omop_core/services/patient_info_service.py
+++ b/omop_core/services/patient_info_service.py
@@ -431,7 +431,7 @@ def _get_treatment_data(person: Person) -> dict:
 
     if len(therapy_details) > 2:
         later_drugs = therapy_details[2:]
-        data['later_therapy'] = '; '.join([d['drug'] for d in later_drugs[:3]])
+        data['later_therapy'] = later_drugs[0]['drug']
         data['later_date'] = later_drugs[0]['start_date']
         data['later_therapies'] = [
             {'therapy': d['drug'], 'startDate': d['start_date'], 'endDate': d['end_date']}


### PR DESCRIPTION
## Summary

- **OrgAdminPage**: replaced Slug column with Patients count, fetched in parallel from `/stats/org-disease/`
- **OrgDetail**: added Stats tab with per-disease patient breakdown for the selected org
- **App.tsx / PatientList**: `/stats` redirects to `/org-admin`; Stats button navigates directly (no double-redirect)
- **TreatmentTab**: normalize legacy semicolon-joined `later_therapy` values at display time so existing rows render correctly in the select field
- **patient_info_service**: store only the first later-line drug name in `later_therapy` (full list remains in `later_therapies`)
- **Migration fix**: patch `0097_org_management` `CheckConstraint` to use `check=` instead of `condition=` for Django 4.2 compatibility

## Test plan

- [x] Backend: 557 tests passing (`ctomop_test` local PostgreSQL)
- [x] Frontend: 38 tests passing (Vitest)
- [ ] Manually verify Patients count column shows correct totals on Org Admin list
- [ ] Manually verify Stats tab on Org Admin detail shows disease breakdown
- [ ] Manually verify existing patients with semicolon-joined `later_therapy` display correctly in Treatment tab select

🤖 Generated with [Claude Code](https://claude.com/claude-code)