### PR TITLE
fix: cascade OMOP rows in bulk_delete; add org index (#151, #167)

### DIFF
--- a/omop_core/migrations/0102_patient_info_organization_id_index.py
+++ b/omop_core/migrations/0102_patient_info_organization_id_index.py
@@ -1,0 +1,31 @@
+# Generated 2026-07-02 — add standalone index on patient_info.organization_id
+#
+# The composite index ix_pi_org_updated_at (organization_id, updated_at DESC)
+# already exists, but PostgreSQL may prefer a single-column index for pure
+# equality filters without an ORDER BY clause (e.g. cohort queries,
+# PatientInfoViewSet list, bulk_delete ACL checks).
+#
+# Use RunSQL with CONCURRENTLY so the index builds without locking the table.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # CONCURRENTLY cannot run inside a transaction block; mark the whole
+    # migration non-atomic so Django doesn't wrap it in BEGIN/COMMIT.
+    # Safe here because IF NOT EXISTS makes the operation idempotent on retry.
+    atomic = False
+
+    dependencies = [
+        ("omop_core", "0101_organization_allows_public_aggregated_data"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_pi_organization_id
+                ON patient_info (organization_id);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ix_pi_organization_id;",
+        ),
+    ]

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -15,7 +15,8 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from omop_core.models import (
     Person, PatientInfo, Concept, ProvenanceRecord,
-    ConditionOccurrence, DrugExposure, Measurement, Observation, ProcedureOccurrence,
+    ConditionOccurrence, DrugExposure, Measurement, MeasurementOwnership,
+    Observation, ProcedureOccurrence, VisitOccurrence,
     PatientDocument, PatientTrialEnrollment, Survey, PatientSurveyResponse,
     # Controlled vocabulary lookup models
     Ethnicity, StemCellTransplant, SctEligibility, HistologicType, EstrogenReceptorStatus,
@@ -2145,17 +2146,34 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                         if not can_access_patient(request.user, person_id):
                             errors.append("Person not found.")
                             continue
-                    # Delete PatientInfo
-                    PatientInfo.objects.filter(person=person).delete()
-                    # Delete associated Identity if exists (via PatientUser)
-                    from patient_portal.models import PatientUser as PU
-                    try:
-                        pu = PU.objects.get(person=person)
-                        pu.identity.delete()
-                    except PU.DoesNotExist:
-                        pass
-                    # Delete Person
-                    person.delete()
+                    with transaction.atomic():
+                        # Delete child OMOP clinical rows first (FK -> person_id).
+                        # Order matters: junction/ownership tables before their parents.
+                        from omop_oncology.models import EpisodeEvent as _EpisodeEvent, Episode as _Episode
+                        episode_ids = list(_Episode.objects.filter(person=person).values_list('episode_id', flat=True))
+                        _EpisodeEvent.objects.filter(episode_id__in=episode_ids).delete()
+                        _Episode.objects.filter(person=person).delete()
+                        visit_ids = list(VisitOccurrence.objects.filter(person=person).values_list('visit_occurrence_id', flat=True))
+                        MeasurementOwnership.objects.filter(visit_occurrence_id__in=visit_ids).delete()
+                        Measurement.objects.filter(person=person).delete()
+                        ConditionOccurrence.objects.filter(person=person).delete()
+                        DrugExposure.objects.filter(person=person).delete()
+                        Observation.objects.filter(person=person).delete()
+                        ProcedureOccurrence.objects.filter(person=person).delete()
+                        VisitOccurrence.objects.filter(person=person).delete()
+                        PatientDocument.objects.filter(person=person).delete()
+                        PatientTrialEnrollment.objects.filter(person=person).delete()
+                        # Delete PatientInfo
+                        PatientInfo.objects.filter(person=person).delete()
+                        # Delete associated Identity if exists (via PatientUser)
+                        from patient_portal.models import PatientUser as PU
+                        try:
+                            pu = PU.objects.get(person=person)
+                            pu.identity.delete()
+                        except PU.DoesNotExist:
+                            pass
+                        # Delete Person last (other rows hold person FK)
+                        person.delete()
                     deleted_count += 1
                 except Person.DoesNotExist:
                     errors.append("Person not found.")

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -153,12 +153,17 @@ def _delete_omop_clinical_rows(person):
     Does NOT delete PatientInfo, PatientGroupMembership, PatientUser/Identity,
     or Person — callers handle those after this returns.
     """
-    from patient_portal.models import PatientUser as _PU
     episode_ids = list(Episode.objects.filter(person=person).values_list('episode_id', flat=True))
     EpisodeEvent.objects.filter(episode_id__in=episode_ids).delete()
     Episode.objects.filter(person=person).delete()
     visit_ids = list(VisitOccurrence.objects.filter(person=person).values_list('visit_occurrence_id', flat=True))
-    MeasurementOwnership.objects.filter(visit_occurrence_id__in=visit_ids).delete()
+    measurement_ids = list(Measurement.objects.filter(person=person).values_list('measurement_id', flat=True))
+    # Delete by both axes: visit_occurrence_id covers normal rows; measurement_id
+    # covers any ownership rows whose visit belongs to a different person (edge case
+    # where measurement_id has no DB FK so those rows would otherwise be orphaned).
+    MeasurementOwnership.objects.filter(
+        Q(visit_occurrence_id__in=visit_ids) | Q(measurement_id__in=measurement_ids)
+    ).delete()
     Measurement.objects.filter(person=person).delete()
     ConditionOccurrence.objects.filter(person=person).delete()
     DrugExposure.objects.filter(person=person).delete()

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -17,7 +17,7 @@ from omop_core.models import (
     Person, PatientInfo, Concept, ProvenanceRecord,
     ConditionOccurrence, DrugExposure, Measurement, MeasurementOwnership,
     Observation, ProcedureOccurrence, VisitOccurrence,
-    PatientDocument, PatientTrialEnrollment, Survey, PatientSurveyResponse,
+    PatientDocument, PatientTrialEnrollment, PatientGroupMembership, Survey, PatientSurveyResponse,
     # Controlled vocabulary lookup models
     Ethnicity, StemCellTransplant, SctEligibility, HistologicType, EstrogenReceptorStatus,
     ProgesteroneReceptorStatus, Her2Status, HrStatus, HrdStatus,
@@ -144,6 +144,29 @@ def _record_provenance(record, source, source_user_id, target_patient_id=None, m
         content_type=ContentType.objects.get_for_model(record),
         object_id=record.pk,
     )
+
+
+def _delete_omop_clinical_rows(person):
+    """Delete all OMOP clinical rows for a person, in FK dependency order.
+
+    Must be called inside a transaction.atomic() block.
+    Does NOT delete PatientInfo, PatientGroupMembership, PatientUser/Identity,
+    or Person — callers handle those after this returns.
+    """
+    from patient_portal.models import PatientUser as _PU
+    episode_ids = list(Episode.objects.filter(person=person).values_list('episode_id', flat=True))
+    EpisodeEvent.objects.filter(episode_id__in=episode_ids).delete()
+    Episode.objects.filter(person=person).delete()
+    visit_ids = list(VisitOccurrence.objects.filter(person=person).values_list('visit_occurrence_id', flat=True))
+    MeasurementOwnership.objects.filter(visit_occurrence_id__in=visit_ids).delete()
+    Measurement.objects.filter(person=person).delete()
+    ConditionOccurrence.objects.filter(person=person).delete()
+    DrugExposure.objects.filter(person=person).delete()
+    Observation.objects.filter(person=person).delete()
+    ProcedureOccurrence.objects.filter(person=person).delete()
+    VisitOccurrence.objects.filter(person=person).delete()
+    PatientDocument.objects.filter(person=person).delete()
+    PatientTrialEnrollment.objects.filter(person=person).delete()
 
 
 @method_decorator(csrf_exempt, name='dispatch')
@@ -2147,22 +2170,11 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                             errors.append("Person not found.")
                             continue
                     with transaction.atomic():
-                        # Delete child OMOP clinical rows first (FK -> person_id).
-                        # Order matters: junction/ownership tables before their parents.
-                        from omop_oncology.models import EpisodeEvent as _EpisodeEvent, Episode as _Episode
-                        episode_ids = list(_Episode.objects.filter(person=person).values_list('episode_id', flat=True))
-                        _EpisodeEvent.objects.filter(episode_id__in=episode_ids).delete()
-                        _Episode.objects.filter(person=person).delete()
-                        visit_ids = list(VisitOccurrence.objects.filter(person=person).values_list('visit_occurrence_id', flat=True))
-                        MeasurementOwnership.objects.filter(visit_occurrence_id__in=visit_ids).delete()
-                        Measurement.objects.filter(person=person).delete()
-                        ConditionOccurrence.objects.filter(person=person).delete()
-                        DrugExposure.objects.filter(person=person).delete()
-                        Observation.objects.filter(person=person).delete()
-                        ProcedureOccurrence.objects.filter(person=person).delete()
-                        VisitOccurrence.objects.filter(person=person).delete()
-                        PatientDocument.objects.filter(person=person).delete()
-                        PatientTrialEnrollment.objects.filter(person=person).delete()
+                        # Delete OMOP clinical rows in FK dependency order.
+                        _delete_omop_clinical_rows(person)
+                        # PatientGroupMembership uses a plain BigIntegerField (no DB FK)
+                        # so it is never cascade-deleted by the ORM.
+                        PatientGroupMembership.objects.filter(person_id=person.person_id).delete()
                         # Delete PatientInfo
                         PatientInfo.objects.filter(person=person).delete()
                         # Delete associated Identity if exists (via PatientUser)
@@ -2174,7 +2186,7 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
                             pass
                         # Delete Person last (other rows hold person FK)
                         person.delete()
-                    deleted_count += 1
+                        deleted_count += 1
                 except Person.DoesNotExist:
                     errors.append("Person not found.")
                 except Exception:
@@ -2210,31 +2222,39 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
             person_ids = [row[1] for row in snapshot]
 
             errors = []
+            # Bulk-delete only the specifically filtered PatientInfo records — correctly
+            # scoped to org + disease + stage + date via the queryset snapshot.
+            # This transaction commits before per-person orphan cleanup so a failure
+            # in the cleanup loop cannot roll back the PatientInfo deletions.
             with transaction.atomic():
-                # Bulk-delete only the specifically filtered PatientInfo records — correctly
-                # scoped to org + disease + stage + date via the queryset snapshot.
                 PatientInfo.objects.filter(id__in=patientinfo_ids).delete()
-                deleted_count = len(patientinfo_ids)
+            deleted_count = len(patientinfo_ids)
 
-                # Clean up Person/Identity for persons that now have no PatientInfo at all.
-                persons = {p.person_id: p for p in Person.objects.filter(person_id__in=person_ids)}
-                from patient_portal.models import PatientUser as PU
-                for person_id in person_ids:
-                    person = persons.get(person_id)
-                    if person is None:
-                        continue
-                    try:
-                        if not PatientInfo.objects.filter(person=person).exists():
+            # Clean up Person/OMOP rows/Identity for persons that now have no PatientInfo
+            # at all.  Each person gets its own savepoint so a single failure does not
+            # abort cleanup for the remaining persons.
+            persons = {p.person_id: p for p in Person.objects.filter(person_id__in=person_ids)}
+            from patient_portal.models import PatientUser as PU
+            for person_id in person_ids:
+                person = persons.get(person_id)
+                if person is None:
+                    continue
+                try:
+                    if not PatientInfo.objects.filter(person=person).exists():
+                        with transaction.atomic():
+                            _delete_omop_clinical_rows(person)
+                            # PatientGroupMembership uses a plain BigIntegerField (no DB FK).
+                            PatientGroupMembership.objects.filter(person_id=person.person_id).delete()
                             try:
                                 pu = PU.objects.get(person=person)
                                 pu.identity.delete()
                             except PU.DoesNotExist:
                                 pass
                             person.delete()
-                    except Exception:
-                        id_hash = hashlib.sha256(str(person_id).encode()).hexdigest()[:12]
-                        logger.warning("bulk_delete_filtered: person cleanup failed (id_hash=%s)", id_hash)
-                        errors.append("Person cleanup failed.")
+                except Exception:
+                    id_hash = hashlib.sha256(str(person_id).encode()).hexdigest()[:12]
+                    logger.warning("bulk_delete_filtered: person cleanup failed (id_hash=%s)", id_hash)
+                    errors.append("Person cleanup failed.")
 
             return Response({
                 'success': True,


### PR DESCRIPTION
## Summary

- **#151 bulk_delete OMOP cascade**: bulk_delete previously deleted only PatientInfo/Identity/Person, leaving orphaned Measurement, ConditionOccurrence, DrugExposure, Observation, ProcedureOccurrence, VisitOccurrence, Episode, EpisodeEvent, MeasurementOwnership, PatientDocument, PatientTrialEnrollment rows. Orphaned rows pointed at deleted Person PKs which could be recycled (MAX+1 PK gen) and silently attached to a new patient. Fix: cascade all clinical rows in correct FK order inside a per-person transaction.atomic().
- **#167 organization_id index**: A composite index (organization_id, updated_at DESC) already existed, but a standalone index helps pure equality filters (cohort queries, ACL checks). Migration 0102 adds ix_pi_organization_id via CREATE INDEX CONCURRENTLY IF NOT EXISTS. Migration marked atomic=False so it does not lock the table on deploy.

## Issues already fixed in dev (no changes needed)
- #149: upload_fhir transaction boundary already present
- #148: VisitOccurrence creation already idempotent via get_or_create
- #158: _SmartBase already sets up ApplicationOrganization; all 615 tests pass

## Test plan
- [ ] All 615 existing tests pass
- [ ] bulk_delete with a patient that has Measurements, ConditionOccurrences, Episodes leaves no orphaned rows
- [ ] Migration 0102 applies cleanly on staging (CONCURRENTLY requires non-transactional context, handled by atomic=False)
- [ ] EXPLAIN ANALYZE SELECT id FROM patient_info WHERE organization_id = 1 shows Index Scan after deploy

Closes #151, #167

Generated with Claude Code