### PR TITLE
fix: add missing PK/UNIQUE constraints to organization before migration 0097 FKs

### DIFF
--- a/omop_core/migrations/0097_org_management.py
+++ b/omop_core/migrations/0097_org_management.py
@@ -13,6 +13,42 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # Production databases created before this migration may lack a PK or
+        # unique constraint on organization.id / organization.slug because the
+        # original 0061_add_organization migration used CREATE TABLE IF NOT
+        # EXISTS raw SQL, which was silently skipped if the table already
+        # existed without those constraints.  Adding them here (idempotently)
+        # is required before we can create foreign keys that reference
+        # organization.id.
+        migrations.RunSQL(
+            sql="""
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'organization'::regclass AND contype = 'p'
+    ) THEN
+        ALTER TABLE organization ADD PRIMARY KEY (id);
+    END IF;
+END $$;
+""",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql="""
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'organization'::regclass
+          AND conname = 'organization_slug_key'
+    ) THEN
+        ALTER TABLE organization ADD CONSTRAINT organization_slug_key UNIQUE (slug);
+    END IF;
+END $$;
+""",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.AddField(
             model_name="organization",
             name="created_by",


### PR DESCRIPTION
## Summary
- Production database had no PRIMARY KEY or UNIQUE constraint on the `organization` table (the table existed without these constraints before migration 0061 was deployed)
- Migration 0097 failed because it creates FK references to `organization.id`, which requires a unique/PK constraint
- Added idempotent DO $$...$$ blocks at the start of 0097 to add the constraints if missing before the FKs are created

## Root Cause
Migration 0061 used `CREATE TABLE IF NOT EXISTS organization (...)` raw SQL. On the production database the table already existed (without the PK/UNIQUE constraints), so the CREATE TABLE was silently skipped, leaving the table in a degraded state.

## Test plan
- Render deploy should now complete migration 0097 successfully
- Idempotent: safe to run on databases that already have the constraints (staging, local)

Generated with Claude Code