### PR TITLE
fix(fhir): stop minting synthetic HemOnc concepts on import (#246)

### DIFF
--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -18,7 +18,7 @@ from omop_core.models import (
     ConditionOccurrence, DrugExposure, Measurement, MeasurementOwnership,
     Observation, ProcedureOccurrence, VisitOccurrence, VisitDetail, Location, Death,
     PatientDocument, PatientTrialEnrollment, PatientGroupMembership, Survey, PatientSurveyResponse,
-    Relationship, ConceptRelationship, ConceptAncestor,
+    Relationship, ConceptRelationship, ConceptAncestor, ConceptSynonym,
     # Controlled vocabulary lookup models
     Ethnicity, StemCellTransplant, SctEligibility, HistologicType, EstrogenReceptorStatus,
     ProgesteroneReceptorStatus, Her2Status, HrStatus, HrdStatus,
@@ -2427,27 +2427,69 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                         name = (name or '').strip()
                         if not name:
                             return None
+
+                        # 1) Prefer a real, licensed HemOnc Regimen concept by name
+                        #    (exact concept_name, then synonym alias). Never mint a
+                        #    synthetic concept when the genuine one exists. Exclude
+                        #    locally-minted `FHIR-*` rows and invalid concepts so a
+                        #    previously-minted synthetic concept is never re-blessed
+                        #    as if it were licensed content.
+                        real = Concept.objects.filter(
+                            vocabulary_id='HemOnc',
+                            concept_class_id='Regimen',
+                            standard_concept='S',
+                            invalid_reason__isnull=True,
+                            concept_name__iexact=name,
+                        ).exclude(concept_code__startswith='FHIR-').first()
+                        if real is None:
+                            syn = ConceptSynonym.objects.filter(
+                                concept_synonym_name__iexact=name,
+                                concept__vocabulary_id='HemOnc',
+                                concept__concept_class_id='Regimen',
+                                concept__standard_concept='S',
+                                concept__invalid_reason__isnull=True,
+                            ).exclude(
+                                concept__concept_code__startswith='FHIR-'
+                            ).select_related('concept').first()
+                            real = syn.concept if syn else None
+                        if real is not None:
+                            return real
+
+                        # 2) No licensed match — quarantine under a DISTINCT local
+                        #    vocabulary id, NON-standard, so a consumer caching promop's
+                        #    HemOnc cannot mistake it for licensed Athena content. The
+                        #    unmapped name is logged for the mapping-gap report (promop#246).
                         code = 'FHIR-' + ''.join(ch.upper() if ch.isalnum() else '-' for ch in name)
                         while '--' in code:
                             code = code.replace('--', '-')
                         code = code.strip('-')[:50]
 
                         concept = Concept.objects.filter(
-                            vocabulary_id='HemOnc',
+                            vocabulary_id='PROMOP_LOCAL',
                             concept_code=code,
                         ).first()
                         if concept:
                             return concept
+
+                        # Emit valid JSON (json.dumps escapes quotes/backslashes in
+                        # the regimen name) — this line is the source for the
+                        # mapping-gap report (promop#246).
+                        logger.warning('%s', json.dumps({
+                            'event': 'regimen_unmapped_local_mint',
+                            'name': name,
+                            'vocabulary_id': 'PROMOP_LOCAL',
+                            'concept_code': code,
+                        }))
 
                         domain, _ = Domain.objects.get_or_create(
                             domain_id='Drug',
                             defaults={'domain_name': 'Drug', 'domain_concept_id': 13},
                         )
                         vocabulary, _ = Vocabulary.objects.get_or_create(
-                            vocabulary_id='HemOnc',
+                            vocabulary_id='PROMOP_LOCAL',
                             defaults={
-                                'vocabulary_name': 'HemOnc',
-                                'vocabulary_reference': 'FHIR import',
+                                'vocabulary_name': 'promop local (unmapped FHIR regimens)',
+                                'vocabulary_reference': 'FHIR import — no licensed HemOnc match',
                                 'vocabulary_version': 'local',
                                 'vocabulary_concept_id': 0,
                             },
@@ -2462,7 +2504,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                             domain=domain,
                             vocabulary=vocabulary,
                             concept_class=concept_class,
-                            standard_concept='S',
+                            standard_concept=None,  # local, NOT licensed HemOnc
                             concept_code=code,
                             valid_start_date=datetime(1970, 1, 1).date(),
                             valid_end_date=datetime(2099, 12, 31).date(),

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -9607,3 +9607,160 @@ class MCODECreatinineLoincTest(FhirUploadBase):
         self.assertIsNotNone(self._pi.serum_creatinine_mg_dl,
                              'serum_creatinine_mg_dl not populated from LOINC 38483-4')
         self.assertAlmostEqual(float(self._pi.serum_creatinine_mg_dl), 1.1, places=1)
+
+
+class FhirRegimenMintingTest(FhirUploadBase):
+    """promop#246 — FHIR import must never mint synthetic concepts under the
+    licensed ``HemOnc`` vocabulary. Unmatched regimen names are quarantined under
+    a distinct local vocabulary (non-standard); genuine HemOnc regimens are
+    reused rather than re-minted."""
+
+    def test_unmatched_regimen_not_minted_under_hemonc(self):
+        resp = self._upload_bundle()
+        self.assertIn(resp.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED],
+                      msg=f'Upload failed: {resp.data}')
+        from omop_core.models import Concept
+        # Core guard: no synthetic FHIR-* concept under licensed HemOnc.
+        self.assertFalse(
+            Concept.objects.filter(
+                vocabulary_id='HemOnc', concept_code__startswith='FHIR-'
+            ).exists(),
+            'FHIR import minted a synthetic concept under vocabulary_id=HemOnc (cache poisoning)',
+        )
+        # 'AC-T' looks like a regimen but has no licensed match → quarantined locally.
+        local = Concept.objects.filter(
+            vocabulary_id='PROMOP_LOCAL', concept_code='FHIR-AC-T'
+        ).first()
+        self.assertIsNotNone(local, 'Unmatched regimen was not quarantined under PROMOP_LOCAL')
+        self.assertIsNone(local.standard_concept, 'Quarantined local concept must be non-standard')
+
+    def test_genuine_hemonc_regimen_reused_via_synonym(self):
+        from omop_core.models import (
+            Concept, ConceptClass, Vocabulary, Domain, ConceptSynonym, DrugExposure,
+        )
+        # Seed a licensed HemOnc Regimen concept whose synonym is the bundle's 'AC-T'.
+        hemonc, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id='HemOnc',
+            defaults={'vocabulary_name': 'HemOnc', 'vocabulary_concept_id': 0},
+        )
+        regimen_class, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Regimen',
+            defaults={'concept_class_name': 'Regimen', 'concept_class_concept_id': 0},
+        )
+        drug = Domain.objects.get(domain_id='Drug')
+        real = Concept.objects.create(
+            concept_id=35800001,
+            concept_name='Doxorubicin and Cyclophosphamide followed by Paclitaxel',
+            domain=drug, vocabulary=hemonc, concept_class=regimen_class,
+            standard_concept='S', concept_code='HemOnc-ACT',
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31),
+        )
+        ConceptSynonym.objects.create(
+            concept=real, concept_synonym_name='AC-T', language_concept=real,
+        )
+
+        resp = self._upload_bundle()
+        self.assertIn(resp.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED],
+                      msg=f'Upload failed: {resp.data}')
+
+        # Genuine concept reused — nothing minted locally or under HemOnc.
+        self.assertFalse(
+            Concept.objects.filter(
+                vocabulary_id='PROMOP_LOCAL', concept_code='FHIR-AC-T'
+            ).exists(),
+            'A licensed HemOnc match existed but the regimen was still minted locally',
+        )
+        self.assertFalse(
+            Concept.objects.filter(
+                vocabulary_id='HemOnc', concept_code__startswith='FHIR-'
+            ).exists(),
+        )
+        # The AC-T DrugExposure resolved to the genuine HemOnc concept.
+        person = self._get_person()
+        self.assertTrue(
+            DrugExposure.objects.filter(person=person, drug_concept=real).exists(),
+            'AC-T DrugExposure did not resolve to the genuine HemOnc concept',
+        )
+
+    def test_genuine_hemonc_regimen_reused_via_exact_name(self):
+        from omop_core.models import (
+            Concept, ConceptClass, Vocabulary, Domain, DrugExposure,
+        )
+        hemonc, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id='HemOnc',
+            defaults={'vocabulary_name': 'HemOnc', 'vocabulary_concept_id': 0},
+        )
+        regimen_class, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Regimen',
+            defaults={'concept_class_name': 'Regimen', 'concept_class_concept_id': 0},
+        )
+        drug = Domain.objects.get(domain_id='Drug')
+        real = Concept.objects.create(
+            concept_id=35800002, concept_name='AC-T',
+            domain=drug, vocabulary=hemonc, concept_class=regimen_class,
+            standard_concept='S', concept_code='HemOnc-9001',
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31),
+        )
+        resp = self._upload_bundle()
+        self.assertIn(resp.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED],
+                      msg=f'Upload failed: {resp.data}')
+        self.assertFalse(
+            Concept.objects.filter(
+                vocabulary_id='PROMOP_LOCAL', concept_code='FHIR-AC-T'
+            ).exists(),
+            'Exact-name HemOnc match existed but the regimen was still minted locally',
+        )
+        person = self._get_person()
+        self.assertTrue(
+            DrugExposure.objects.filter(person=person, drug_concept=real).exists(),
+        )
+
+    def test_legacy_hemonc_fhir_row_not_treated_as_genuine(self):
+        """A pre-existing poisoned `HemOnc`/`FHIR-*` row must NOT be re-blessed as a
+        genuine match — the regimen is quarantined under PROMOP_LOCAL instead."""
+        from omop_core.models import (
+            Concept, ConceptClass, Vocabulary, Domain, DrugExposure,
+        )
+        hemonc, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id='HemOnc',
+            defaults={'vocabulary_name': 'HemOnc', 'vocabulary_concept_id': 0},
+        )
+        regimen_class, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Regimen',
+            defaults={'concept_class_name': 'Regimen', 'concept_class_concept_id': 0},
+        )
+        drug = Domain.objects.get(domain_id='Drug')
+        poisoned = Concept.objects.create(
+            concept_id=35800003, concept_name='AC-T',
+            domain=drug, vocabulary=hemonc, concept_class=regimen_class,
+            standard_concept='S', concept_code='FHIR-AC-T',
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31),
+        )
+        resp = self._upload_bundle()
+        self.assertIn(resp.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED],
+                      msg=f'Upload failed: {resp.data}')
+        local = Concept.objects.filter(
+            vocabulary_id='PROMOP_LOCAL', concept_code='FHIR-AC-T'
+        ).first()
+        self.assertIsNotNone(local, 'Regimen was not quarantined despite only a poisoned match existing')
+        person = self._get_person()
+        self.assertTrue(
+            DrugExposure.objects.filter(person=person, drug_concept=local).exists(),
+            'AC-T resolved to the poisoned HemOnc row instead of the local quarantine',
+        )
+        self.assertFalse(
+            DrugExposure.objects.filter(person=person, drug_concept=poisoned).exists(),
+            'AC-T was re-blessed to the legacy poisoned HemOnc concept',
+        )
+
+    def test_reupload_does_not_duplicate_local_concept(self):
+        from omop_core.models import Concept
+        self._upload_bundle()
+        self._upload_bundle()
+        self.assertEqual(
+            Concept.objects.filter(
+                vocabulary_id='PROMOP_LOCAL', concept_code='FHIR-AC-T'
+            ).count(),
+            1,
+            'Re-upload duplicated the quarantined local concept',
+        )


