### PR TITLE
Add analyst invite redirect URLs

### DIFF
--- a/frontend/src/components/Auth/AcceptInvite.test.tsx
+++ b/frontend/src/components/Auth/AcceptInvite.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import AcceptInvite from './AcceptInvite';
+import * as AcceptInviteModule from './AcceptInvite';
 
 // vi.hoisted runs before any module is imported, so the fn is available in factory closures
 const { mockAxiosPost } = vi.hoisted(() => ({ mockAxiosPost: vi.fn() }));
@@ -32,20 +32,20 @@ const withoutToken = () =>
 describe('AcceptInvite', () => {
   it('shows error message immediately when no token is in the URL', () => {
     withoutToken();
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     expect(screen.getByText(/No invitation token found/i)).toBeInTheDocument();
   });
 
   it('shows the Accept button when a token is present', () => {
     withToken();
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     expect(screen.getByRole('button', { name: /accept invitation/i })).toBeInTheDocument();
   });
 
   it('calls the confirm-invitation endpoint with the token on accept', async () => {
     withToken();
     mockAxiosPost.mockResolvedValueOnce({ data: { detail: 'Done.' } });
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /accept invitation/i }));
     await waitFor(() =>
@@ -56,7 +56,7 @@ describe('AcceptInvite', () => {
   it('shows success message and Go to PROMOP button after a successful accept', async () => {
     withToken();
     mockAxiosPost.mockResolvedValueOnce({ data: { detail: 'Access granted to Acme Oncology.' } });
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /accept invitation/i }));
     await waitFor(() =>
@@ -65,10 +65,28 @@ describe('AcceptInvite', () => {
     expect(screen.getByRole('button', { name: /go to promop/i })).toBeInTheDocument();
   });
 
+  it('redirects to the supplied analyst site after a successful accept', async () => {
+    withToken();
+    mockAxiosPost.mockResolvedValueOnce({
+      data: {
+        detail: 'Access granted to Acme Oncology.',
+        redirect_url: 'https://analytics.healthkey.ai/custom',
+      },
+    });
+    render(<AcceptInviteModule.default />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /accept invitation/i }));
+    await waitFor(() => screen.getByRole('link', { name: /continue/i }));
+    expect(screen.getByRole('link', { name: /continue/i })).toHaveAttribute(
+      'href',
+      'https://analytics.healthkey.ai/custom'
+    );
+  });
+
   it('navigates to / when Go to PROMOP is clicked after success', async () => {
     withToken();
     mockAxiosPost.mockResolvedValueOnce({ data: { detail: 'Done.' } });
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /accept invitation/i }));
     await waitFor(() => screen.getByRole('button', { name: /go to promop/i }));
@@ -81,7 +99,7 @@ describe('AcceptInvite', () => {
     mockAxiosPost.mockRejectedValueOnce({
       response: { data: { error: 'Invitation has expired.' } },
     });
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /accept invitation/i }));
     await waitFor(() =>
@@ -92,7 +110,7 @@ describe('AcceptInvite', () => {
   it('shows a fallback error message when the response has no error field', async () => {
     withToken();
     mockAxiosPost.mockRejectedValueOnce(new Error('Network Error'));
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /accept invitation/i }));
     await waitFor(() =>
@@ -102,7 +120,7 @@ describe('AcceptInvite', () => {
 
   it('navigates to /login when Back to Login is clicked from error state', async () => {
     withoutToken();
-    render(<AcceptInvite />);
+    render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /back to login/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/login');

--- a/frontend/src/components/Auth/AcceptInvite.tsx
+++ b/frontend/src/components/Auth/AcceptInvite.tsx
@@ -11,6 +11,10 @@ const publicApi = axios.create({
   },
 });
 
+export function redirectBrowser(url: string) {
+  window.location.assign(url);
+}
+
 export default function AcceptInvite() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
@@ -19,13 +23,18 @@ export default function AcceptInvite() {
   const [state, setState] = useState<State>(token ? 'ready' : 'error');
   const [message, setMessage] = useState(token ? '' : 'No invitation token found in this link.');
   const [confirming, setConfirming] = useState(false);
+  const [redirectUrl, setRedirectUrl] = useState('');
 
   const handleAccept = async () => {
     setConfirming(true);
     try {
       const res = await publicApi.post('/orgs/confirm-invitation/', { token });
       setMessage(res.data.detail ?? 'Invitation accepted.');
+      setRedirectUrl(res.data.redirect_url ?? '');
       setState('success');
+      if (res.data.redirect_url) {
+        redirectBrowser(res.data.redirect_url);
+      }
     } catch (err: unknown) {
       const msg =
         err && typeof err === 'object' && 'response' in err
@@ -63,12 +72,21 @@ export default function AcceptInvite() {
             <p className="text-sm text-green-700 bg-green-50 border border-green-200 rounded p-3">
               {message}
             </p>
-            <button
-              onClick={() => navigate('/')}
-              className="w-full py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm font-medium"
-            >
-              Go to PROMOP
-            </button>
+            {redirectUrl ? (
+              <a
+                href={redirectUrl}
+                className="block w-full py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm font-medium text-center"
+              >
+                Continue
+              </a>
+            ) : (
+              <button
+                onClick={() => navigate('/')}
+                className="w-full py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm font-medium"
+              >
+                Go to PROMOP
+              </button>
+            )}
           </>
         )}
 

--- a/frontend/src/components/OrgAdmin/OrgDetail.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { ArrowLeft, Trash2 } from 'lucide-react';
 import api from '@/api/axios';
 
+const DEFAULT_ANALYST_REDIRECT_URL = 'https://analytics.healthkey.ai';
+
 interface OrgDetailProps {
   slug: string;
   isStaff: boolean;
@@ -30,6 +32,7 @@ interface Invitation {
   org_slug: string;
   email: string;
   role: string;
+  redirect_url: string | null;
   status: string;
   expires_at: string;
   created_at: string;
@@ -48,6 +51,7 @@ interface AccessGrant {
   org_slug: string;
   group_name: string | null;
   role: string;
+  redirect_url: string | null;
   expires_at: string | null;
   granted_at: string;
 }
@@ -98,6 +102,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   // Invite form state
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState('doctor');
+  const [inviteRedirectUrl, setInviteRedirectUrl] = useState(DEFAULT_ANALYST_REDIRECT_URL);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteSuccess, setInviteSuccess] = useState<string | null>(null);
 
@@ -193,7 +198,11 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
     try {
       setInviteError(null);
       setInviteSuccess(null);
-      const res = await api.post<InviteResponse>(`${base}/invite/`, { email: inviteEmail, role: inviteRole });
+      const payload: Record<string, string> = { email: inviteEmail, role: inviteRole };
+      if (inviteRole === 'analyst') {
+        payload.redirect_url = inviteRedirectUrl;
+      }
+      const res = await api.post<InviteResponse>(`${base}/invite/`, payload);
       if (res.data.email_warning) {
         setInviteSuccess(`User access was updated for ${inviteEmail}, but the invitation email was not sent.`);
       } else if (res.data.access_granted) {
@@ -202,6 +211,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
         setInviteSuccess(`Invitation sent to ${inviteEmail}.`);
       }
       setInviteEmail('');
+      setInviteRedirectUrl(DEFAULT_ANALYST_REDIRECT_URL);
       fetchAll();
     } catch {
       setInviteError('Failed to send invitation.');
@@ -237,7 +247,8 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const handleUpdateGrant = async (grantId: number, patch: { role?: string; is_premium?: boolean }) => {
     setAccessGrants(prev => prev.map(g => g.id === grantId ? { ...g, ...patch } : g));
     try {
-      await api.patch(`${base}/access/${grantId}/`, patch);
+      const res = await api.patch<AccessGrant>(`${base}/access/${grantId}/`, patch);
+      setAccessGrants(prev => prev.map(g => g.id === grantId ? res.data : g));
     } catch (err) {
       console.error('Failed to update access grant:', err);
       setAccessError('Failed to update access grant. Please try again.');
@@ -252,7 +263,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
     { key: 'settings', label: 'Settings' },
     { key: 'stats', label: 'Stats' },
     { key: 'trusts', label: 'Access Rules' },
-    { key: 'admins', label: 'Admins' },
+    { key: 'admins', label: 'Access Grants' },
     { key: 'invitations', label: 'Invitations' },
   ];
 
@@ -452,7 +463,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
         </div>
       )}
 
-      {/* Admins (org_admin access grants) */}
+      {/* Access grants */}
       {activeSection === 'admins' && (
         <div className="space-y-4">
           <h2 className="font-medium text-gray-900">Access Grants</h2>
@@ -460,48 +471,83 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
           {accessGrants.length === 0 ? (
             <p className="text-sm text-gray-500">No access grants.</p>
           ) : (
-            <ul className="divide-y divide-gray-100 border border-gray-200 rounded-lg overflow-hidden">
-              {accessGrants.map(g => (
-                <li key={g.id} className="flex items-center justify-between px-4 py-3 gap-3">
-                  <div className="flex flex-col gap-0.5 min-w-0">
-                    <span className="text-sm font-medium truncate">{g.name || g.email}</span>
-                    {g.name && <span className="text-xs text-gray-400 truncate">{g.email}</span>}
-                  </div>
-                  <div className="flex items-center gap-3 shrink-0">
-                    {g.role === 'org_admin' ? (
-                      <span className="text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700 font-medium">Org Admin</span>
-                    ) : (
-                      <>
-                        <select
-                          value={g.role}
-                          onChange={e => handleUpdateGrant(g.id, { role: e.target.value })}
-                          className="border border-gray-300 rounded px-2 py-1 text-xs"
+            <div className="overflow-x-auto border border-gray-200 rounded-lg">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">User</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Role</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Site</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Premium</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {accessGrants.map(g => (
+                    <tr key={g.id} className="border-t border-gray-100 align-top">
+                      <td className="px-4 py-3">
+                        <div className="flex flex-col gap-0.5 min-w-0">
+                          <span className="text-sm font-medium truncate">{g.name || g.email}</span>
+                          {g.name && <span className="text-xs text-gray-400 truncate">{g.email}</span>}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        {g.role === 'org_admin' ? (
+                          <span className="text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700 font-medium">Org Admin</span>
+                        ) : (
+                          <select
+                            value={g.role}
+                            onChange={e => handleUpdateGrant(g.id, { role: e.target.value })}
+                            className="border border-gray-300 rounded px-2 py-1 text-xs"
+                          >
+                            <option value="doctor">Doctor</option>
+                            <option value="analyst">Analyst</option>
+                          </select>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {g.redirect_url ? (
+                          <a
+                            href={g.redirect_url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-blue-600 hover:text-blue-800 break-all"
+                          >
+                            {g.redirect_url}
+                          </a>
+                        ) : (
+                          'PROMOP'
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        {g.role === 'org_admin' ? (
+                          <span className="text-xs text-gray-400">N/A</span>
+                        ) : (
+                          <label className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer select-none">
+                            <input
+                              type="checkbox"
+                              checked={g.is_premium}
+                              onChange={e => handleUpdateGrant(g.id, { is_premium: e.target.checked })}
+                              className="h-3.5 w-3.5 rounded border-gray-300 text-blue-600"
+                            />
+                            Premium
+                          </label>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          onClick={() => handleRevokeAccess(g.id)}
+                          className="text-red-400 hover:text-red-600"
+                          title="Revoke access"
                         >
-                          <option value="doctor">Doctor</option>
-                          <option value="analyst">Analyst</option>
-                        </select>
-                        <label className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer select-none">
-                          <input
-                            type="checkbox"
-                            checked={g.is_premium}
-                            onChange={e => handleUpdateGrant(g.id, { is_premium: e.target.checked })}
-                            className="h-3.5 w-3.5 rounded border-gray-300 text-blue-600"
-                          />
-                          Premium
-                        </label>
-                      </>
-                    )}
-                    <button
-                      onClick={() => handleRevokeAccess(g.id)}
-                      className="text-red-400 hover:text-red-600"
-                      title="Revoke access"
-                    >
-                      <Trash2 size={14} />
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
+                          <Trash2 size={14} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
 
           {/* Invite form */}
@@ -519,7 +565,13 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
             <div className="flex gap-2">
               <select
                 value={inviteRole}
-                onChange={e => setInviteRole(e.target.value)}
+                onChange={e => {
+                  const nextRole = e.target.value;
+                  setInviteRole(nextRole);
+                  if (nextRole !== 'analyst') {
+                    setInviteRedirectUrl(DEFAULT_ANALYST_REDIRECT_URL);
+                  }
+                }}
                 className="border border-gray-300 rounded px-2 py-1.5 text-sm"
               >
                 <option value="org_admin">Org Admin</option>
@@ -533,6 +585,18 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
                 Send Invite
               </button>
             </div>
+            {inviteRole === 'analyst' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Analyst redirect site</label>
+                <input
+                  type="url"
+                  placeholder={DEFAULT_ANALYST_REDIRECT_URL}
+                  value={inviteRedirectUrl}
+                  onChange={e => setInviteRedirectUrl(e.target.value)}
+                  className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                />
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/omop_core/migrations/0119_org_invitation_group_access_redirect_url.py
+++ b/omop_core/migrations/0119_org_invitation_group_access_redirect_url.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("omop_core", "0118_seed_hk_vocabularies_remap_fhir_concepts"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="groupaccess",
+            name="redirect_url",
+            field=models.URLField(blank=True, default="", max_length=500),
+        ),
+        migrations.AddField(
+            model_name="orginvitation",
+            name="redirect_url",
+            field=models.URLField(blank=True, default="", max_length=500),
+        ),
+    ]

--- a/omop_core/models.py
+++ b/omop_core/models.py
@@ -127,6 +127,7 @@ class OrgInvitation(models.Model):
     )
     email = models.EmailField()
     role = models.CharField(max_length=20, choices=ROLE, default='doctor')
+    redirect_url = models.URLField(max_length=500, blank=True, default='')
     token = models.CharField(max_length=64, unique=True)
     invited_by = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.SET_NULL,
@@ -260,6 +261,7 @@ class GroupAccess(models.Model):
         null=True, blank=True, related_name='access_grants',
     )
     role = models.CharField(max_length=20, choices=ROLE_CHOICES)
+    redirect_url = models.URLField(max_length=500, blank=True, default='')
     expires_at = models.DateTimeField(null=True, blank=True)
     granted_at = models.DateTimeField(auto_now_add=True)
     granted_by = models.ForeignKey(

--- a/patient_portal/api/authentication.py
+++ b/patient_portal/api/authentication.py
@@ -184,7 +184,10 @@ def _claim_placeholder_access(identity: Identity, email: str | None) -> None:
                     existing.role = grant.role
                     existing.granted_by = grant.granted_by
                     existing.expires_at = grant.expires_at
-                    existing.save(update_fields=["role", "granted_by", "expires_at"])
+                    existing.redirect_url = grant.redirect_url if grant.role == "analyst" else ""
+                    existing.save(
+                        update_fields=["role", "granted_by", "expires_at", "redirect_url"]
+                    )
                 grant.delete()
             else:
                 grant.identity = identity

--- a/patient_portal/api/org_views.py
+++ b/patient_portal/api/org_views.py
@@ -17,8 +17,10 @@ import logging
 import secrets
 from django.conf import settings
 from django.core.mail import send_mail
+from django.core.validators import URLValidator
 from django.db import transaction
 from django.db.models import Q
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -28,6 +30,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 logger = logging.getLogger(__name__)
+DEFAULT_ANALYST_REDIRECT_URL = 'https://analytics.healthkey.ai'
 
 
 class InvitationEmailError(Exception):
@@ -135,18 +138,39 @@ def _get_or_create_invitee_identity(email):
 ROLE_RANK = {'org_admin': 3, 'doctor': 2, 'analyst': 1}
 
 
-def _grant_org_access(identity, org, role, granted_by):
+def _normalize_redirect_url(role, redirect_url):
+    if role != 'analyst':
+        return ''
+
+    candidate = (redirect_url or '').strip() or DEFAULT_ANALYST_REDIRECT_URL
+    validator = URLValidator(schemes=['http', 'https'])
+    validator(candidate)
+    return candidate
+
+
+def _grant_org_access(identity, org, role, granted_by, redirect_url=''):
+    normalized_redirect_url = _normalize_redirect_url(role, redirect_url)
     existing = GroupAccess.objects.filter(identity=identity, org=org).first()
     if existing:
+        changed_fields = []
         if ROLE_RANK.get(existing.role, 0) < ROLE_RANK.get(role, 0):
             existing.role = role
             existing.granted_by = granted_by
-            existing.save(update_fields=['role', 'granted_by'])
+            changed_fields.extend(['role', 'granted_by'])
+
+        desired_redirect_url = normalized_redirect_url if existing.role == 'analyst' else ''
+        if existing.redirect_url != desired_redirect_url:
+            existing.redirect_url = desired_redirect_url
+            changed_fields.append('redirect_url')
+
+        if changed_fields:
+            existing.save(update_fields=changed_fields)
         return existing
     return GroupAccess.objects.create(
         identity=identity,
         org=org,
         role=role,
+        redirect_url=normalized_redirect_url if role == 'analyst' else '',
         granted_by=granted_by,
     )
 
@@ -213,11 +237,19 @@ class OrgInviteView(APIView):
         org = _get_org(slug)
         email = request.data.get('email', '').strip().lower()
         role = request.data.get('role', 'doctor')
+        redirect_url = request.data.get('redirect_url', '')
 
         if not email:
             return Response({'error': 'email is required'}, status=status.HTTP_400_BAD_REQUEST)
         if role not in dict(OrgInvitation.ROLE):
             return Response({'error': f'Invalid role: {role}'}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            normalized_redirect_url = _normalize_redirect_url(role, redirect_url)
+        except ValidationError:
+            return Response(
+                {'error': 'redirect_url must be a valid http(s) URL.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         with transaction.atomic():
             invitation = OrgInvitation.objects.select_for_update().filter(
@@ -229,22 +261,26 @@ class OrgInviteView(APIView):
             expires_at = timezone.now() + timezone.timedelta(days=7)
             if invitation:
                 invitation.role = role
+                invitation.redirect_url = normalized_redirect_url
                 invitation.token = token
                 invitation.invited_by = request.user
                 invitation.expires_at = expires_at
-                invitation.save(update_fields=['role', 'token', 'invited_by', 'expires_at'])
+                invitation.save(
+                    update_fields=['role', 'redirect_url', 'token', 'invited_by', 'expires_at']
+                )
             else:
                 invitation = OrgInvitation.objects.create(
                     org=org,
                     email=email,
                     role=role,
+                    redirect_url=normalized_redirect_url,
                     token=token,
                     invited_by=request.user,
                     expires_at=expires_at,
                 )
 
             identity = _get_or_create_invitee_identity(email)
-            _grant_org_access(identity, org, role, request.user)
+            _grant_org_access(identity, org, role, request.user, redirect_url=normalized_redirect_url)
 
         email_warning = None
         try:
@@ -323,12 +359,21 @@ def confirm_invitation(request):
     # silently downgrading an existing higher-privilege role (e.g. org_admin → doctor).
     # If the grant already exists, leave it unchanged; the invitation is still
     # marked confirmed so it can't be replayed.
-    _grant_org_access(identity, invitation.org, invitation.role, invitation.invited_by)
+    grant = _grant_org_access(
+        identity,
+        invitation.org,
+        invitation.role,
+        invitation.invited_by,
+        redirect_url=invitation.redirect_url,
+    )
 
     invitation.confirmed_at = timezone.now()
     invitation.save(update_fields=['confirmed_at'])
 
-    return Response({'detail': f'Invitation confirmed. Access granted to {invitation.org.name}.'})
+    response_data = {'detail': f'Invitation confirmed. Access granted to {invitation.org.name}.'}
+    if grant.redirect_url:
+        response_data['redirect_url'] = grant.redirect_url
+    return Response(response_data)
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +449,11 @@ class OrgAccessDetailView(APIView):
                 )
             grant.role = new_role
             changed_grant.append('role')
+            normalized_redirect_url = _normalize_redirect_url(new_role, grant.redirect_url)
+            desired_redirect_url = normalized_redirect_url if new_role == 'analyst' else ''
+            if grant.redirect_url != desired_redirect_url:
+                grant.redirect_url = desired_redirect_url
+                changed_grant.append('redirect_url')
 
         if 'is_premium' in request.data:
             raw = request.data['is_premium']

--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -133,17 +133,21 @@ class OrgTrustSerializer(serializers.ModelSerializer):
 class OrgInvitationSerializer(serializers.ModelSerializer):
     status = serializers.SerializerMethodField()
     org_slug = serializers.SlugRelatedField(source='org', slug_field='slug', read_only=True)
+    redirect_url = serializers.SerializerMethodField()
 
     class Meta:
         model = OrgInvitation
         fields = [
-            'id', 'org_slug', 'email', 'role', 'status',
+            'id', 'org_slug', 'email', 'role', 'redirect_url', 'status',
             'expires_at', 'created_at',
         ]
-        read_only_fields = ['id', 'org_slug', 'status', 'expires_at', 'created_at']
+        read_only_fields = ['id', 'org_slug', 'redirect_url', 'status', 'expires_at', 'created_at']
 
     def get_status(self, obj):
         return obj.status
+
+    def get_redirect_url(self, obj):
+        return obj.redirect_url or None
 
 
 class GroupAccessSerializer(serializers.ModelSerializer):
@@ -152,17 +156,21 @@ class GroupAccessSerializer(serializers.ModelSerializer):
     is_premium = serializers.BooleanField(source='identity.is_premium', read_only=True)
     org_slug = serializers.SlugRelatedField(source='org', slug_field='slug', read_only=True)
     group_name = serializers.CharField(source='group.name', read_only=True, default=None)
+    redirect_url = serializers.SerializerMethodField()
 
     class Meta:
         model = GroupAccess
         fields = [
             'id', 'email', 'name', 'is_premium', 'org_slug', 'group_name', 'role',
-            'expires_at', 'granted_at',
+            'redirect_url', 'expires_at', 'granted_at',
         ]
         read_only_fields = [
             'id', 'email', 'name', 'is_premium', 'org_slug', 'group_name', 'role',
-            'expires_at', 'granted_at',
+            'redirect_url', 'expires_at', 'granted_at',
         ]
+
+    def get_redirect_url(self, obj):
+        return obj.redirect_url or None
 
 
 class PatientListSerializer(serializers.ModelSerializer):

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -8528,10 +8528,32 @@ class OrgInvitationFlowTest(TestCase):
         })
         self.assertEqual(resp.status_code, 201)
         invitee = Identity.objects.get(email='placeholder@example.com', issuer='urn:local')
+        invitation = OrgInvitation.objects.get(org=self.org, email='placeholder@example.com')
+        grant = GroupAccess.objects.get(identity=invitee, org=self.org, role='analyst')
         self.assertFalse(invitee.has_usable_password())
-        self.assertTrue(
-            GroupAccess.objects.filter(identity=invitee, org=self.org, role='analyst').exists()
-        )
+        self.assertEqual(invitation.redirect_url, 'https://analytics.healthkey.ai')
+        self.assertEqual(grant.redirect_url, 'https://analytics.healthkey.ai')
+
+    def test_invite_analyst_allows_custom_redirect_url(self):
+        resp = self.client.post('/api/orgs/invite-org/invite/', {
+            'email': 'analyst-custom@example.com',
+            'role': 'analyst',
+            'redirect_url': 'https://analytics.healthkey.ai/tenant/acme',
+        })
+        self.assertEqual(resp.status_code, 201)
+        invitation = OrgInvitation.objects.get(org=self.org, email='analyst-custom@example.com')
+        grant = GroupAccess.objects.get(identity__email='analyst-custom@example.com', org=self.org)
+        self.assertEqual(invitation.redirect_url, 'https://analytics.healthkey.ai/tenant/acme')
+        self.assertEqual(grant.redirect_url, 'https://analytics.healthkey.ai/tenant/acme')
+
+    def test_invite_rejects_invalid_analyst_redirect_url(self):
+        resp = self.client.post('/api/orgs/invite-org/invite/', {
+            'email': 'analyst-invalid@example.com',
+            'role': 'analyst',
+            'redirect_url': 'not-a-url',
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.data['error'], 'redirect_url must be a valid http(s) URL.')
 
     def test_partner_auth_identity_claims_placeholder_access(self):
         placeholder = Identity.objects.create_user(email='partner@example.com', password=None)
@@ -8626,7 +8648,12 @@ class OrgInvitationFlowTest(TestCase):
 
     def test_invite_existing_user_updates_existing_org_role(self):
         invitee = Identity.objects.create_user(email='role-update@example.com', password='pass')
-        GroupAccess.objects.create(identity=invitee, org=self.org, role='analyst')
+        GroupAccess.objects.create(
+            identity=invitee,
+            org=self.org,
+            role='analyst',
+            redirect_url='https://analytics.healthkey.ai/old',
+        )
         resp = self.client.post('/api/orgs/invite-org/invite/', {
             'email': 'role-update@example.com',
             'role': 'doctor',
@@ -8635,6 +8662,7 @@ class OrgInvitationFlowTest(TestCase):
         self.assertTrue(resp.data['access_granted'])
         grant = GroupAccess.objects.get(identity=invitee, org=self.org)
         self.assertEqual(grant.role, 'doctor')
+        self.assertEqual(grant.redirect_url, '')
 
     def test_invite_existing_user_does_not_downgrade_org_admin(self):
         invitee = Identity.objects.create_user(email='admin-role@example.com', password='pass')
@@ -8680,6 +8708,25 @@ class OrgInvitationFlowTest(TestCase):
         )
         inv = OrgInvitation.objects.get(token=token)
         self.assertEqual(inv.status, OrgInvitation.STATUS_CONFIRMED)
+
+    def test_confirm_analyst_invitation_returns_redirect_url(self):
+        from django.utils import timezone
+        invitee = Identity.objects.create_user(email='analyst-invitee@example.com', password='pass')
+        token = _secrets.token_hex(32)
+        OrgInvitation.objects.create(
+            org=self.org,
+            email='analyst-invitee@example.com',
+            role='analyst',
+            redirect_url='https://analytics.healthkey.ai/org/acme',
+            token=token,
+            expires_at=timezone.now() + timezone.timedelta(days=7),
+        )
+        public_client = APIClient()
+        resp = public_client.post('/api/orgs/confirm-invitation/', {'token': token})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['redirect_url'], 'https://analytics.healthkey.ai/org/acme')
+        grant = GroupAccess.objects.get(identity=invitee, org=self.org)
+        self.assertEqual(grant.redirect_url, 'https://analytics.healthkey.ai/org/acme')
 
     def test_cancel_invitation(self):
         from django.utils import timezone
@@ -8824,11 +8871,44 @@ class OrgAccessAPITest(TestCase):
         self.assertEqual(resp.status_code, 200)
         emails = [g['email'] for g in resp.data]
         self.assertIn('grantee@example.com', emails)
+        self.assertEqual(resp.data[0]['redirect_url'], None)
+
+    def test_list_access_grants_includes_redirect_url(self):
+        self.grant.role = 'analyst'
+        self.grant.redirect_url = 'https://analytics.healthkey.ai/custom'
+        self.grant.save(update_fields=['role', 'redirect_url'])
+        resp = self.client.get('/api/orgs/access-org/access/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data[0]['redirect_url'], 'https://analytics.healthkey.ai/custom')
 
     def test_revoke_access_grant(self):
         resp = self.client.delete(f'/api/orgs/access-org/access/{self.grant.id}/')
         self.assertEqual(resp.status_code, 204)
         self.assertFalse(GroupAccess.objects.filter(id=self.grant.id).exists())
+
+    def test_patch_access_grant_sets_default_analyst_redirect_url(self):
+        resp = self.client.patch(
+            f'/api/orgs/access-org/access/{self.grant.id}/',
+            {'role': 'analyst'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.grant.refresh_from_db()
+        self.assertEqual(self.grant.role, 'analyst')
+        self.assertEqual(self.grant.redirect_url, 'https://analytics.healthkey.ai')
+
+    def test_patch_access_grant_clears_redirect_url_when_switching_to_doctor(self):
+        self.grant.role = 'analyst'
+        self.grant.redirect_url = 'https://analytics.healthkey.ai/custom'
+        self.grant.save(update_fields=['role', 'redirect_url'])
+        resp = self.client.patch(
+            f'/api/orgs/access-org/access/{self.grant.id}/',
+            {'role': 'doctor'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.grant.refresh_from_db()
+        self.assertEqual(self.grant.redirect_url, '')
 
 
 class SetupDemoCommandTest(TestCase):


### PR DESCRIPTION
## Summary
- add a persisted redirect URL for analyst org invites and access grants
- default analysts to PRism Analytics while keeping non-analyst invites on PROMOP
- expose the site in the Access Grants UI and redirect accepted analyst invites to it

## Testing
- Found 24 test(s).
Operations to perform:
  Synchronize unmigrated apps: anymail, corsheaders, drf_spectacular, messages, postgres, rest_framework, staticfiles
  Apply all migrations: admin, auth, contenttypes, oauth2_provider, omop_core, omop_genomics, omop_oncology, patient_portal, sessions
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
Running migrations:
  No migrations to apply.
System check identified no issues (0 silenced).
- 
- 

Closes #272
