### PR TITLE
feat(api): include vocabulary_version in concept responses (#240)

### DIFF
--- a/API_SURFACE.md
+++ b/API_SURFACE.md
@@ -351,6 +351,7 @@ Response:
       "concept_name": "HER2 inhibitor",
       "concept_code": "CLASS-HER2",
       "vocabulary_id": "HemOnc",
+      "vocabulary_version": "HemOnc 2024-12-19",
       "concept_class_id": "Drug Class",
       "domain_id": "Drug",
       "standard_concept": null,
@@ -394,6 +395,7 @@ Response:
       "concept_name": "trastuzumab",
       "concept_code": "RX-TRAST",
       "vocabulary_id": "RxNorm",
+      "vocabulary_version": "RxNorm 2024-09-03",
       "concept_class_id": "Ingredient",
       "domain_id": "Drug",
       "standard_concept": null,
@@ -443,6 +445,7 @@ Response:
         "concept_name": "trastuzumab",
         "concept_code": "RX-TRAST",
         "vocabulary_id": "RxNorm",
+        "vocabulary_version": "RxNorm 2024-09-03",
         "concept_class_id": "Ingredient",
         "domain_id": "Drug",
         "standard_concept": null,
@@ -595,6 +598,15 @@ GET /api/v1/concepts/lookup/?lookup=LOINC:2160-0&lookup=LOINC:2345-7&lookup=SNOM
 
 Unknown codes return `null`. Requires `patient/*.read` scope (read-only).
 
+**Opt-in `?include_versions=1`** — adds a top-level `_vocabulary_versions` map (release/version per requested vocabulary) so consumers can pin a release and detect drift. The default `{vocab: {code: id}}` shape is unchanged (phr-etl reads `result[vocab][code]`), so this is additive and off by default.
+```json
+{
+  "LOINC":  { "2160-0": 3013682 },
+  "SNOMED": { "44054006": 201826 },
+  "_vocabulary_versions": { "LOINC": "LOINC 2.77", "SNOMED": "SNOMED 2024-09-01" }
+}
+```
+
 **Response 400** — no `lookup` params supplied, or a param is missing the `:` separator.
 
 ---
@@ -633,6 +645,7 @@ GET /api/v1/concepts/search/?q=creatinine&vocabulary_id=LOINC&domain_id=Measurem
       "concept_id": 3016723,
       "concept_name": "Creatinine [Mass/volume] in Serum or Plasma",
       "vocabulary_id": "LOINC",
+      "vocabulary_version": "LOINC 2.77",
       "concept_code": "2160-0",
       "domain_id": "Measurement",
       "concept_class_id": "Lab Test",
@@ -685,6 +698,7 @@ GET /api/v1/concepts/?domain_id=Measurement&concept_class_id=Lab%20Test&page_siz
       "concept_id": 3016723,
       "concept_name": "Creatinine [Mass/volume] in Serum or Plasma",
       "vocabulary_id": "LOINC",
+      "vocabulary_version": "LOINC 2.77",
       "concept_code": "2160-0",
       "domain_id": "Measurement",
       "concept_class_id": "Lab Test",

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -3874,11 +3874,15 @@ def concept_lookup(request):
 
     Query params (repeatable):
         lookup=VOCAB_ID:concept_code
+        include_versions=1   (optional) — also return a top-level
+                             `_vocabulary_versions` map {vocab_id: version}
 
     Response 200:
         { "LOINC": { "2160-0": 3013682, "2345-7": null }, "SNOMED": { ... } }
 
     Unknown codes return null; healthkey-etl substitutes concept_id=0 downstream.
+    The default `{vocab: {code: id}}` shape is frozen; `include_versions=1` is
+    additive so consumers can pin a vocabulary release / detect drift (promop#240).
     """
     from omop_core.models import Concept as OmopConcept
 
@@ -3919,6 +3923,16 @@ def concept_lookup(request):
         if v in result and c in result[v]:
             result[v][c] = cid
 
+    # Opt-in: add a top-level `_vocabulary_versions` map so consumers can pin a
+    # release / detect drift (promop#240). Off by default to keep the frozen
+    # `{vocab: {code: id}}` shape that healthkey-etl reads.
+    if request.query_params.get('include_versions') in ('1', 'true', 'True', 'yes') \
+            and '_vocabulary_versions' not in result:
+        # Guard: never clobber a user-requested vocabulary bucket that happens to
+        # be literally named `_vocabulary_versions` (not a real OMOP vocab id).
+        version_map = _vocab_version_map()
+        result['_vocabulary_versions'] = {v: version_map.get(v) for v in by_vocab}
+
     return Response(result)
 
 
@@ -3948,12 +3962,21 @@ def _concept_graph_filters(request):
     return relationship_ids, vocabulary_ids, concept_class_ids, max_levels
 
 
-def _serialize_concept_graph_node(concept, **extra):
+def _vocab_version_map():
+    """``{vocabulary_id: vocabulary_version}`` for every vocabulary (small table,
+    one query). Lets concept responses carry the release/version each concept
+    came from, so consumers can pin a release and detect drift (promop#240)."""
+    from omop_core.models import Vocabulary
+    return dict(Vocabulary.objects.values_list('vocabulary_id', 'vocabulary_version'))
+
+
+def _serialize_concept_graph_node(concept, versions=None, **extra):
     payload = {
         'concept_id': concept.concept_id,
         'concept_name': concept.concept_name,
         'concept_code': concept.concept_code,
         'vocabulary_id': concept.vocabulary_id,
+        'vocabulary_version': (versions or {}).get(concept.vocabulary_id),
         'concept_class_id': concept.concept_class_id,
         'domain_id': concept.domain_id,
         'standard_concept': concept.standard_concept,
@@ -3978,6 +4001,7 @@ def _query_concept_graph(source_ids, direction, relationship_ids, vocabulary_ids
     """
     grouped = {source_id: [] for source_id in source_ids}
     truncated = set()
+    versions = _vocab_version_map()
 
     def _append(source_id, node):
         bucket = grouped[source_id]
@@ -4011,6 +4035,7 @@ def _query_concept_graph(source_ids, direction, relationship_ids, vocabulary_ids
                 'concept_2_id',
                 lambda edge: _serialize_concept_graph_node(
                     edge.concept_1,
+                    versions=versions,
                     relationship_id=edge.relationship_id,
                     min_levels_of_separation=None,
                     max_levels_of_separation=None,
@@ -4027,6 +4052,7 @@ def _query_concept_graph(source_ids, direction, relationship_ids, vocabulary_ids
                 'concept_1_id',
                 lambda edge: _serialize_concept_graph_node(
                     edge.concept_2,
+                    versions=versions,
                     relationship_id=edge.relationship_id,
                     min_levels_of_separation=None,
                     max_levels_of_separation=None,
@@ -4050,6 +4076,7 @@ def _query_concept_graph(source_ids, direction, relationship_ids, vocabulary_ids
             'descendant_concept_id',
             lambda edge: _serialize_concept_graph_node(
                 edge.ancestor_concept,
+                versions=versions,
                 relationship_id=None,
                 min_levels_of_separation=edge.min_levels_of_separation,
                 max_levels_of_separation=edge.max_levels_of_separation,
@@ -4070,6 +4097,7 @@ def _query_concept_graph(source_ids, direction, relationship_ids, vocabulary_ids
             'ancestor_concept_id',
             lambda edge: _serialize_concept_graph_node(
                 edge.descendant_concept,
+                versions=versions,
                 relationship_id=None,
                 min_levels_of_separation=edge.min_levels_of_separation,
                 max_levels_of_separation=edge.max_levels_of_separation,
@@ -4200,11 +4228,12 @@ def _apply_concept_filters(queryset, query_params):
     return queryset
 
 
-def _serialize_concept(concept):
+def _serialize_concept(concept, versions=None):
     return {
         'concept_id': concept.concept_id,
         'concept_name': concept.concept_name,
         'vocabulary_id': concept.vocabulary_id,
+        'vocabulary_version': (versions or {}).get(concept.vocabulary_id),
         'concept_code': concept.concept_code,
         'domain_id': concept.domain_id,
         'concept_class_id': concept.concept_class_id,
@@ -4218,7 +4247,8 @@ def _paginated_concept_response(queryset, request):
     # the matched set on every page request.
     paginator = ConceptPagination()
     page = paginator.paginate_queryset(queryset.order_by('concept_id'), request)
-    return paginator.get_paginated_response([_serialize_concept(c) for c in page])
+    versions = _vocab_version_map()
+    return paginator.get_paginated_response([_serialize_concept(c, versions) for c in page])
 
 
 @api_view(['GET'])

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -6095,6 +6095,33 @@ class ConceptLookupTest(_SmartBase):
         resp = self.client.get(f'{self.URL}?lookup=LOINC:2160-0')
         self.assertIn(resp.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
 
+    def test_default_response_has_no_vocabulary_versions(self):
+        resp = self.client.get(self.URL, {'lookup': 'LOINC:2160-0'}, **self._auth())
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertNotIn('_vocabulary_versions', resp.json())  # frozen shape for etl
+
+    def test_include_versions_adds_vocabulary_versions_map(self):
+        from omop_core.models import Vocabulary
+        Vocabulary.objects.filter(vocabulary_id='LOINC').update(vocabulary_version='LOINC 2.77')
+        resp = self.client.get(
+            self.URL, {'lookup': 'LOINC:2160-0', 'include_versions': '1'}, **self._auth(),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        body = resp.json()
+        self.assertEqual(body['LOINC']['2160-0'], 3013682)  # existing shape preserved
+        self.assertEqual(body['_vocabulary_versions'], {'LOINC': 'LOINC 2.77'})
+
+    def test_include_versions_does_not_clobber_requested_vocab(self):
+        # Pathological: a lookup for a vocab literally named `_vocabulary_versions`
+        # must keep its own bucket, not be overwritten by the meta map.
+        resp = self.client.get(
+            self.URL,
+            {'lookup': '_vocabulary_versions:x', 'include_versions': '1'},
+            **self._auth(),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.json()['_vocabulary_versions'], {'x': None})
+
 
 class ConceptGraphTest(_SmartBase):
     """GET /api/v1/concepts/{id}/ancestors|descendants and /api/v1/concepts/graph/."""
@@ -6226,6 +6253,18 @@ class ConceptGraphTest(_SmartBase):
         self.assertEqual(node['concept_id'], self.drug_class.concept_id)
         self.assertEqual(node['min_levels_of_separation'], 1)
         self.assertEqual(node['vocabulary_id'], 'HemOnc')
+
+    def test_graph_node_carries_vocabulary_version(self):
+        self.hemonc_vocab.vocabulary_version = 'HemOnc 2024-12-19'
+        self.hemonc_vocab.save(update_fields=['vocabulary_version'])
+        resp = self.client.get(
+            f'{self.url_ancestors}?max_levels=1&vocabulary_id=HemOnc',
+            **self._auth(),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        node = resp.json()['results'][0]
+        self.assertEqual(node['vocabulary_id'], 'HemOnc')
+        self.assertEqual(node['vocabulary_version'], 'HemOnc 2024-12-19')
 
     def test_batch_endpoint_groups_results_by_source_concept(self):
         resp = self.client.get(
@@ -6470,11 +6509,26 @@ class ConceptSearchTest(_ConceptFixtureBase):
             'concept_id': 201826,
             'concept_name': 'Type 2 diabetes mellitus',
             'vocabulary_id': 'SNOMED',
+            'vocabulary_version': '',
             'concept_code': '44054006',
             'domain_id': 'Condition',
             'concept_class_id': 'Clinical Finding',
             'standard_concept': 'S',
         })
+
+    def test_search_result_carries_vocabulary_version(self):
+        from omop_core.models import Vocabulary
+        Vocabulary.objects.filter(vocabulary_id='SNOMED').update(
+            vocabulary_version='SNOMED 2024-09-01')
+        resp = self.client.get(
+            self.URL, {'q': 'Type 2 diabetes', 'page_size': 100}, **self._auth(),
+        )
+        match = next(
+            (r for r in resp.json()['results'] if r['concept_id'] == self.diabetes.concept_id),
+            None,
+        )
+        self.assertIsNotNone(match)
+        self.assertEqual(match['vocabulary_version'], 'SNOMED 2024-09-01')
 
     def test_search_filtered_by_vocabulary(self):
         resp = self.client.get(


### PR DESCRIPTION
Part of #238 (vocabulary source of truth), per [ADR 0001](https://github.com/healthkey-ai/promop/blob/dev/docs/adr/0001-vocabulary-source-of-truth.md).

## Problem
`Vocabulary.vocabulary_version` is populated but **no** concept endpoint returns it, so a consumer caching promop's vocabulary cannot pin a release or detect drift.

## Change
- **Concept graph** nodes (`/ancestors/`, `/descendants/`, `/graph/`) and **concept search/list** results now carry `vocabulary_version`, resolved via a single per-request `{vocabulary_id: version}` map (`_vocab_version_map()`) — one query, no N+1.
- **`concept_lookup`** keeps its frozen `{vocab: {code: id}}` shape by default (phr-etl reads `result[vocab][code]`); opt-in `?include_versions=1` adds a top-level `_vocabulary_versions` map. Guarded so it can never clobber a user-requested vocabulary bucket.
- `API_SURFACE.md` response examples updated (graph / search / list / lookup opt-in).

## Review findings addressed (Claude fresh-context + Codex)
- **[P2]** `_vocabulary_versions` key could overwrite a bucket if a caller literally requested a vocab named `_vocabulary_versions` → guarded (`'_vocabulary_versions' not in result`) + regression test `test_include_versions_does_not_clobber_requested_vocab`.
- **[P2]** stale `API_SURFACE.md` examples → updated.
- Confirmed by both reviewers: one version-map query per response path, all four graph serializers receive it, missing/NULL versions yield `null`, exact-shape assertion updated.

## Tests (full `patient_portal` suite green — 589)
graph node + search result carry the version; lookup adds the map only when requested and never clobbers a requested bucket; default lookup shape unchanged.