### PR DESCRIPTION
Closes #246. Part of #238 (vocabulary source of truth), per [ADR 0001](https://github.com/healthkey-ai/promop/blob/dev/docs/adr/0001-vocabulary-source-of-truth.md).

## Problem
FHIR import minted local `Concept` rows under the **licensed** `vocabulary_id='HemOnc'` with `FHIR-*` codes for regimen names lacking an embedded HemOnc concept_id — and did so **before** trying to match a genuine HemOnc regimen by name (so `RVD`/`AC-T` could become `FHIR-*` even when the real concept exists). A consumer caching promop's HemOnc cannot distinguish these from licensed Athena content — cache poisoning, and a blocker for publishing HemOnc as the source of truth.

## Change
`_get_or_create_local_regimen_concept` (`patient_portal/api/views.py`) now:
1. **Resolves a genuine HemOnc `Regimen` concept first** — exact `concept_name`, then `ConceptSynonym` alias — requiring `standard_concept='S'`, `invalid_reason IS NULL`, and **excluding `FHIR-*` codes** so a previously-minted synthetic row is never re-blessed as licensed.
2. **Quarantines** an unmatched name under a distinct local vocabulary `vocabulary_id='PROMOP_LOCAL'`, **non-standard** (`standard_concept=None`), so it can never be mistaken for licensed HemOnc.
3. **WARNING-logs** each unmapped mint (`{"event":"regimen_unmapped_local_mint",...}`) as the source for the mapping-gap report.

