### PR TITLE
feat: surface flipi_score_options and later_therapies in UI (closes #14)

### DIFF
--- a/frontend/src/components/PatientInfo/patientConstants.ts
+++ b/frontend/src/components/PatientInfo/patientConstants.ts
@@ -92,6 +92,7 @@ export const HR_OPTIONS = ['HR+', 'HR-', 'HR+ with low expression', 'HR+ with hi
 export const HRD_OPTIONS = ['HRD+', 'HRD-', 'Unknown'];
 export const MENOPAUSAL_OPTIONS = ['Pre-menopausal', 'Peri-menopausal', 'Post-menopausal', 'Unknown'];
 export const FLIPI_RISK_OPTIONS = ['Low', 'Intermediate', 'High'];
+export const FLIPI_FACTOR_OPTIONS = ['Age ≥ 60', 'Stage III/IV', 'Hgb < 12 g/dL', 'Nodal areas > 4', 'Elevated LDH'];
 export const GELF_OPTIONS = ['Met', 'Not Met', 'Unknown'];
 export const FL_TUMOR_GRADE_OPTIONS = [
   'Grade 1 (0–5 centroblasts/HPF)',

--- a/frontend/src/components/PatientInfo/tabs/DiseaseTab.tsx
+++ b/frontend/src/components/PatientInfo/tabs/DiseaseTab.tsx
@@ -10,7 +10,7 @@ import {
   STAGING_MODALITIES_OPTIONS, DISTANT_METASTASIS_STAGE_OPTIONS,
   YES_NO_OPTIONS, ER_OPTIONS, PR_OPTIONS, HER2_OPTIONS, HR_OPTIONS, HRD_OPTIONS,
   DISEASE_OPTIONS,
-  FLIPI_RISK_OPTIONS, GELF_OPTIONS, FL_TUMOR_GRADE_OPTIONS,
+  FLIPI_RISK_OPTIONS, FLIPI_FACTOR_OPTIONS, GELF_OPTIONS, FL_TUMOR_GRADE_OPTIONS,
   ISS_STAGE_OPTIONS, MM_PROGRESSION_OPTIONS, STEM_CELL_TRANSPLANT_OPTIONS, SCT_ELIGIBILITY_OPTIONS,
   MRD_STATUS_OPTIONS, CYTOGENETIC_RISK_OPTIONS,
   BINET_STAGE_OPTIONS, TUMOR_BURDEN_OPTIONS, DISEASE_ACTIVITY_OPTIONS,
@@ -186,6 +186,9 @@ function LymphomaSection({ formData, onChange }: Pick<Props, 'formData' | 'onCha
           <Field label="GELF Criteria" name="gelf_criteria_status" type="select" value={formData?.gelf_criteria_status} options={GELF_OPTIONS} onChange={onChange} vocabSource={gelfSource} />
           <Field label="FLIPI Score" name="flipi_score" type="number" value={formData?.flipi_score} onChange={onChange} />
           <Field label="FLIPI Risk Category" name="flipi_risk_category" type="select" value={formData?.flipi_risk_category} options={FLIPI_RISK_OPTIONS} onChange={onChange} vocabSource={flipiSource} />
+          <div className="sm:col-span-2">
+            <Field label="FLIPI Risk Factors" name="flipi_score_options" type="multiselect" value={formData?.flipi_score_options} options={FLIPI_FACTOR_OPTIONS} onChange={onChange} />
+          </div>
           <Field label="Bulky Disease" name="bulky_disease" type="select" value={formData?.bulky_disease} options={YES_NO_OPTIONS} onChange={onChange} />
           <Field label="B Symptoms" name="b_symptoms" type="select" value={formData?.b_symptoms} options={YES_NO_OPTIONS} onChange={onChange} />
         </div>

--- a/frontend/src/components/PatientInfo/tabs/TreatmentTab.tsx
+++ b/frontend/src/components/PatientInfo/tabs/TreatmentTab.tsx
@@ -11,6 +11,13 @@ import {
   CLL_FIRST_LINE, CLL_SECOND_LINE, CLL_LATER_LINE,
 } from '../patientConstants';
 
+interface LaterTherapy {
+  therapy: string;
+  startDate?: string | null;
+  endDate?: string | null;
+  lineNumber?: number | null;
+}
+
 interface Props {
   formData: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -115,7 +122,7 @@ export default function TreatmentTab({ formData, onChange, diseaseType }: Props)
         </div>
       </Section>}
 
-      {linesCount >= 3 && <Section title="Later Line Therapy">
+      {(linesCount >= 3 || (Array.isArray(formData?.later_therapies) && (formData.later_therapies as LaterTherapy[]).length > 0)) && <Section title="Later Line Therapy">
         <div className="grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
           <div className="sm:col-span-2">
             <Field label="Later Line Therapy" name="later_therapy" type="select"
@@ -129,20 +136,26 @@ export default function TreatmentTab({ formData, onChange, diseaseType }: Props)
           <Field label="Therapy Intent" name="later_intent" type="select" value={formData?.later_intent} options={THERAPY_INTENT_OPTIONS} onChange={onChange} />
           <Field label="Reason for Discontinuation" name="later_discontinuation_reason" type="select" value={formData?.later_discontinuation_reason} options={DISCONTINUATION_REASON_OPTIONS} onChange={onChange} />
           <Field label="Later Line Outcome" name="later_outcome" type="select" value={formData?.later_outcome} options={THERAPY_OUTCOME_OPTIONS} onChange={onChange} />
-          {Array.isArray(formData?.later_therapies) && (formData.later_therapies as Array<{ therapy: string; startDate: string; endDate?: string | null }>).length > 0 && (
-            <div className="sm:col-span-2">
-              <label className="block text-sm font-medium text-gray-700 mb-1">All Later Therapy Lines</label>
-              <ul className="text-sm text-gray-800 space-y-1 pl-1">
-                {(formData.later_therapies as Array<{ therapy: string; startDate: string; endDate?: string | null }>).map((t, i) => (
-                  <li key={i} className="flex gap-2">
-                    <span className="font-medium">Line {i + 3}:</span>
-                    <span>{t.therapy}</span>
-                    <span className="text-gray-500">{t.startDate}{t.endDate ? ` – ${t.endDate}` : ''}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          {(() => {
+            const laterTherapies = Array.isArray(formData?.later_therapies)
+              ? (formData.later_therapies as LaterTherapy[])
+              : [];
+            if (!laterTherapies.length) return null;
+            return (
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium text-portal-text-primary mb-1">All Later Therapy Lines</label>
+                <ul className="text-sm text-portal-text-primary space-y-1 pl-1">
+                  {laterTherapies.map((t) => (
+                    <li key={`${t.startDate ?? ''}-${t.therapy}`} className="flex gap-2">
+                      <span className="font-medium">Line {t.lineNumber ?? 3}:</span>
+                      <span>{t.therapy}</span>
+                      <span className="text-portal-text-secondary">{t.startDate}{t.endDate ? ` – ${t.endDate}` : ''}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })()}
         </div>
       </Section>}
 

--- a/frontend/src/components/PatientInfo/tabs/TreatmentTab.tsx
+++ b/frontend/src/components/PatientInfo/tabs/TreatmentTab.tsx
@@ -129,6 +129,20 @@ export default function TreatmentTab({ formData, onChange, diseaseType }: Props)
           <Field label="Therapy Intent" name="later_intent" type="select" value={formData?.later_intent} options={THERAPY_INTENT_OPTIONS} onChange={onChange} />
           <Field label="Reason for Discontinuation" name="later_discontinuation_reason" type="select" value={formData?.later_discontinuation_reason} options={DISCONTINUATION_REASON_OPTIONS} onChange={onChange} />
           <Field label="Later Line Outcome" name="later_outcome" type="select" value={formData?.later_outcome} options={THERAPY_OUTCOME_OPTIONS} onChange={onChange} />
+          {Array.isArray(formData?.later_therapies) && (formData.later_therapies as Array<{ therapy: string; startDate: string; endDate?: string | null }>).length > 0 && (
+            <div className="sm:col-span-2">
+              <label className="block text-sm font-medium text-gray-700 mb-1">All Later Therapy Lines</label>
+              <ul className="text-sm text-gray-800 space-y-1 pl-1">
+                {(formData.later_therapies as Array<{ therapy: string; startDate: string; endDate?: string | null }>).map((t, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span className="font-medium">Line {i + 3}:</span>
+                    <span>{t.therapy}</span>
+                    <span className="text-gray-500">{t.startDate}{t.endDate ? ` – ${t.endDate}` : ''}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </Section>}
 

--- a/frontend/src/types/patient.ts
+++ b/frontend/src/types/patient.ts
@@ -82,7 +82,7 @@ export interface PatientInfo {
   second_line_outcome?: string;
   later_therapy?: string;
   later_line_therapy?: string;  // UI uses this name
-  later_therapies?: Array<{ therapy: string; startDate: string; endDate?: string | null }> | null;
+  later_therapies?: Array<{ therapy: string; startDate?: string | null; endDate?: string | null; lineNumber?: number | null }> | null;
   // HemOnc concept_id fields
   first_line_therapy_id?: number | null;
   second_line_therapy_id?: number | null;

--- a/frontend/src/types/patient.ts
+++ b/frontend/src/types/patient.ts
@@ -36,6 +36,7 @@ export interface PatientInfo {
   // Follicular Lymphoma specific
   gelf_criteria?: string;
   flipi_score?: number;
+  flipi_score_options?: string;
   tumor_grade?: string;
   
   // Multiple Myeloma specific
@@ -81,6 +82,7 @@ export interface PatientInfo {
   second_line_outcome?: string;
   later_therapy?: string;
   later_line_therapy?: string;  // UI uses this name
+  later_therapies?: Array<{ therapy: string; startDate: string; endDate?: string | null }> | null;
   // HemOnc concept_id fields
   first_line_therapy_id?: number | null;
   second_line_therapy_id?: number | null;


### PR DESCRIPTION
## Summary

Closes #14. Two `PatientInfo` fields were genuinely missing from the frontend — the other 26 fields listed in the issue were already present in `DiseaseTab`, `TreatmentTab`, or the CLL section.

- **`flipi_score_options`** — added to the FL section of `DiseaseTab` as a full-width multiselect of the five standard FLIPI adverse risk factors (Age ≥ 60, Stage III/IV, Hgb < 12 g/dL, Nodal areas > 4, Elevated LDH). Follows the same TextField-backed multiselect pattern as `protein_expressions` and `gelf_criteria_status`.
- **`later_therapies`** — added as a structured read-only list in the Later Line Therapy section of `TreatmentTab`, showing all later lines (3+) with start/end dates from the backend-computed JSONField populated by `patient_info_service`.

Fields not addressed: `status` (computed Python property, not a model column) and `language_skills` (a separate `PersonLanguageSkill` relation, not a `PatientInfo` field).

## Code review fixes applied

A code review was run before this PR was opened. Findings addressed in the second commit:

| Finding | Fix |
|---|---|
| `later_therapies` hidden when episode ingest path populates it without setting `therapy_lines_count` | Widened section gate: `linesCount >= 3 \|\| laterTherapies.length > 0` |
| Inline type cast written twice | Hoisted `LaterTherapy` interface and typed local variable |
| `key={i}` index-based React key | Changed to stable `startDate+therapy` composite key |
| Hardcoded `text-gray-700`/`text-gray-800` | Changed to `text-portal-text-primary`/`text-portal-text-secondary` design tokens |
| `startDate` typed as required but can be null from backend | Relaxed to optional in `LaterTherapy` interface |

## Test plan

- [ ] Open a Follicular Lymphoma patient — FLIPI Risk Factors multiselect appears after FLIPI Score, selections round-trip as comma-separated string
- [ ] Open a patient whose `later_therapies` JSONField was populated via the episode ingest path (not just `therapy_lines_count`) — "All Later Therapy Lines" section renders correctly even if `therapy_lines_count` is not set
- [ ] Open a patient with `later_therapies = []` — the list does not render

🤖 Generated with [Claude Code](https://claude.com/claude-code)