### PR TITLE
fix: make death_date migration idempotent

### DIFF
--- a/omop_core/migrations/0110_patientrecord_death_date.py
+++ b/omop_core/migrations/0110_patientrecord_death_date.py
@@ -8,13 +8,26 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name='patientrecord',
-            name='death_date',
-            field=models.DateField(
-                blank=True,
-                help_text='Date of death (from OMOP Death)',
-                null=True,
-            ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        'ALTER TABLE patient_record '
+                        'ADD COLUMN IF NOT EXISTS death_date date NULL'
+                    ),
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name='patientrecord',
+                    name='death_date',
+                    field=models.DateField(
+                        blank=True,
+                        help_text='Date of death (from OMOP Death)',
+                        null=True,
+                    ),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary
- make omop_core.0110 add patient_record.death_date with ADD COLUMN IF NOT EXISTS
- preserve Django migration state with SeparateDatabaseAndState so existing Render DB columns do not break deploys

## Validation
- DEBUG=True DATABASE_URL=postgresql://postgres@localhost:5432/promop_test .venv/bin/python manage.py makemigrations --check --dry-run
- DEBUG=True DATABASE_URL=postgresql://postgres@localhost:5432/promop_test .venv/bin/python manage.py check