## Review findings addressed (Claude fresh-context + Codex)
- **[P1, Codex]** genuine-match was matching legacy `HemOnc/FHIR-*` poisoned rows → now excluded via `.exclude(concept_code__startswith='FHIR-')` + `invalid_reason IS NULL` (both name and synonym paths). Covered by `test_legacy_hemonc_fhir_row_not_treated_as_genuine`.
- **[P2]** synonym path now also requires `standard_concept='S'` / non-invalid (consistency with the exact-name path).
- Note: `(vocabulary_id, concept_code)` already has a unique index, so the filter+create mint is DB-dedup safe; re-upload is idempotent (`test_reupload_does_not_duplicate_local_concept`).

## Tests (5, full `patient_portal` suite green — 589 tests)
genuine reuse via synonym + via exact name; unmatched → PROMOP_LOCAL non-standard; legacy poisoned row not re-blessed; re-upload idempotent.

## Follow-ups (out of scope — same anti-pattern, separate tickets)
- `omop_core/management/commands/enrich_breast_cancer_omop_data.py:196` still mints HemOnc regimen concepts (synthetic benchmark/dev tool, not the FHIR-import path).
- `_get_or_create_local_concept` / procedure / visit mint sites create synthetic standard concepts under RxNorm/SNOMED/LOINC/CVX (HemOnc is now protected; other vocabs are not).
- A data migration to **remap + remove existing** poisoned `HemOnc/FHIR-*` rows already in staging/prod (this PR stops new poisoning and stops trusting old rows, but does not delete them).
