### PR TITLE
Honor trust admin access in patient list scope

### DIFF
--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -50,7 +50,7 @@ from omop_core.services.regimen_resolution import (
     validate_hemonc_regimen,
 )
 from omop_core.services.concept_cache import concept_by_id as _cc_by_id, concept_by_loinc as _cc_by_loinc, concept_by_name_ilike as _cc_by_name, concept_by_vocab as _cc_by_vocab
-from omop_core.services.access import get_visible_orgs, build_trusting_map
+from omop_core.services.access import get_visible_orgs, build_trusting_map, get_admin_orgs
 from datetime import datetime, timedelta
 from django.utils.timezone import localdate
 import csv
@@ -218,10 +218,8 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                 Q(expires_at__isnull=True) | Q(expires_at__gt=now),
             )
 
-            # Org-admin grants: see all patients belonging to those orgs
-            admin_org_ids = list(
-                active_grants.filter(role='org_admin').values_list('org_id', flat=True)
-            )
+            # Org-admin access includes trust-derived admin orgs.
+            admin_org_ids = list(get_admin_orgs(self.request.user).values_list('id', flat=True))
 
             # Group grants: see patients in those groups
             actor_group_ids = list(

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -7964,6 +7964,27 @@ class OrgAdminPatientListScopingTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn('filter_options', resp.data)
 
+    def test_domain_trust_admin_sees_trusted_org_patients(self):
+        trusted_admin = Identity.objects.create_user(email='trusted@t.com', password='x')
+        OrgTrust.objects.create(granting_org=self.org_a, trusted_domain='t.com')
+        resp = self._get(trusted_admin)
+        self.assertEqual(resp.status_code, 200)
+        ids = {p['id'] for p in resp.data}
+        self.assertIn(self.pi_a1.id, ids)
+        self.assertIn(self.pi_a2.id, ids)
+        self.assertNotIn(self.pi_b.id, ids)
+
+    def test_org_to_org_trust_admin_sees_trusted_org_patients(self):
+        trusted_admin = Identity.objects.create_user(email='trusted-org-link@t.com', password='x')
+        source_org = Organization.objects.create(name='Source Org', slug='source-org-patient-scope')
+        GroupAccess.objects.create(identity=trusted_admin, org=source_org, role='doctor')
+        OrgTrust.objects.create(granting_org=self.org_b, trusted_org=source_org)
+        resp = self._get(trusted_admin)
+        self.assertEqual(resp.status_code, 200)
+        ids = {p['id'] for p in resp.data}
+        self.assertIn(self.pi_b.id, ids)
+        self.assertNotIn(self.pi_a1.id, ids)
+
 
 # ---------------------------------------------------------------------------
 # bulk_delete_filtered Tests


### PR DESCRIPTION
## Summary
- use the shared trust-aware admin-org helper when scoping patient-list org-admin access
- make trust-derived admins see the same patient rows as direct org admins
- add regression coverage for domain-trust and org-to-org trust patient-list visibility

## Testing
- Django: patient_portal.tests.OrgAdminPatientListScopingTest
- Python compile check: patient_portal/api/views.py
