### PR TITLE
Grant org admin rights via access rules

### DIFF
--- a/omop_core/services/access.py
+++ b/omop_core/services/access.py
@@ -131,3 +131,70 @@ def get_visible_orgs(user) -> QuerySet:
         return Organization.objects.none()
 
     return Organization.objects.filter(id__in=all_ids)
+
+
+def get_admin_orgs(user) -> QuerySet:
+    """Return orgs the user may administer.
+
+    Admin access is granted via:
+      - is_staff → all orgs
+      - direct org_admin grants
+      - OrgTrust rows that match the user's email domain
+      - OrgTrust rows that trust an org the user already belongs to
+
+    Public aggregated-data visibility does not confer admin rights.
+    """
+    if getattr(user, 'is_staff', False):
+        return Organization.objects.all()
+
+    now = timezone.now()
+    active = GroupAccess.objects.filter(
+        identity=user,
+    ).filter(
+        Q(expires_at__isnull=True) | Q(expires_at__gt=now)
+    )
+
+    admin_ids = set(
+        active.filter(role='org_admin', org__isnull=False)
+              .values_list('org_id', flat=True)
+    )
+    direct_ids = set(
+        active.filter(org__isnull=False)
+              .values_list('org_id', flat=True)
+    )
+    group_org_ids = set(
+        active.exclude(role='org_admin')
+              .values_list('group__organization_id', flat=True)
+    )
+    group_org_ids.discard(None)
+    direct_ids |= group_org_ids
+
+    trusted_by_org = set(
+        OrgTrust.objects.filter(
+            trusted_org_id__in=direct_ids,
+            granting_org__is_active=True,
+        ).values_list('granting_org_id', flat=True)
+    ) if direct_ids else set()
+
+    email = (getattr(user, 'email', '') or '')
+    user_domain = email.split('@')[1] if '@' in email else ''
+    trusted_by_domain = set(
+        OrgTrust.objects.filter(
+            trusted_domain=user_domain,
+            granting_org__is_active=True,
+        ).values_list('granting_org_id', flat=True)
+    ) if user_domain else set()
+
+    all_ids = admin_ids | trusted_by_org | trusted_by_domain
+    if not all_ids:
+        return Organization.objects.none()
+
+    return Organization.objects.filter(id__in=all_ids)
+
+
+def has_org_admin_access(user, slug: str | None = None) -> bool:
+    """Return True when the user may administer any org or a specific org slug."""
+    admin_orgs = get_admin_orgs(user)
+    if slug is None:
+        return admin_orgs.exists()
+    return admin_orgs.filter(slug=slug).exists()

--- a/patient_portal/api/org_views.py
+++ b/patient_portal/api/org_views.py
@@ -83,6 +83,7 @@ def _send_invitation_email(invitation) -> None:
 
 from omop_core.models import Organization, OrgTrust, OrgInvitation, GroupAccess
 from omop_core.services.organization_cleanup import delete_organization_with_patient_cascade
+from omop_core.services.access import get_admin_orgs
 from patient_portal.models import Identity
 from omop_core.models import Person, PatientRecord
 from .permissions import IsStaffPermission, IsStaffOrOrgAdmin
@@ -101,21 +102,8 @@ def _get_org(slug: str) -> Organization:
 
 
 def _visible_orgs(user):
-    """Return orgs the user may ADMINISTER (staff: all; org_admin: own only).
-
-    Intentionally narrower than get_visible_orgs() in services/access.py —
-    trust-based orgs (domain/org-to-org) appear in patient-data visibility but
-    NOT here, because the user holds no admin rights on those orgs.
-    """
-    if getattr(user, 'is_staff', False):
-        return Organization.objects.all()
-    now = timezone.now()
-    admin_org_ids = GroupAccess.objects.filter(
-        identity=user, role='org_admin',
-    ).filter(
-        Q(expires_at__isnull=True) | Q(expires_at__gt=now)
-    ).values_list('org_id', flat=True)
-    return Organization.objects.filter(id__in=admin_org_ids)
+    """Return orgs the user may administer, including trust-derived admin access."""
+    return get_admin_orgs(user)
 
 
 def _find_identity_by_email(email):

--- a/patient_portal/api/permissions.py
+++ b/patient_portal/api/permissions.py
@@ -1,9 +1,7 @@
-from django.db.models import Q
-from django.utils import timezone
 from rest_framework.permissions import BasePermission
 
 from .providers.base import TokenClaims
-from omop_core.models import GroupAccess, Organization
+from omop_core.services.access import has_org_admin_access
 
 # Sentinel value set by ServiceTokenAuthentication when the HMAC check passes.
 # Use is_service_token() rather than comparing this string directly.
@@ -144,21 +142,4 @@ class IsStaffOrOrgAdmin(BasePermission):
             return True
 
         slug = view.kwargs.get('slug')
-        if not slug:
-            # No slug: allow if user has any active org_admin grant (e.g., list view)
-            now = timezone.now()
-            return GroupAccess.objects.filter(
-                identity=request.user,
-                role='org_admin',
-            ).filter(
-                Q(expires_at__isnull=True) | Q(expires_at__gt=now)
-            ).exists()
-
-        now = timezone.now()
-        return GroupAccess.objects.filter(
-            identity=request.user,
-            role='org_admin',
-            org__slug=slug,
-        ).filter(
-            Q(expires_at__isnull=True) | Q(expires_at__gt=now)
-        ).exists()
+        return has_org_admin_access(request.user, slug)

