### PR TITLE
Let service-token bypass ACL in ProvenanceMixin + PersonViewSet

### DIFF
--- a/patient_portal/api/authentication.py
+++ b/patient_portal/api/authentication.py
@@ -20,6 +20,7 @@ from rest_framework.exceptions import AuthenticationFailed
 
 from patient_portal.models import Identity
 
+from .permissions import SERVICE_TOKEN
 from .providers import get_providers
 from .providers.base import TokenClaims, decode_jwt_unverified
 
@@ -211,7 +212,7 @@ class ServiceTokenAuthentication(BaseAuthentication):
             identity.set_unusable_password()
             identity.save(update_fields=['password'])
 
-        return (identity, "service-token")
+        return (identity, SERVICE_TOKEN)
 
     def authenticate_header(self, request):
         return "Bearer"

--- a/patient_portal/api/lab_results/sync.py
+++ b/patient_portal/api/lab_results/sync.py
@@ -30,7 +30,7 @@ from omop_core.models import (
     Person, ProvenanceRecord, VisitOccurrence,
 )
 from omop_core.services.pk import next_pk, next_pk_batch
-from patient_portal.api.permissions import LabSyncPermission, get_request_org
+from patient_portal.api.permissions import LabSyncPermission, get_request_org, is_service_token
 
 logger = logging.getLogger(__name__)
 
@@ -182,7 +182,7 @@ class SyncView(APIView):
         # patient cannot impersonate another actor. Trusted service tokens and
         # superusers supply the actor explicitly for server-to-server / admin
         # on-behalf-of writes.
-        is_service = request.auth == 'service-token'
+        is_service = is_service_token(request)
         is_privileged = is_service or getattr(request.user, 'is_superuser', False)
         if not is_privileged and getattr(request.user, 'is_authenticated', False):
             actor_iss = getattr(request.user, 'issuer', '') or ''

--- a/patient_portal/api/permissions.py
+++ b/patient_portal/api/permissions.py
@@ -5,6 +5,15 @@ from rest_framework.permissions import BasePermission
 from .providers.base import TokenClaims
 from omop_core.models import GroupAccess, Organization
 
