### PR TITLE
fix: guard /patient-info/me/ against auto-provisioning non-patient users

### DIFF
--- a/frontend/src/federation/PatientInfo.tsx
+++ b/frontend/src/federation/PatientInfo.tsx
@@ -222,6 +222,14 @@ function PatientInfoInner({ readOnly, onPatientUpdated }: Pick<PatientInfoProps,
   if (isLoading) return <PatientInfoSkeleton />;
 
   if (isError) {
+    const httpStatus = (error as { response?: { status?: number } })?.response?.status;
+    if (httpStatus === 404) {
+      return (
+        <div className="rounded-2xl bg-background p-8 text-center shadow-sm">
+          <p className="text-sm text-gray-500">No patient record linked to this account.</p>
+        </div>
+      );
+    }
     return (
       <div className="rounded-2xl bg-background p-8 text-center shadow-sm">
         <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-400" />

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -544,7 +544,23 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=False, methods=['get', 'patch'], permission_classes=[ScopedTokenPermission])
     def me(self, request):
         """GET/PATCH /api/patient-info/me/ — current user's own PatientInfo."""
+        from patient_portal.models import PatientUser
         from patient_portal.services import resolve_or_create_person
+
+        # Fast path: user already has a confirmed patient record — no creation risk.
+        existing_pu = PatientUser.objects.filter(identity=request.user).select_related('person').first()
+        if existing_pu is None:
+            # Staff and superusers are not patients.
+            if getattr(request.user, 'is_staff', False) or getattr(request.user, 'is_superuser', False):
+                return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
+            # Users with a non-patient org role (doctor/navigator/org_admin) but no
+            # PatientUser are clinical staff, not patients — don't pollute the dataset.
+            from omop_core.models import GroupAccess
+            if GroupAccess.objects.filter(
+                identity=request.user,
+                role__in=['org_admin', 'doctor', 'navigator'],
+            ).exists():
+                return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
         person = resolve_or_create_person(request.user)
         patient_info, _ = PatientInfo.objects.get_or_create(person=person)

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -547,22 +547,30 @@ class PatientInfoViewSet(viewsets.ReadOnlyModelViewSet):
         from patient_portal.models import PatientUser
         from patient_portal.services import resolve_or_create_person
 
-        # Fast path: user already has a confirmed patient record — no creation risk.
+        # Fast path: confirmed patient — use cached person directly, no extra query.
         existing_pu = PatientUser.objects.filter(identity=request.user).select_related('person').first()
-        if existing_pu is None:
-            # Staff and superusers are not patients.
-            if getattr(request.user, 'is_staff', False) or getattr(request.user, 'is_superuser', False):
-                return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
-            # Users with a non-patient org role (doctor/navigator/org_admin) but no
-            # PatientUser are clinical staff, not patients — don't pollute the dataset.
+        if existing_pu is not None:
+            person = existing_pu.person
+        else:
+            # Determine whether this identity may auto-provision a patient record.
+            # Staff/superusers and users with an *active* clinical-role grant are not
+            # patients; resolve_or_create_person skips creation when allow_create=False
+            # but still returns a Person via email match (re-links a deleted PatientUser).
             from omop_core.models import GroupAccess
-            if GroupAccess.objects.filter(
-                identity=request.user,
-                role__in=['org_admin', 'doctor', 'navigator'],
-            ).exists():
+            now = timezone.now()
+            is_clinical = (
+                getattr(request.user, 'is_staff', False)
+                or getattr(request.user, 'is_superuser', False)
+                or GroupAccess.objects.filter(
+                    identity=request.user,
+                    role__in=['org_admin', 'doctor', 'navigator'],
+                ).filter(
+                    Q(expires_at__isnull=True) | Q(expires_at__gt=now)
+                ).exists()
+            )
+            person = resolve_or_create_person(request.user, allow_create=not is_clinical)
+            if person is None:
                 return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
-
-        person = resolve_or_create_person(request.user)
         patient_info, _ = PatientInfo.objects.get_or_create(person=person)
 
         if request.method == 'GET':

--- a/patient_portal/services.py
+++ b/patient_portal/services.py
@@ -12,7 +12,7 @@ from patient_portal.models import PatientUser
 logger = logging.getLogger(__name__)
 
 
-def resolve_or_create_person(identity, email=None):
+def resolve_or_create_person(identity, email=None, allow_create=True):
     """Resolve an existing Person for *identity*, or auto-provision one.
 
     Lookup order:
@@ -20,13 +20,16 @@ def resolve_or_create_person(identity, email=None):
       2. PatientInfo whose email matches
       3. Brand-new Person + PatientUser (+ PatientInfo if email known)
 
-    Returns the linked Person.
+    When allow_create=False, steps 1 and 2 still run (an existing patient is
+    always returned) but step 3 is skipped — returns None instead of creating.
+
+    Returns the linked Person, or None if not found and allow_create=False.
     """
     pu = PatientUser.objects.filter(identity=identity).first()
     if pu:
         return pu.person
 
-    email = (email or identity.email or "").strip()
+    email = (email or getattr(identity, 'email', None) or "").strip()
     if email:
         email_qs = PatientInfo.objects.filter(email=email)
         # Guard against cross-org collision: if multiple patients share the
@@ -43,6 +46,9 @@ def resolve_or_create_person(identity, email=None):
                 defaults={"identity": identity},
             )
             return pi.person
+
+    if not allow_create:
+        return None
 
     try:
         with transaction.atomic():

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -7595,3 +7595,145 @@ class ServiceTokenOmopAccessTest(TestCase):
         returned_pids = {r['person_id'] for r in rows}
         self.assertIn(self.person_a.person_id, returned_pids)
         self.assertIn(self.person_b.person_id, returned_pids)
+
+
+class MeEndpointGuardTest(TestCase):
+    """Tests for the /api/patient-info/me/ auto-provisioning guard (PR #190)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        import datetime
+        from django.utils import timezone as tz
+        from omop_core.models import Organization, GroupAccess
+
+        _make_vocab_fixtures()
+
+        cls.org = Organization.objects.create(name='Guard Test Org', slug='guard-test-org')
+
+        # A confirmed patient: has PatientUser + Person
+        cls.patient_user = Identity.objects.create_user(
+            email='patient_me@test.com', password='pass'
+        )
+        cls.patient_person = Person.objects.create(
+            person_id=88001,
+            year_of_birth=1985,
+            gender_source_value='female',
+            race_source_value='unknown',
+            ethnicity_source_value='unknown',
+        )
+        PatientInfo.objects.create(person=cls.patient_person, organization=cls.org)
+        from patient_portal.models import PatientUser as PU
+        PU.objects.create(identity=cls.patient_user, person=cls.patient_person)
+
+        # Staff user with no patient record
+        cls.staff_user = Identity.objects.create_user(
+            email='staff_me@test.com', password='pass', is_staff=True
+        )
+
+        # Superuser with no patient record
+        cls.super_user = Identity.objects.create_superuser(
+            email='super_me@test.com', password='pass'
+        )
+
+        # org_admin with an active GroupAccess grant
+        cls.org_admin_user = Identity.objects.create_user(
+            email='orgadmin_me@test.com', password='pass'
+        )
+        GroupAccess.objects.create(
+            identity=cls.org_admin_user, org=cls.org, role='org_admin'
+        )
+
+        # doctor with an active GroupAccess grant
+        cls.doctor_user = Identity.objects.create_user(
+            email='doctor_me@test.com', password='pass'
+        )
+        GroupAccess.objects.create(
+            identity=cls.doctor_user, org=cls.org, role='doctor'
+        )
+
+        # navigator with an active GroupAccess grant
+        cls.navigator_user = Identity.objects.create_user(
+            email='navigator_me@test.com', password='pass'
+        )
+        GroupAccess.objects.create(
+            identity=cls.navigator_user, org=cls.org, role='navigator'
+        )
+
+        # Clinical user whose grant is expired — should be allowed through
+        cls.expired_clinical_user = Identity.objects.create_user(
+            email='expired_doc_me@test.com', password='pass'
+        )
+        GroupAccess.objects.create(
+            identity=cls.expired_clinical_user,
+            org=cls.org,
+            role='doctor',
+            expires_at=tz.now() - datetime.timedelta(days=1),
+        )
+
+        # Staff user who is also a patient by email match (PatientUser deleted)
+        cls.staff_patient_user = Identity.objects.create_user(
+            email='staffpatient_me@test.com', password='pass', is_staff=True
+        )
+        staff_patient_person = Person.objects.create(
+            person_id=88002,
+            year_of_birth=1975,
+            gender_source_value='male',
+            race_source_value='unknown',
+            ethnicity_source_value='unknown',
+        )
+        # PatientInfo with matching email exists, but no PatientUser row
+        PatientInfo.objects.create(
+            person=staff_patient_person,
+            email='staffpatient_me@test.com',
+            organization=cls.org,
+        )
+
+    def _client(self, user):
+        c = APIClient()
+        c.force_authenticate(user=user)
+        return c
+
+    def test_confirmed_patient_get_returns_200(self):
+        resp = self._client(self.patient_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('patient_info', resp.data)
+
+    def test_confirmed_patient_patch_returns_200(self):
+        resp = self._client(self.patient_user).patch(
+            '/api/patient-info/me/', {}, format='json'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_staff_without_patient_record_returns_404(self):
+        resp = self._client(self.staff_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_superuser_without_patient_record_returns_404(self):
+        resp = self._client(self.super_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_org_admin_without_patient_record_returns_404(self):
+        resp = self._client(self.org_admin_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_doctor_without_patient_record_returns_404(self):
+        resp = self._client(self.doctor_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_navigator_without_patient_record_returns_404(self):
+        resp = self._client(self.navigator_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_expired_clinical_grant_allows_auto_provisioning(self):
+        """An expired clinical-role grant must not block patient self-registration."""
+        resp = self._client(self.expired_clinical_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_staff_with_email_match_returns_200(self):
+        """Staff user whose email matches a PatientInfo row is re-linked, not blocked."""
+        resp = self._client(self.staff_patient_user).get('/api/patient-info/me/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_unauthenticated_returns_401_or_403(self):
+        resp = APIClient().get('/api/patient-info/me/')
+        self.assertIn(resp.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])


### PR DESCRIPTION
## Summary

- `GET /patient-info/me/` previously called `resolve_or_create_person()` unconditionally for any authenticated user, creating ghost `Person` + `PatientInfo` rows for staff, admins, and doctors
- Added an early-exit guard: staff/superusers get 404; users with `org_admin`/`doctor`/`navigator` GroupAccess but no `PatientUser` get 404
- Users with an existing `PatientUser` (confirmed patients) proceed unchanged; new patients with no elevated role still get auto-provisioned

Closes #155

## Test plan

- [ ] Existing 615 backend tests pass (no regressions)
- [ ] Staff user hitting `/api/patient-info/me/` returns 404, no Person created
- [ ] Org admin user hitting `/api/patient-info/me/` returns 404, no Person created
- [ ] Patient user (has PatientUser) hitting `/api/patient-info/me/` returns 200 with their data
- [ ] New patient user (no PatientUser, no elevated role) gets auto-provisioned on first hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)