--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -12,6 +12,7 @@ from omop_oncology.models import Episode, EpisodeEvent
 from datetime import date
 from django.utils.timezone import localdate
 from django.utils import timezone
+from omop_core.services.access import has_org_admin_access
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -47,14 +48,7 @@ class UserSerializer(serializers.ModelSerializer):
         return person.person_id if person else None
 
     def get_is_org_admin(self, obj):
-        now = timezone.now()
-        from django.db.models import Q
-        return GroupAccess.objects.filter(
-            identity=obj,
-            role='org_admin',
-        ).filter(
-            Q(expires_at__isnull=True) | Q(expires_at__gt=now)
-        ).exists()
+        return has_org_admin_access(obj)
 
     def get_org_accesses(self, obj):
         now = timezone.now()

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -8212,7 +8212,7 @@ class OrgManagementModelTest(TestCase):
 
 
 class OrgTrustAccessTest(TestCase):
-    """get_visible_orgs includes trust-based orgs."""
+    """Access helpers include trust-based orgs."""
 
     def setUp(self):
         self.org_a = _make_org('Org A', 'org-a')
@@ -8256,6 +8256,19 @@ class OrgTrustAccessTest(TestCase):
     def test_staff_sees_all_orgs(self):
         staff = _make_user('staff@test.com', is_staff=True)
         orgs = get_visible_orgs(staff)
+        self.assertIn(self.org_a, orgs)
+        self.assertIn(self.org_b, orgs)
+
+    def test_domain_trust_gives_admin_access(self):
+        from omop_core.services.access import get_admin_orgs
+        OrgTrust.objects.create(granting_org=self.org_b, trusted_domain='trusted.com')
+        orgs = get_admin_orgs(self.domain_user)
+        self.assertIn(self.org_b, orgs)
+
+    def test_org_to_org_trust_gives_admin_access(self):
+        from omop_core.services.access import get_admin_orgs
+        OrgTrust.objects.create(granting_org=self.org_b, trusted_org=self.org_a)
+        orgs = get_admin_orgs(self.direct_user)
         self.assertIn(self.org_a, orgs)
         self.assertIn(self.org_b, orgs)
 
@@ -8477,6 +8490,35 @@ class OrgViewSetOrgAdminTest(TestCase):
     def test_cannot_access_other_org(self):
         resp = self.client.get('/api/orgs/other-org/')
         self.assertEqual(resp.status_code, 403)
+
+
+class OrgViewSetTrustedAdminTest(TestCase):
+    """Trust-based org access confers org-admin rights."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = _make_user('trusted@partner.com')
+        self.org = _make_org('Trusted Org', 'trusted-org')
+        self.client.force_authenticate(user=self.user)
+
+    def test_domain_trust_can_list_and_patch_org(self):
+        OrgTrust.objects.create(granting_org=self.org, trusted_domain='partner.com')
+        resp = self.client.get('/api/orgs/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('trusted-org', [o['slug'] for o in resp.data])
+
+        resp = self.client.patch('/api/orgs/trusted-org/', {'name': 'Renamed Trusted Org'})
+        self.assertEqual(resp.status_code, 200)
+        self.org.refresh_from_db()
+        self.assertEqual(self.org.name, 'Renamed Trusted Org')
+
+    def test_org_to_org_trust_can_access_other_org(self):
+        source_org = _make_org('Source Org', 'source-org')
+        GroupAccess.objects.create(identity=self.user, org=source_org, role='doctor')
+        OrgTrust.objects.create(granting_org=self.org, trusted_org=source_org)
+
+        resp = self.client.get('/api/orgs/trusted-org/')
+        self.assertEqual(resp.status_code, 200)
 
 
 class OrgViewSetUnauthorizedTest(TestCase):
@@ -8973,6 +9015,15 @@ class UserSerializerOrgAdminTest(TestCase):
     def test_is_org_admin_true_with_grant(self):
         GroupAccess.objects.create(identity=self.user, org=self.org, role='org_admin')
         self.client.force_authenticate(user=self.user)
+        resp = self.client.get('/api/user/')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.data.get('user', resp.data)
+        self.assertTrue(data.get('is_org_admin'))
+
+    def test_is_org_admin_true_with_domain_trust(self):
+        OrgTrust.objects.create(granting_org=self.org, trusted_domain='example.com')
+        trusted_user = _make_user('trusted@example.com')
+        self.client.force_authenticate(user=trusted_user)
         resp = self.client.get('/api/user/')
         self.assertEqual(resp.status_code, 200)
         data = resp.data.get('user', resp.data)


### PR DESCRIPTION
## Summary
- treat trust-based access rules as org-admin rights for org management
- reuse a shared admin-org helper in permissions, org listing, and user serialization
- cover domain-trust and org-to-org trust admin behavior with targeted tests

## Testing
- Django: patient_portal.tests.OrgTrustAccessTest
- Django: patient_portal.tests.OrgViewSetOrgAdminTest
- Django: patient_portal.tests.OrgViewSetTrustedAdminTest
- Django: patient_portal.tests.OrgViewSetUnauthorizedTest
- Django: patient_portal.tests.UserSerializerOrgAdminTest
- Python compile check on touched backend modules