+# Sentinel value set by ServiceTokenAuthentication when the HMAC check passes.
+# Use is_service_token() rather than comparing this string directly.
+SERVICE_TOKEN = "service-token"
+
+
+def is_service_token(request) -> bool:
+    """Return True when the request was authenticated as a trusted service token."""
+    return request.auth == SERVICE_TOKEN
+
 
 def get_request_org(request):
     """
@@ -53,7 +62,7 @@ class ScopedTokenPermission(BasePermission):
         token = request.auth
 
         # Service-to-service: trusted backend — full access.
-        if token == "service-token":
+        if token == SERVICE_TOKEN:
             return True  # hmac already validated in ServiceTokenAuthentication.authenticate()
 
         # Partner-auth (Firebase, SAML) and session-auth: role-based enforcement.

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -46,7 +46,7 @@ import hashlib
 import json
 import logging
 from io import StringIO
-from .permissions import ScopedTokenPermission, get_request_org
+from .permissions import ScopedTokenPermission, get_request_org, is_service_token
 from .providers.base import TokenClaims
 from .serializers import (
     UserSerializer, PatientInfoSerializer, PatientListSerializer, ProvenanceRecordSerializer,
@@ -159,6 +159,9 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
     
     def get_queryset(self):
         qs = PatientInfo.objects.all().select_related('person', 'organization')
+        # Trusted backend (service-token): full visibility across all patients.
+        if is_service_token(self.request):
+            return qs
         org = get_request_org(self.request)
         if org is not None:
             qs = qs.filter(organization=org)
@@ -2463,9 +2466,10 @@ class PersonViewSet(viewsets.GenericViewSet):
         except (Person.DoesNotExist, ValueError):
             return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
-        # Trusted backend (service-token): skip ACL — already validated at
-        # the permission layer (ScopedTokenPermission).
-        if request.auth != "service-token":
+        # Trusted backend (service-token): skip per-person row-level ACL.
+        # ScopedTokenPermission confirmed the caller holds a valid HMAC-verified
+        # service token. Service tokens have full cross-person write access by design.
+        if not is_service_token(request):
             org = get_request_org(request)
             if org is not None:
                 if not PatientInfo.objects.filter(person=person, organization=org).exists():
@@ -2521,7 +2525,7 @@ class _OmopFilterMixin:
             qs = qs.filter(person_id=person_id)
         # Trusted backend (service-token): full visibility. Already
         # validated at the permission layer (ScopedTokenPermission).
-        if self.request.auth == "service-token":
+        if is_service_token(self.request):
             return qs
         org = get_request_org(self.request)
         if org is not None:
@@ -2570,7 +2574,7 @@ class _ProvenanceMixin:
 
         # Trusted backend (service-token): skip ACL — already validated at
         # the permission layer (ScopedTokenPermission).
-        if self.request.auth == "service-token":
+        if is_service_token(self.request):
             obj = serializer.save()
             self._prov(obj)
             return
@@ -2603,7 +2607,7 @@ class _ProvenanceMixin:
     def perform_update(self, serializer):
         # Trusted backend (service-token): skip ACL — already validated at
         # the permission layer (ScopedTokenPermission).
-        if self.request.auth == "service-token":
+        if is_service_token(self.request):
             obj = serializer.save()
             self._prov(obj)
             return
@@ -2720,6 +2724,9 @@ class EpisodeEventViewSet(viewsets.ModelViewSet):
         episode_id = self.request.query_params.get('episode_id')
         if episode_id:
             qs = qs.filter(episode_id=episode_id)
+        # Trusted backend (service-token): full visibility across all episode events.
+        if is_service_token(self.request):
+            return qs
         # Org / per-patient scoping: EpisodeEvent.episode_id is a bare integer FK to Episode.
         # Resolve allowed episode_ids via the Episode → person → org chain.
         # Bootstrap patients (organization=NULL) are included so that create-path
@@ -2759,6 +2766,10 @@ class EpisodeEventViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+        # Trusted backend (service-token): skip ACL — full cross-patient write access.
+        if is_service_token(self.request):
+            serializer.save()
+            return
         episode_id = serializer.validated_data.get('episode_id')
         org = get_request_org(self.request)
         if org is not None:
@@ -2967,7 +2978,7 @@ class SurveyViewSet(viewsets.ModelViewSet):
         if request.method in ('GET', 'HEAD', 'OPTIONS'):
             return
         token = getattr(request, 'auth', None)
-        if token == 'service-token':
+        if is_service_token(request):
             return
         if token is not None and not isinstance(token, TokenClaims):
             # OAuth2: allow only internal service apps (no org).

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -2463,14 +2463,17 @@ class PersonViewSet(viewsets.GenericViewSet):
         except (Person.DoesNotExist, ValueError):
             return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
-        org = get_request_org(request)
-        if org is not None:
-            if not PatientInfo.objects.filter(person=person, organization=org).exists():
-                return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
-        elif not (getattr(request.user, 'is_superuser', False) or getattr(request.user, 'is_staff', False)):
-            from omop_core.authorization import can_access_patient
-            if not can_access_patient(request.user, person.person_id):
-                return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
+        # Trusted backend (service-token): skip ACL — already validated at
+        # the permission layer (ScopedTokenPermission).
+        if request.auth != "service-token":
+            org = get_request_org(request)
+            if org is not None:
+                if not PatientInfo.objects.filter(person=person, organization=org).exists():
+                    return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
+            elif not (getattr(request.user, 'is_superuser', False) or getattr(request.user, 'is_staff', False)):
+                from omop_core.authorization import can_access_patient
+                if not can_access_patient(request.user, person.person_id):
+                    return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
         changed = []
         for field, (kind, placeholders) in _PERSON_PATCHABLE_FIELDS.items():
@@ -2516,6 +2519,10 @@ class _OmopFilterMixin:
         person_id = self.request.query_params.get('person_id')
         if person_id:
             qs = qs.filter(person_id=person_id)
+        # Trusted backend (service-token): full visibility. Already
+        # validated at the permission layer (ScopedTokenPermission).
+        if self.request.auth == "service-token":
+            return qs
         org = get_request_org(self.request)
         if org is not None:
             from omop_core.models import PatientInfo
@@ -2561,6 +2568,13 @@ class _ProvenanceMixin:
             if pk_field not in serializer.validated_data:
                 serializer.validated_data[pk_field] = next_pk(model_cls, pk_field)
 
+        # Trusted backend (service-token): skip ACL — already validated at
+        # the permission layer (ScopedTokenPermission).
+        if self.request.auth == "service-token":
+            obj = serializer.save()
+            self._prov(obj)
+            return
+
         # Org-scoping: reject cross-org persons; allow new/bootstrap patients
         org = get_request_org(self.request)
         if org is not None:
@@ -2587,6 +2601,13 @@ class _ProvenanceMixin:
         self._prov(obj)
 
     def perform_update(self, serializer):
+        # Trusted backend (service-token): skip ACL — already validated at
+        # the permission layer (ScopedTokenPermission).
+        if self.request.auth == "service-token":
+            obj = serializer.save()
+            self._prov(obj)
+            return
+
         org = get_request_org(self.request)
         if org is not None:
             person = serializer.validated_data.get('person') or serializer.instance.person

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -7419,3 +7419,179 @@ class WearablePatientInfoTest(TestCase):
         anon = AnonClient()
         resp = anon.get(f'/api/patient-info/{self.person.person_id}/')
         self.assertIn(resp.status_code, [401, 403])
+
+
+# ---------------------------------------------------------------------------
+# Service-token ACL bypass integration tests
+# ---------------------------------------------------------------------------
+
+class ServiceTokenOmopAccessTest(TestCase):
+    """
+    Verify that service-token callers bypass row-level ACL checks in:
+      - _OmopFilterMixin.get_queryset  (MeasurementViewSet list/retrieve)
+      - _ProvenanceMixin.perform_create / perform_update  (MeasurementViewSet write)
+      - PersonViewSet.partial_update
+      - EpisodeEventViewSet.get_queryset + perform_create
+      - PatientInfoViewSet.get_queryset
+
+    Each test authenticates with the canonical service identity and
+    token="service-token" (the same sentinel ServiceTokenAuthentication sets).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        _make_vocab_fixtures()
+
+        # Two patients in different orgs so cross-org visibility is meaningful.
+        from omop_core.models import Organization
+        cls.org_a = Organization.objects.create(name='ST Org A', slug='st-org-a')
+        cls.org_b = Organization.objects.create(name='ST Org B', slug='st-org-b')
+
+        cls.person_a = Person.objects.create(person_id=29001)
+        cls.person_b = Person.objects.create(person_id=29002)
+        PatientInfo.objects.create(person=cls.person_a, organization=cls.org_a)
+        PatientInfo.objects.create(person=cls.person_b, organization=cls.org_b)
+
+        # One measurement per patient.
+        m_concept = Concept.objects.get(concept_id=3000963)   # Laboratory test result
+        type_concept = Concept.objects.get(concept_id=32817)  # EHR
+        cls.m_a = Measurement.objects.create(
+            measurement_id=29001,
+            person=cls.person_a,
+            measurement_concept=m_concept,
+            measurement_date=date(2024, 1, 1),
+            measurement_type_concept=type_concept,
+        )
+        cls.m_b = Measurement.objects.create(
+            measurement_id=29002,
+            person=cls.person_b,
+            measurement_concept=m_concept,
+            measurement_date=date(2024, 2, 1),
+            measurement_type_concept=type_concept,
+        )
+
+        # Episode + EpisodeEvent for person_a.
+        ep_concept = Concept.objects.get(concept_id=32531)   # Treatment Regimen
+        cls.ep_a = Episode.objects.create(
+            episode_id=29001,
+            person=cls.person_a,
+            episode_concept=ep_concept,
+            episode_object_concept=type_concept,
+            episode_type_concept=type_concept,
+            episode_start_date=date(2024, 1, 1),
+            episode_number=1,
+            episode_source_value='TEST-LOT',
+        )
+        drug_concept = Concept.objects.get(concept_id=19136160)
+        cls.drug_a = DrugExposure.objects.create(
+            drug_exposure_id=29001,
+            person=cls.person_a,
+            drug_concept=drug_concept,
+            drug_exposure_start_date=date(2024, 1, 1),
+            drug_type_concept=type_concept,
+        )
+        field_concept = Concept.objects.get(concept_id=1147094)
+        cls.ee_a = EpisodeEvent.objects.create(
+            episode_id=cls.ep_a.episode_id,
+            event_id=cls.drug_a.drug_exposure_id,
+            episode_event_field_concept=field_concept,
+        )
+
+        # Service identity — mirrors what ServiceTokenAuthentication creates.
+        cls.service_identity = Identity.objects.get_or_create(
+            issuer='urn:service', sub='hk-labs-sync',
+        )[0]
+        cls.service_identity.set_unusable_password()
+        cls.service_identity.save()
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_authenticate(
+            user=self.service_identity, token="service-token"
+        )
+
+    # --- MeasurementViewSet (via _OmopFilterMixin + _ProvenanceMixin) ---
+
+    def test_service_token_measurement_list_sees_all_orgs(self):
+        """GET /api/measurements/ returns measurements from all orgs."""
+        resp = self.client.get('/api/measurements/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        rows = resp.data['results'] if isinstance(resp.data, dict) else resp.data
+        returned_ids = {r['measurement_id'] for r in rows}
+        self.assertIn(self.m_a.measurement_id, returned_ids)
+        self.assertIn(self.m_b.measurement_id, returned_ids)
+
+    def test_service_token_measurement_create(self):
+        """POST /api/measurements/ creates without org or ACL error."""
+        m_concept = Concept.objects.get(concept_id=3000963)
+        type_concept = Concept.objects.get(concept_id=32817)
+        resp = self.client.post('/api/measurements/', {
+            'person': self.person_a.person_id,
+            'measurement_concept': m_concept.concept_id,
+            'measurement_date': '2024-03-01',
+            'measurement_type_concept': type_concept.concept_id,
+        }, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_service_token_measurement_update(self):
+        """PATCH /api/measurements/{id}/ updates without org ACL error."""
+        resp = self.client.patch(
+            f'/api/measurements/{self.m_a.measurement_id}/',
+            {'value_as_number': 7.5},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.m_a.refresh_from_db()
+        self.assertEqual(float(self.m_a.value_as_number), 7.5)
+
+    # --- PersonViewSet.partial_update ---
+
+    def test_service_token_person_patch_bypasses_acl(self):
+        """PATCH /api/persons/{person_id}/ succeeds without can_access_patient."""
+        resp = self.client.patch(
+            f'/api/persons/{self.person_b.person_id}/',
+            {'given_name': 'ServicePatched'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.person_b.refresh_from_db()
+        self.assertEqual(self.person_b.given_name, 'ServicePatched')
+
+    # --- EpisodeEventViewSet ---
+
+    def test_service_token_episode_event_list(self):
+        """GET /api/episode-events/?episode_id=X returns events without ACL error."""
+        resp = self.client.get(
+            f'/api/episode-events/?episode_id={self.ep_a.episode_id}'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        rows = resp.data['results'] if isinstance(resp.data, dict) else resp.data
+        returned_ids = {r['event_id'] for r in rows}
+        self.assertIn(self.drug_a.drug_exposure_id, returned_ids)
+
+    def test_service_token_episode_event_create(self):
+        """POST /api/episode-events/ creates without PermissionDenied."""
+        drug2 = DrugExposure.objects.create(
+            drug_exposure_id=29099,
+            person=self.person_a,
+            drug_concept=Concept.objects.get(concept_id=19136160),
+            drug_exposure_start_date=date(2024, 4, 1),
+            drug_type_concept=Concept.objects.get(concept_id=32817),
+        )
+        resp = self.client.post('/api/episode-events/', {
+            'episode_id': self.ep_a.episode_id,
+            'event_id': drug2.drug_exposure_id,
+            'episode_event_field_concept': 1147094,
+        }, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    # --- PatientInfoViewSet ---
+
+    def test_service_token_patient_info_list_sees_all_orgs(self):
+        """GET /api/patient-info/ returns patients from all orgs."""
+        resp = self.client.get('/api/patient-info/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        rows = resp.data['results'] if isinstance(resp.data, dict) else resp.data
+        returned_pids = {r['person_id'] for r in rows}
+        self.assertIn(self.person_a.person_id, returned_pids)
+        self.assertIn(self.person_b.person_id, returned_pids)


### PR DESCRIPTION
ScopedTokenPermission.has_permission already returns True for service-token requests, but the row-level ACL checks in _ProvenanceMixin.perform_create / perform_update, _OmopFilterMixin. get_queryset, and PersonViewSet.partial_update ignored that and still required is_superuser/is_staff or can_access_patient, causing every clinical-event write and Person PATCH to 403 for trusted backend callers (healthkey-etl SDK smoke tests hit this).