### PR TITLE
fix(api): make derived therapy/component fields read-only (#248)

### DIFF
--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -203,6 +203,14 @@ class PatientRecordSerializer(serializers.ModelSerializer):
             'organization', 'person', 'created_at', 'updated_at',
             'first_line_therapy_display', 'second_line_therapy_display', 'later_therapy_display',
             'death_date',
+            # Derived vocabulary fields — re-computed from OMOP by
+            # refresh_patient_record (regimen concept_ids + component_ids expanded
+            # from the HemOnc graph). A client PATCH would be silently overwritten
+            # on the next refresh, so reject writes rather than persist bogus data
+            # (promop#248). Provenance/typed-split tracked in #259 / P1.
+            'first_line_therapy_id', 'second_line_therapy_id', 'later_therapy_ids',
+            'first_line_component_ids', 'second_line_component_ids',
+            'later_component_ids', 'therapy_component_ids',
             # Wearable summaries are written by the device-sync service, never by the client API.
             'wearable_last_sync_at', 'wearable_coverage_ratio_30d',
             'median_daily_steps_30d', 'active_minutes_per_day_30d', 'activity_trend_30d',

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -467,7 +467,9 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         serializer = PatientRecordSerializer(patient_info, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
 
-        changed_fields = {f for f in request.data if f not in _prov_meta}
+        # Exclude read-only (derived) fields — they are not written by the
+        # serializer, so they must not drive OMOP sync or provenance either.
+        changed_fields = {f for f in request.data if f not in _prov_meta and f not in _read_only}
         try:
             with transaction.atomic():
                 serializer.save()

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -907,7 +907,7 @@ _COMPONENT_ID_FIELDS = (
 
 class TherapyComponentIdsAPITest(FhirUploadBase):
     """The component concept_id fields are exposed on both patient-record
-    endpoints and are writable via the v1 API."""
+    endpoints but are read-only (derived from OMOP; promop#248)."""
 
     @classmethod
     def setUpTestData(cls):
@@ -936,15 +936,26 @@ class TherapyComponentIdsAPITest(FhirUploadBase):
             self.assertIn(field, resp.data['patient_info'],
                           f'Field {field!r} missing from v1 patient-records response')
 
-    def test_component_fields_writable_via_patch(self):
-        resp = self.client.patch(
-            f'/api/v1/patient-records/{self._pid}/',
-            {'therapy_component_ids': [35806260, 19103793]},
-            format='json',
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        record = PatientRecord.objects.get(person_id=self._pid)
-        self.assertEqual(record.therapy_component_ids, [35806260, 19103793])
+    def test_derived_vocab_fields_readonly_via_patch(self):
+        # All derived regimen/component fields are read-only: a PATCH is accepted
+        # (200) but does NOT change the value — it stays whatever refresh derived.
+        bogus = {
+            'first_line_therapy_id': 999999991,
+            'second_line_therapy_id': 999999992,
+            'later_therapy_ids': [999999993],
+            'first_line_component_ids': [999999994],
+            'second_line_component_ids': [999999995],
+            'later_component_ids': [999999996],
+            'therapy_component_ids': [999999997, 999999998],
+        }
+        for field, value in bogus.items():
+            before = getattr(PatientRecord.objects.get(person_id=self._pid), field)
+            resp = self.client.patch(
+                f'/api/v1/patient-records/{self._pid}/', {field: value}, format='json')
+            self.assertEqual(resp.status_code, status.HTTP_200_OK, f'{field}: {resp.data}')
+            after = getattr(PatientRecord.objects.get(person_id=self._pid), field)
+            self.assertNotEqual(after, value, f'{field} accepted a client write (must be read-only)')
+            self.assertEqual(after, before, f'{field} changed on PATCH (must be read-only)')
 
 
 class FhirUploadComponentIdsTest(FhirUploadBase):


### PR DESCRIPTION
Part of #238 (vocabulary source of truth), per [ADR 0001](https://github.com/healthkey-ai/promop/blob/dev/docs/adr/0001-vocabulary-source-of-truth.md).

## Problem
The regimen concept_id and component_id fields on `PatientRecord` are re-derived from OMOP by `refresh_patient_record` (regimen concept_ids + HemOnc-graph component expansion). They were **writable via the v1 PATCH** endpoint, so a client could persist bogus ids that the next refresh silently overwrites — a provenance/integrity hole flagged during the #240/#246 reviews.

## Change
- Add to `PatientRecordSerializer.Meta.read_only_fields`: `first_line_therapy_id`, `second_line_therapy_id`, `later_therapy_ids`, `first/second/later_line_component_ids`, `therapy_component_ids`. The PATCH endpoint validates through this serializer, so read-only fields are dropped from the write.
- `partial_update` also excludes read-only fields from `changed_fields` (passed to `sync_to_omop`/provenance) for symmetry — defensive against a future `sync_to_omop` handler re-opening the write path.

## Scope
Read-only integrity fix **only**. The typed identifier split (`hemonc_component_ids` / `rxnorm_ingredient_ids` / `exposure_concept_ids`) and provenance (asserted-vs-inferred, release id) are deferred and coordinated with **#259** (source column) and **P1** (`lines_of_therapy`).

## Review findings addressed (Claude fresh-context + Codex)
- Both verified read-only actually blocks the write: `sync_to_omop` only handles lab/condition/demographic/therapy-*line* fields — not `*_therapy_id`/`*_component_ids` — so a lone read-only PATCH writes no OMOP row, fires no `post_save`, triggers no refresh; the value is unchanged.
- **[P2, Codex]** test covered only 2 of 7 fields → replaced with a loop asserting all 7 are read-only.
- Confirmed no other test / FHIR path / frontend depends on these being writable (FHIR writes OMOP + refresh; `TreatmentTab.tsx` renders component_ids read-only).

## Tests (full `patient_portal` suite green — 584)
PATCH of each of the 7 derived fields is accepted (200) but does not change the derived value.
