### PR TITLE
Remove hosting URLs from CLAUDE.md (public repo hygiene)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,12 +653,10 @@ If `remoteEntry.js` returns 500 on staging, check that `WHITENOISE_ROOT` points 
 
 ## Deployment
 
-- **Render service**: `https://promop.onrender.com`
 - **`start.sh`** runs `python manage.py migrate` on every deploy — so migrations pushed to `main` are auto-applied on next Render deploy.
 - **Push to `main`** triggers deploy (once Render GitHub App access is granted in dashboard).
 - **Admin credentials**: set via `ADMIN_EMAIL` / `ADMIN_PASSWORD` env vars on Render (no hardcoded default)
-- **Render DB internal hostname**: `dpg-d6ptpqi4d50c739fufqg-a` (only reachable from Render)
-- **Render DB external hostname**: `dpg-d6ptpqi4d50c739fufqg-a.oregon-postgres.render.com`
+- **Hostnames and connection strings**: do not commit them — this is a public repo. Service URLs and database hostnames live in `.env` and the Render/GCP dashboards.
 
 ## Database Selection Rule
 


### PR DESCRIPTION
## Summary
- Removes the Render service URL and Render DB internal/external hostnames from CLAUDE.md's Deployment section (repo is public)
- Replaces them with an explicit rule: hostnames/connection strings live in `.env` and the Render/GCP dashboards, never in the repo
- Verified no other tracked files contain `dpg-`/`onrender.com` references

## Test plan
- [x] Backend suite: 747 tests OK (local PostgreSQL)
- [x] Frontend suite: 54 tests OK
- [x] Docs-only change, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
