### PR TITLE
feat: PHR-S FM hardening + Phase 2 FHIR export

### DIFF
--- a/docs/phase2-fhir-export-plan.md
+++ b/docs/phase2-fhir-export-plan.md
@@ -1,0 +1,89 @@
+# Phase 2 — FHIR Export Sub-plan
+
+Detailed implementation plan for the OMOP → FHIR R4 export capability.
+
+## Strategy
+
+Invert the existing `upload_fhir_bundle` mapping. The upload handler already maps FHIR →
+OMOP; export reverses this direction. Use `*_source_value` fields and
+`Concept.concept_code` for FHIR coding (LOINC codes for Observations/Measurements, SNOMED
+for Conditions, RxNorm for medications).
+
+## OMOP → FHIR Resource Mapping
+
+| OMOP Table | FHIR Resource | Key Fields |
+|---|---|---|
+| `Person` | `Patient` | `given_name`, `family_name`, `date_of_birth`, gender concept → FHIR `gender` |
+| `ConditionOccurrence` | `Condition` | `condition_concept` → SNOMED code, `condition_start_date` → `onsetDateTime` |
+| `Measurement` | `Observation` | `measurement_concept` → LOINC code, `value_as_number` / `value_as_concept` → `valueQuantity` / `valueCodeableConcept` |
+| `Observation` | `Observation` | `observation_concept` → code, `value_as_number` / `value_as_string` |
+| `DrugExposure` | `MedicationStatement` | `drug_concept` → RxNorm code, `drug_exposure_start_date` → `effectivePeriod` |
+| `DrugExposure` (immunization) | `Immunization` | Filtered by `drug_type_concept_id` or source value containing "vaccine" |
+| `ProcedureOccurrence` | `Procedure` | `procedure_concept` → SNOMED/CPT code, `procedure_date` |
+| `VisitOccurrence` | `Encounter` | `visit_start_date` → `period`, `visit_concept` → `class` |
+
+## API Endpoint
+
+```
+GET /api/v1/patient-records/{id}/export-fhir/
+```
+
+- `@action(detail=True)` on `PatientRecordViewSet`
+- Guarded by existing `ScopedTokenPermission` + `PatientSelfScopePermission` — patients
+  can only export their own record
+- Returns `application/fhir+json` content type
+- Response is a FHIR R4 `Bundle` of type `searchset`
+
+## Management Command
+
+```bash
+.venv/bin/python manage.py export_fhir_bundle --person-id 123 --output patient_123.json
+```
+
+Mirrors the `import_fhir_bundle` pattern: uses Django's `RequestFactory` to call the API
+view in-process, avoiding Render's 30-second request timeout for large exports.
+
+Supports `--org <slug>` for bulk export of all patients in an organization.
+
+## Implementation Steps
+
+1. **Export service** (`omop_core/services/fhir_export.py`): pure function
+   `build_fhir_bundle(person: Person) -> dict` that queries all OMOP tables for the person
+   in one pass and builds the Bundle in memory.
+
+2. **Concept code resolution**: for each OMOP concept FK, look up `Concept.concept_code`
+   and `Concept.vocabulary_id` to produce `coding.system` + `coding.code`. Map vocabulary
+   IDs: `LOINC` → `http://loinc.org`, `SNOMED` → `http://snomed.info/sct`, `RxNorm` →
+   `http://www.nlm.nih.gov/research/umls/rxnorm`.
+
+3. **API action**: thin wrapper calling the service, returning `Response(bundle)`.
+
+4. **Management command**: `export_fhir_bundle` with `--person-id` and `--output` args.
+
+5. **Frontend**: "Download my record (FHIR)" button on `PatientHome`, triggering a
+   download of the JSON response.
+
+## Round-trip Testing
+
+Import a FHIR bundle → export → verify core resources are preserved:
+
+```python
+def test_import_export_roundtrip(self):
+    # Import
+    self.client.post('/api/v1/patient-records/upload_fhir/', ...)
+    # Export
+    resp = self.client.get(f'/api/v1/patient-records/{pr.pk}/export-fhir/')
+    bundle = resp.json()
+    # Verify Patient, Condition, Observation resources present
+    resource_types = {e['resource']['resourceType'] for e in bundle['entry']}
+    self.assertIn('Patient', resource_types)
+    self.assertIn('Condition', resource_types)
+    self.assertIn('Observation', resource_types)
+```
+
+## Performance Considerations
+
+- Bulk-query all OMOP tables for the person in one pass (not N+1 per resource)
+- Build Bundle in memory — typical patient record is <1MB JSON
+- For org-wide export (management command), process patients in batches
+- Consider streaming JSON for very large bundles (future optimization)

--- a/docs/phrs-fm-roadmap.md
+++ b/docs/phrs-fm-roadmap.md
@@ -47,6 +47,19 @@ applied on staging. Shipped: the patient role surface (`patient_person_for`,
 (`can_access_patient` + `_OmopFilterMixin`) and is covered by existing tests. 810 backend /
 68 frontend tests green. The design detail below is retained as the as-built record.
 
+**Post-merge hardening (same PR series):**
+- **`PatientSelfScopePermission`** — centralized object-level permission
+  (`permissions.py`) applied to all OMOP viewsets as belt-and-suspenders on top of
+  queryset filtering. Uses `_resolve_person_id()` to extract `person_id` from any OMOP
+  model (including `EpisodeEvent` via its bare `episode_id` → `Episode` lookup). Bypasses
+  for service tokens, staff, superusers, and non-patient identities.
+- **Patient account deletion (GDPR right to erasure)** — `DELETE /api/v1/patient-records/me/`
+  with `{"confirm": "DELETE"}`. Hard-deletes all patient data (Person cascade + orphan
+  EpisodeEvent cleanup + Identity removal) inside `transaction.atomic()`. Frontend: profile
+  dropdown in `PatientDetail` header replaces standalone "Sign out" button; includes
+  `DeleteAccountDialog` with typed confirmation.
+- **FM:** TI.1.7 (Account Holder data deletion).
+
 **FM:** PH.1 (PHR Account Holder Profile), TI.1 (Security / access control).
 
 **Goal:** a patient can log in and **view/edit their own record** (and only their own),
@@ -136,13 +149,20 @@ and a duplicate/claim guard, so it is kept out of this phase.
 
 ---
 
-## Phase 2 — Own-record FHIR export
+## Phase 2 — Own-record FHIR export  ✅ DONE
 
 **FM:** PH.2 (Manage Historical & Current-State Data), PH.2.4 (Ad-hoc views), S.3
 (import/export).
 
+**Status:** Implemented. Export service (`omop_core/services/fhir_export.py`), API endpoint
+(`GET /api/v1/patient-records/{person_id}/export-fhir/`), management command
+(`export_fhir_bundle`), and frontend "Download my record (FHIR)" button on `PatientHome`.
+830 backend / 75 frontend tests green.
+
 *(Own-record viewing lands in Phase 1 via `PatientHome`. This phase adds the ability to
 export that record as FHIR, plus any read-only presentation refinements.)*
+
+**Detailed sub-plan:** see [`docs/phase2-fhir-export-plan.md`](phase2-fhir-export-plan.md).
 
 **Gap:** promop has three FHIR **import** paths but **no export** of a real patient's data
 (`generate_fhir_bundle` is synthetic-only; `export_org_patients` emits raw JSON, not FHIR).
@@ -181,23 +201,34 @@ boolean-per-type model is adequate for the oncology use case.
 
 ---
 
-## Phase 4 — Patient-originated data & messaging
+## Phase 4a — Patient-originated data (surveys in patient mode)
 
-**FM:** PH.6 (Manage Encounters w/ Providers), PH.2.1 (Account-Holder-Originated Data),
-PH.3.1.
+**FM:** PH.2.1 (Account-Holder-Originated Data), PH.3.1.
 
 **Existing:** Surveys/PRO capture is solid (`Survey` / `PatientSurveyResponse`,
 `omop_core/models.py:2473,2510`; viewsets `api/views.py:4124,4199`); HealthKit device sync
-(`api/fhir/sync.py`); messaging is **one-way, server-rendered, no provider recipient**
+(`api/fhir/sync.py`).
+
+- Expose surveys + responses in patient mode (self-scoped via
+  `PatientSelfScopePermission`) so patients complete PROs from the SPA.
+- Small, well-bounded: the viewsets already exist and are scoped; this phase adds the
+  patient-mode UI route and wires it to the existing API.
+- Tests: patient completes a survey (own responses only).
+
+---
+
+## Phase 4b — Bidirectional messaging
+
+**FM:** PH.6 (Manage Encounters w/ Providers).
+
+**Existing:** messaging is **one-way, server-rendered, no provider recipient**
 (`PatientMessage` `patient_portal/models.py:138`, `views.py:80`).
 
-- Expose surveys + responses in patient mode (self-scoped) so patients complete PROs from
-  the SPA.
-- Upgrade messaging to bidirectional: add a DRF endpoint under `/api/v1/`, a
-  recipient/thread concept, and read-state, replacing the template-only flow. Render in
-  patient mode.
-- Tests: patient completes a survey (own responses only); message create/list/reply
-  self-scoped.
+- Upgrade `PatientMessage` to a DRF endpoint under `/api/v1/` with threading,
+  recipient, and read-state, replacing the template-only flow. Render in patient mode.
+- Full feature requiring its own model changes (thread, recipient FK, read timestamp),
+  serializer, and UI — warranting a separate phase.
+- Tests: message create/list/reply self-scoped.
 
 ---
 

--- a/frontend/src/components/Patient/DeleteAccountDialog.test.tsx
+++ b/frontend/src/components/Patient/DeleteAccountDialog.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import DeleteAccountDialog from "./DeleteAccountDialog";
+
+// Mock the axios instance
+vi.mock("@/api/axios", () => ({
+  default: {
+    delete: vi.fn(),
+  },
+}));
+
+import api from "@/api/axios";
+
+describe("DeleteAccountDialog", () => {
+  const onClose = vi.fn();
+  const onDeleted = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders warning text and confirm input", () => {
+    render(<DeleteAccountDialog onClose={onClose} onDeleted={onDeleted} />);
+    expect(screen.getByText(/permanently delete/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/DELETE/)).toBeInTheDocument();
+  });
+
+  it("confirm button is disabled until DELETE is typed", () => {
+    render(<DeleteAccountDialog onClose={onClose} onDeleted={onDeleted} />);
+    const btn = screen.getByRole("button", { name: /delete my account/i });
+    expect(btn).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/DELETE/), { target: { value: "DELETE" } });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("calls API and onDeleted on successful delete", async () => {
+    (api.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} });
+
+    render(<DeleteAccountDialog onClose={onClose} onDeleted={onDeleted} />);
+    fireEvent.change(screen.getByLabelText(/DELETE/), { target: { value: "DELETE" } });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => {
+      expect(api.delete).toHaveBeenCalledWith("/api/v1/patient-records/me/", {
+        data: { confirm: "DELETE" },
+      });
+      expect(onDeleted).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error message on API failure", async () => {
+    (api.delete as ReturnType<typeof vi.fn>).mockRejectedValueOnce({
+      response: { data: { detail: "Something went wrong" } },
+    });
+
+    render(<DeleteAccountDialog onClose={onClose} onDeleted={onDeleted} />);
+    fireEvent.change(screen.getByLabelText(/DELETE/), { target: { value: "DELETE" } });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    render(<DeleteAccountDialog onClose={onClose} onDeleted={onDeleted} />);
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Patient/DeleteAccountDialog.tsx
+++ b/frontend/src/components/Patient/DeleteAccountDialog.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import api from "@/api/axios";
+
+interface DeleteAccountDialogProps {
+  onClose: () => void;
+  onDeleted: () => void;
+}
+
+export default function DeleteAccountDialog({ onClose, onDeleted }: DeleteAccountDialogProps) {
+  const [confirmText, setConfirmText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canConfirm = confirmText === "DELETE";
+
+  async function handleDelete() {
+    if (!canConfirm || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.delete("/api/v1/patient-records/me/", { data: { confirm: "DELETE" } });
+      onDeleted();
+    } catch (err: unknown) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+        ?? "Failed to delete account. Please try again.";
+      setError(detail);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div
+        className="mx-4 w-full max-w-md rounded-2xl bg-background p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-100">
+            <AlertTriangle className="h-5 w-5 text-red-600" />
+          </div>
+          <h3 className="text-lg font-semibold text-foreground">Delete your account</h3>
+        </div>
+
+        <p className="mb-4 text-sm text-muted-foreground">
+          This will <strong>permanently delete</strong> your account and all associated health data.
+          This action cannot be undone.
+        </p>
+
+        <label className="mb-1 block text-sm font-medium text-foreground" htmlFor="delete-confirm">
+          Type <span className="font-mono font-bold">DELETE</span> to confirm
+        </label>
+        <input
+          id="delete-confirm"
+          type="text"
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          className="mb-4 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none focus:border-red-400 focus:ring-1 focus:ring-red-400"
+          autoComplete="off"
+          autoFocus
+        />
+
+        {error && <p className="mb-3 text-sm text-red-600">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={!canConfirm || submitting}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            {submitting ? "Deleting..." : "Delete my account"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, Check, AlertCircle } from "lucide-react";
+import { ArrowLeft, Check, AlertCircle, ChevronDown } from "lucide-react";
 import api from "@/api/axios";
 import { getActiveBranding } from "@/config/branding";
+import DeleteAccountDialog from "./DeleteAccountDialog";
 import GeneralTab from "@/components/PatientInfo/tabs/GeneralTab";
 import DiseaseTab from "@/components/PatientInfo/tabs/DiseaseTab";
 import TreatmentTab from "@/components/PatientInfo/tabs/TreatmentTab";
@@ -50,6 +51,57 @@ function SaveStatusIndicator({ status, onRetry }: { status: SaveStatus; onRetry:
         </>
       )}
     </div>
+  );
+}
+
+function ProfileDropdown({ onLogout }: { onLogout: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  return (
+    <>
+      <div className="relative" ref={ref}>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="flex shrink-0 items-center gap-1 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-[#eef0f4] hover:text-foreground"
+        >
+          Account
+          <ChevronDown className="h-3 w-3" />
+        </button>
+        {open && (
+          <div className="absolute right-0 top-full z-40 mt-1 w-44 rounded-lg border border-border bg-background py-1 shadow-lg">
+            <button
+              onClick={() => { setOpen(false); onLogout(); }}
+              className="w-full px-4 py-2 text-left text-sm text-foreground hover:bg-muted"
+            >
+              Sign out
+            </button>
+            <button
+              onClick={() => { setOpen(false); setShowDeleteDialog(true); }}
+              className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50"
+            >
+              Delete my account
+            </button>
+          </div>
+        )}
+      </div>
+      {showDeleteDialog && (
+        <DeleteAccountDialog
+          onClose={() => setShowDeleteDialog(false)}
+          onDeleted={onLogout}
+        />
+      )}
+    </>
   );
 }
 
@@ -425,12 +477,7 @@ export default function PatientDetail({
               </div>
             )}
             {patientMode && onLogout && (
-              <button
-                onClick={onLogout}
-                className="shrink-0 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-[#eef0f4] hover:text-foreground"
-              >
-                Sign out
-              </button>
+              <ProfileDropdown onLogout={onLogout} />
             )}
           </div>
         </div>

--- a/frontend/src/components/Patient/PatientHome.test.tsx
+++ b/frontend/src/components/Patient/PatientHome.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/components/Patient/PatientDetail", () => ({
   ),
 }));
 
+vi.mock("@/api/axios", () => ({
+  default: { get: vi.fn() },
+}));
+
 const makeUser = (overrides: Partial<User>): User => ({
   id: 1,
   sub: "sub",
@@ -38,5 +42,22 @@ describe("PatientHome", () => {
   it("shows a no-record message when user is null", () => {
     render(<PatientHome user={null} onLogout={vi.fn()} />);
     expect(screen.getByText(/no health record is linked/i)).toBeInTheDocument();
+  });
+
+  it("renders the download FHIR button when patient has a person_id", () => {
+    render(
+      <PatientHome
+        user={makeUser({ is_patient: true, person_id: 7 })}
+        onLogout={vi.fn()}
+      />
+    );
+    const downloadBtn = screen.getByRole("button", { name: /download my record \(fhir\)/i });
+    expect(downloadBtn).toBeInTheDocument();
+    expect(downloadBtn).toBeEnabled();
+  });
+
+  it("does not render the download FHIR button when no person is linked", () => {
+    render(<PatientHome user={makeUser({ is_patient: true, person_id: null })} onLogout={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /download my record \(fhir\)/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Patient/PatientHome.tsx
+++ b/frontend/src/components/Patient/PatientHome.tsx
@@ -1,6 +1,8 @@
-import { AlertCircle } from "lucide-react";
+import { useState } from "react";
+import { AlertCircle, Download } from "lucide-react";
 import type { User } from "@/hooks/useAuth";
 import PatientDetail from "@/components/Patient/PatientDetail";
+import api from "@/api/axios";
 
 /**
  * Patient (PHR Account Holder) landing view — PHR-S FM PH.1 / PH.2.
@@ -16,6 +18,9 @@ export default function PatientHome({
   user: User | null;
   onLogout: () => void;
 }) {
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
   if (!user || user.person_id == null) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#f5f7fa] p-6">
@@ -35,11 +40,47 @@ export default function PatientHome({
     );
   }
 
+  const handleDownloadFhir = async () => {
+    setDownloading(true);
+    setDownloadError(null);
+    try {
+      const response = await api.get(`/v1/patient-records/${user.person_id}/export-fhir/`);
+      const blob = new Blob([JSON.stringify(response.data, null, 2)], { type: "application/fhir+json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "my-health-record.fhir.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setDownloadError("Failed to download your health record. Please try again.");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
   return (
-    <PatientDetail
-      personIdOverride={String(user.person_id)}
-      patientMode
-      onLogout={onLogout}
-    />
+    <div>
+      <div className="flex justify-end px-6 pt-4">
+        <button
+          onClick={handleDownloadFhir}
+          disabled={downloading}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Download className="h-4 w-4" />
+          {downloading ? "Downloading..." : "Download my record (FHIR)"}
+        </button>
+      </div>
+      {downloadError && (
+        <div className="px-6 pt-2">
+          <p className="text-sm text-red-600">{downloadError}</p>
+        </div>
+      )}
+      <PatientDetail
+        personIdOverride={String(user.person_id)}
+        patientMode
+        onLogout={onLogout}
+      />
+    </div>
   );
 }

--- a/omop_core/management/commands/export_fhir_bundle.py
+++ b/omop_core/management/commands/export_fhir_bundle.py
@@ -1,0 +1,107 @@
+"""
+Export a patient's OMOP data as a FHIR R4 Bundle JSON file.
+
+Usage:
+    # Single patient → file
+    python manage.py export_fhir_bundle --person-id 123 --output patient_123.json
+
+    # All patients in an org → file (JSON array of bundles)
+    python manage.py export_fhir_bundle --org acme-onc --output acme_patients.json
+
+    # Single patient → stdout (for piping)
+    python manage.py export_fhir_bundle --person-id 123
+"""
+
+import json
+import sys
+
+from django.core.management.base import BaseCommand, CommandError
+
+from omop_core.models import PatientRecord, Person
+from omop_core.services.fhir_export import build_fhir_bundle
+
+
+class Command(BaseCommand):
+    help = 'Export OMOP patient data as a FHIR R4 Bundle JSON file'
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            '--person-id',
+            type=int,
+            help='Export a single patient by person_id',
+        )
+        group.add_argument(
+            '--org',
+            type=str,
+            help='Export all patients in an organization (by slug)',
+        )
+        parser.add_argument(
+            '-o', '--output',
+            type=str,
+            default=None,
+            help='Output file path (default: stdout)',
+        )
+
+    def handle(self, *args, **options):
+        person_id = options['person_id']
+        org_slug = options['org']
+        output_path = options['output']
+
+        if person_id is not None:
+            self._export_single(person_id, output_path)
+        else:
+            self._export_org(org_slug, output_path)
+
+    def _export_single(self, person_id, output_path):
+        try:
+            person = Person.objects.get(person_id=person_id)
+        except Person.DoesNotExist:
+            raise CommandError(f'Person with person_id={person_id} does not exist.')
+
+        bundle = build_fhir_bundle(person)
+        json_str = json.dumps(bundle, indent=2)
+
+        if output_path:
+            with open(output_path, 'w') as f:
+                f.write(json_str)
+            self.stderr.write(self.style.SUCCESS(
+                f'Exported {bundle["total"]} resources for person_id={person_id} → {output_path}'
+            ))
+        else:
+            sys.stdout.write(json_str)
+            sys.stdout.write('\n')
+            self.stderr.write(self.style.SUCCESS(
+                f'Exported {bundle["total"]} resources for person_id={person_id}'
+            ))
+
+    def _export_org(self, org_slug, output_path):
+        records = (
+            PatientRecord.objects
+            .filter(organization__slug=org_slug)
+            .select_related('person')
+        )
+        if not records.exists():
+            raise CommandError(
+                f'No patients found for organization slug="{org_slug}".'
+            )
+
+        bundles = []
+        for record in records.iterator():
+            bundle = build_fhir_bundle(record.person)
+            bundles.append(bundle)
+
+        json_str = json.dumps(bundles, indent=2)
+
+        if output_path:
+            with open(output_path, 'w') as f:
+                f.write(json_str)
+            self.stderr.write(self.style.SUCCESS(
+                f'Exported {len(bundles)} patients for org="{org_slug}" → {output_path}'
+            ))
+        else:
+            sys.stdout.write(json_str)
+            sys.stdout.write('\n')
+            self.stderr.write(self.style.SUCCESS(
+                f'Exported {len(bundles)} patients for org="{org_slug}"'
+            ))

--- a/omop_core/services/fhir_export.py
+++ b/omop_core/services/fhir_export.py
@@ -1,0 +1,431 @@
+"""
+FHIR R4 Bundle export service.
+
+Converts a patient's OMOP CDM data into a FHIR R4 Bundle (type "searchset").
+All OMOP tables are queried in bulk up front to avoid N+1 queries.
+"""
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from omop_core.models import (
+    ConditionOccurrence,
+    DrugExposure,
+    Measurement,
+    Observation,
+    Person,
+    ProcedureOccurrence,
+    VisitOccurrence,
+)
+
+# ---------------------------------------------------------------------------
+# Vocabulary → FHIR system mapping
+# ---------------------------------------------------------------------------
+
+_VOCAB_TO_FHIR_SYSTEM: dict[str, str] = {
+    "LOINC": "http://loinc.org",
+    "SNOMED": "http://snomed.info/sct",
+    "RxNorm": "http://www.nlm.nih.gov/research/umls/rxnorm",
+    "CPT4": "http://www.ama-assn.org/go/cpt",
+    "ICD10CM": "http://hl7.org/fhir/sid/icd-10-cm",
+    "HemOnc": "https://hemonc.org",
+}
+
+# Gender concept_id → FHIR AdministrativeGender code
+_GENDER_MAP: dict[int, str] = {
+    8532: "female",
+    8507: "male",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fhir_system(vocabulary_id: str) -> str:
+    """Map an OMOP vocabulary_id to a FHIR coding system URI."""
+    return _VOCAB_TO_FHIR_SYSTEM.get(vocabulary_id, f"urn:oid:unknown:{vocabulary_id}")
+
+
+def _make_coding(concept) -> dict[str, str] | None:
+    """Build a FHIR Coding dict from an OMOP Concept, or None if concept is missing/zero."""
+    if concept is None or concept.concept_id == 0:
+        return None
+    return {
+        "system": _fhir_system(concept.vocabulary_id),
+        "code": concept.concept_code,
+        "display": concept.concept_name,
+    }
+
+
+def _date_str(d: date | datetime | None) -> str | None:
+    """Format a date or datetime as an ISO string, or None."""
+    if d is None:
+        return None
+    if isinstance(d, datetime):
+        return d.isoformat()
+    return d.isoformat()
+
+
+def _decimal_to_float(val: Decimal | None) -> float | None:
+    """Convert a Decimal to float for JSON serialization, or None."""
+    if val is None:
+        return None
+    return float(val)
+
+
+def _make_entry(resource: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a FHIR resource in a Bundle entry."""
+    resource_id = resource.get("id", str(uuid.uuid4()))
+    return {
+        "fullUrl": f"urn:uuid:{resource_id}",
+        "resource": resource,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Resource builders
+# ---------------------------------------------------------------------------
+
+def _build_patient(person: Person) -> dict[str, Any]:
+    """Convert an OMOP Person to a FHIR Patient resource."""
+    resource_id = str(uuid.uuid4())
+    patient: dict[str, Any] = {
+        "resourceType": "Patient",
+        "id": resource_id,
+    }
+
+    # Name
+    name_parts: dict[str, Any] = {}
+    if person.family_name:
+        name_parts["family"] = person.family_name
+    if person.given_name:
+        name_parts["given"] = [person.given_name]
+    if name_parts:
+        patient["name"] = [name_parts]
+
+    # Birth date
+    if person.year_of_birth:
+        month = person.month_of_birth or 1
+        day = person.day_of_birth or 1
+        try:
+            birth_date = date(person.year_of_birth, month, day)
+            patient["birthDate"] = birth_date.isoformat()
+        except ValueError:
+            # Invalid date components — use year only
+            patient["birthDate"] = str(person.year_of_birth)
+
+    # Gender
+    gender_concept_id = person.gender_concept_id
+    patient["gender"] = _GENDER_MAP.get(gender_concept_id, "unknown")
+
+    return patient
+
+
+def _build_condition(condition: ConditionOccurrence, patient_ref: str) -> dict[str, Any]:
+    """Convert an OMOP ConditionOccurrence to a FHIR Condition resource."""
+    resource_id = str(uuid.uuid4())
+    result: dict[str, Any] = {
+        "resourceType": "Condition",
+        "id": resource_id,
+        "subject": {"reference": patient_ref},
+    }
+
+    # Code
+    coding = _make_coding(condition.condition_concept)
+    code_obj: dict[str, Any] = {}
+    if coding:
+        code_obj["coding"] = [coding]
+    if condition.condition_source_value:
+        code_obj["text"] = condition.condition_source_value
+    if code_obj:
+        result["code"] = code_obj
+
+    # Onset
+    onset = _date_str(condition.condition_start_datetime) or _date_str(condition.condition_start_date)
+    if onset:
+        result["onsetDateTime"] = onset
+
+    # Abatement
+    abatement = _date_str(condition.condition_end_datetime) or _date_str(condition.condition_end_date)
+    if abatement:
+        result["abatementDateTime"] = abatement
+
+    return result
+
+
+def _build_measurement_observation(meas: Measurement, patient_ref: str) -> dict[str, Any]:
+    """Convert an OMOP Measurement to a FHIR Observation resource."""
+    resource_id = str(uuid.uuid4())
+    result: dict[str, Any] = {
+        "resourceType": "Observation",
+        "id": resource_id,
+        "status": "final",
+        "subject": {"reference": patient_ref},
+    }
+
+    # Code
+    coding = _make_coding(meas.measurement_concept)
+    code_obj: dict[str, Any] = {}
+    if coding:
+        code_obj["coding"] = [coding]
+    if meas.measurement_source_value:
+        code_obj["text"] = meas.measurement_source_value
+    if code_obj:
+        result["code"] = code_obj
+
+    # Effective date
+    effective = _date_str(meas.measurement_datetime) or _date_str(meas.measurement_date)
+    if effective:
+        result["effectiveDateTime"] = effective
+
+    # Value
+    if meas.value_as_number is not None:
+        quantity: dict[str, Any] = {"value": _decimal_to_float(meas.value_as_number)}
+        if meas.unit_source_value:
+            quantity["unit"] = meas.unit_source_value
+        result["valueQuantity"] = quantity
+    elif meas.value_as_concept_id and meas.value_as_concept_id != 0:
+        val_coding = _make_coding(meas.value_as_concept)
+        if val_coding:
+            result["valueCodeableConcept"] = {"coding": [val_coding]}
+    elif meas.value_as_string:
+        result["valueString"] = meas.value_as_string
+
+    # Reference range
+    if meas.range_low is not None or meas.range_high is not None:
+        ref_range: dict[str, Any] = {}
+        if meas.range_low is not None:
+            ref_range["low"] = {"value": _decimal_to_float(meas.range_low)}
+        if meas.range_high is not None:
+            ref_range["high"] = {"value": _decimal_to_float(meas.range_high)}
+        result["referenceRange"] = [ref_range]
+
+    return result
+
+
+def _build_observation(obs: Observation, patient_ref: str) -> dict[str, Any]:
+    """Convert an OMOP Observation to a FHIR Observation resource."""
+    resource_id = str(uuid.uuid4())
+    result: dict[str, Any] = {
+        "resourceType": "Observation",
+        "id": resource_id,
+        "status": "final",
+        "subject": {"reference": patient_ref},
+    }
+
+    # Code
+    coding = _make_coding(obs.observation_concept)
+    code_obj: dict[str, Any] = {}
+    if coding:
+        code_obj["coding"] = [coding]
+    if obs.observation_source_value:
+        code_obj["text"] = obs.observation_source_value
+    if code_obj:
+        result["code"] = code_obj
+
+    # Effective date
+    effective = _date_str(obs.observation_datetime) or _date_str(obs.observation_date)
+    if effective:
+        result["effectiveDateTime"] = effective
+
+    # Value
+    if obs.value_as_number is not None:
+        quantity: dict[str, Any] = {"value": _decimal_to_float(obs.value_as_number)}
+        if obs.unit_source_value:
+            quantity["unit"] = obs.unit_source_value
+        result["valueQuantity"] = quantity
+    elif obs.value_as_string:
+        result["valueString"] = obs.value_as_string
+    elif obs.value_as_concept_id and obs.value_as_concept_id != 0:
+        val_coding = _make_coding(obs.value_as_concept)
+        if val_coding:
+            result["valueCodeableConcept"] = {"coding": [val_coding]}
+
+    return result
+
+
+def _build_medication_statement(drug: DrugExposure, patient_ref: str) -> dict[str, Any]:
+    """Convert an OMOP DrugExposure to a FHIR MedicationStatement resource."""
+    resource_id = str(uuid.uuid4())
+    result: dict[str, Any] = {
+        "resourceType": "MedicationStatement",
+        "id": resource_id,
+        "status": "completed",
+        "subject": {"reference": patient_ref},
+    }
+
+    # Medication coding
+    coding = _make_coding(drug.drug_concept)
+    med_obj: dict[str, Any] = {}
+    if coding:
+        med_obj["coding"] = [coding]
+    if drug.drug_source_value:
+        med_obj["text"] = drug.drug_source_value
+    if med_obj:
+        result["medicationCodeableConcept"] = med_obj
+
+    # Effective period
+    period: dict[str, str] = {}
+    start = _date_str(drug.drug_exposure_start_datetime) or _date_str(drug.drug_exposure_start_date)
+    if start:
+        period["start"] = start
+    end = _date_str(drug.drug_exposure_end_datetime) or _date_str(drug.drug_exposure_end_date)
+    if end:
+        period["end"] = end
+    if period:
+        result["effectivePeriod"] = period
+
+    return result
+
+
+def _build_procedure(proc: ProcedureOccurrence, patient_ref: str) -> dict[str, Any]:
+    """Convert an OMOP ProcedureOccurrence to a FHIR Procedure resource."""
+    resource_id = str(uuid.uuid4())
+    result: dict[str, Any] = {
+        "resourceType": "Procedure",
+        "id": resource_id,
+        "status": "completed",
+        "subject": {"reference": patient_ref},
+    }
+
+    # Code
+    coding = _make_coding(proc.procedure_concept)
+    code_obj: dict[str, Any] = {}
+    if coding:
+        code_obj["coding"] = [coding]
+    if proc.procedure_source_value:
+        code_obj["text"] = proc.procedure_source_value
+    if code_obj:
+        result["code"] = code_obj
+
+    # Performed date
+    performed = _date_str(proc.procedure_datetime) or _date_str(proc.procedure_date)
+    if performed:
+        result["performedDateTime"] = performed
+
+    return result
+
+
+def _build_encounter(visit: VisitOccurrence, patient_ref: str) -> dict[str, Any]:
+    """Convert an OMOP VisitOccurrence to a FHIR Encounter resource."""
+    resource_id = str(uuid.uuid4())
+    result: dict[str, Any] = {
+        "resourceType": "Encounter",
+        "id": resource_id,
+        "status": "finished",
+        "subject": {"reference": patient_ref},
+    }
+
+    # Class
+    coding = _make_coding(visit.visit_concept)
+    if coding:
+        result["class"] = coding
+
+    # Period
+    period: dict[str, str] = {}
+    start = _date_str(visit.visit_start_datetime) or _date_str(visit.visit_start_date)
+    if start:
+        period["start"] = start
+    end = _date_str(visit.visit_end_datetime) or _date_str(visit.visit_end_date)
+    if end:
+        period["end"] = end
+    if period:
+        result["period"] = period
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main export function
+# ---------------------------------------------------------------------------
+
+def build_fhir_bundle(person: Person) -> dict[str, Any]:
+    """
+    Build a FHIR R4 Bundle of type "searchset" from a patient's OMOP data.
+
+    Queries all relevant OMOP tables for the given Person in bulk (one query
+    per table, with select_related for concept FKs) and converts each row
+    to its corresponding FHIR resource.
+
+    Args:
+        person: An OMOP Person model instance.
+
+    Returns:
+        A JSON-serializable dict representing a FHIR R4 Bundle.
+    """
+    entries: list[dict[str, Any]] = []
+
+    # Patient resource
+    patient_resource = _build_patient(person)
+    patient_ref = f"Patient/{patient_resource['id']}"
+    entries.append(_make_entry(patient_resource))
+
+    # --- ConditionOccurrence → Condition ---
+    conditions = (
+        ConditionOccurrence.objects
+        .filter(person=person)
+        .select_related("condition_concept", "condition_concept__vocabulary")
+    )
+    for cond in conditions:
+        entries.append(_make_entry(_build_condition(cond, patient_ref)))
+
+    # --- Measurement → Observation ---
+    measurements = (
+        Measurement.objects
+        .filter(person=person)
+        .select_related(
+            "measurement_concept", "measurement_concept__vocabulary",
+            "value_as_concept", "value_as_concept__vocabulary",
+        )
+    )
+    for meas in measurements:
+        entries.append(_make_entry(_build_measurement_observation(meas, patient_ref)))
+
+    # --- Observation → Observation ---
+    observations = (
+        Observation.objects
+        .filter(person=person)
+        .select_related(
+            "observation_concept", "observation_concept__vocabulary",
+            "value_as_concept", "value_as_concept__vocabulary",
+        )
+    )
+    for obs in observations:
+        entries.append(_make_entry(_build_observation(obs, patient_ref)))
+
+    # --- DrugExposure → MedicationStatement ---
+    drug_exposures = (
+        DrugExposure.objects
+        .filter(person=person)
+        .select_related("drug_concept", "drug_concept__vocabulary")
+    )
+    for drug in drug_exposures:
+        entries.append(_make_entry(_build_medication_statement(drug, patient_ref)))
+
+    # --- ProcedureOccurrence → Procedure ---
+    procedures = (
+        ProcedureOccurrence.objects
+        .filter(person=person)
+        .select_related("procedure_concept", "procedure_concept__vocabulary")
+    )
+    for proc in procedures:
+        entries.append(_make_entry(_build_procedure(proc, patient_ref)))
+
+    # --- VisitOccurrence → Encounter ---
+    visits = (
+        VisitOccurrence.objects
+        .filter(person=person)
+        .select_related("visit_concept", "visit_concept__vocabulary")
+    )
+    for visit in visits:
+        entries.append(_make_entry(_build_encounter(visit, patient_ref)))
+
+    return {
+        "resourceType": "Bundle",
+        "type": "searchset",
+        "total": len(entries),
+        "entry": entries,
+    }

--- a/patient_portal/api/permissions.py
+++ b/patient_portal/api/permissions.py
@@ -1,7 +1,12 @@
+import logging
+
+from django.utils import timezone
 from rest_framework.permissions import BasePermission
 
 from .providers.base import TokenClaims
 from omop_core.services.access import has_org_admin_access
+
+logger = logging.getLogger(__name__)
 
 # Sentinel value set by ServiceTokenAuthentication when the HMAC check passes.
 # Use is_service_token() rather than comparing this string directly.
@@ -129,6 +134,88 @@ class IsStaffPermission(BasePermission):
             request.user.is_authenticated and
             getattr(request.user, 'is_staff', False)
         )
+
+
+def _resolve_person_id(obj):
+    """Extract person_id from any OMOP model instance.
+
+    Returns the person_id (int) or None if it cannot be determined.
+
+    Handles two patterns:
+    - Direct FK: obj.person_id (covers Person, PatientRecord, ConditionOccurrence,
+      DrugExposure, Measurement, Observation, ProcedureOccurrence, Episode,
+      PatientDocument, PatientTrialEnrollment, PatientSurveyResponse)
+    - EpisodeEvent: has a bare episode_id (BigIntegerField, not a FK). Resolves
+      via Episode.objects.values_list('person_id', ...).
+    """
+    # Pattern 1: direct person_id attribute (covers most OMOP models)
+    pid = getattr(obj, 'person_id', None)
+    if pid is not None:
+        return pid
+
+    # Pattern 2: EpisodeEvent — resolve via Episode table
+    episode_id = getattr(obj, 'episode_id', None)
+    if episode_id is not None:
+        from omop_oncology.models import Episode
+        try:
+            return Episode.objects.values_list('person_id', flat=True).get(
+                episode_id=episode_id
+            )
+        except Episode.DoesNotExist:
+            return None
+
+    return None
+
+
+class PatientSelfScopePermission(BasePermission):
+    """Object-level permission: patients may only access their own data.
+
+    Belt-and-suspenders safety net on top of queryset filtering. DRF calls
+    ``has_object_permission`` on retrieve/update/destroy — not on list (which
+    relies on queryset scoping in ``_OmopFilterMixin``/viewset ``get_queryset``).
+
+    Bypass rules (allow access regardless of object ownership):
+    - Service tokens (trusted backend)
+    - Staff / superuser
+    - Non-patient identities (no PatientUser link, or has provider GroupAccess)
+    """
+
+    def has_permission(self, request, view):
+        return True  # View-level gating is ScopedTokenPermission's job
+
+    def has_object_permission(self, request, view, obj):
+        if is_service_token(request):
+            return True
+
+        from patient_portal.services import patient_person_for
+        patient_person = patient_person_for(request.user)
+        if patient_person is None:
+            # Not a patient (staff, superuser, provider, or unauthenticated).
+            return True
+
+        obj_person_id = _resolve_person_id(obj)
+        if obj_person_id is None:
+            # Cannot determine ownership — fail closed.
+            logger.warning(
+                'PatientSelfScopePermission: cannot resolve person_id for %s pk=%s',
+                type(obj).__name__, getattr(obj, 'pk', '?'),
+            )
+            return False
+
+        return obj_person_id == patient_person.person_id
+
+
+class PatientDeletePermission(ScopedTokenPermission):
+    """ScopedTokenPermission that also allows DELETE for patient account deletion.
+
+    Used on the ``me`` action where patients need to delete their own account.
+    All other methods defer to the standard ScopedTokenPermission rules.
+    """
+
+    def has_permission(self, request, view):
+        if request.method == 'DELETE':
+            return bool(request.user and request.user.is_authenticated)
+        return super().has_permission(request, view)
 
 
 class IsStaffOrOrgAdmin(BasePermission):

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -59,7 +59,7 @@ import json
 import logging
 import re
 from io import StringIO
-from .permissions import ScopedTokenPermission, get_request_org, is_service_token
+from .permissions import ScopedTokenPermission, PatientSelfScopePermission, PatientDeletePermission, get_request_org, is_service_token
 from .providers.base import TokenClaims
 from .serializers import (
     UserSerializer, PatientRecordSerializer, PatientListSerializer, ProvenanceRecordSerializer,
@@ -171,7 +171,7 @@ def _delete_omop_clinical_rows(person):
 @method_decorator(csrf_exempt, name='dispatch')
 class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PatientRecordSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     pagination_class = PatientRecordPagination
 
     DATE_FILTERS = {
@@ -511,7 +511,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
 
         return Response({**serializer.data, 'previous_values': previous_values})
 
-    @action(detail=True, methods=['get'], permission_classes=[ScopedTokenPermission])
+    @action(detail=True, methods=['get'], permission_classes=[ScopedTokenPermission, PatientSelfScopePermission])
     def provenance(self, request, pk=None):
         """GET /api/patient-info/{person_id}/provenance/ — full provenance history for a patient."""
         try:
@@ -547,9 +547,12 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         records = ProvenanceRecord.objects.filter(q).select_related('content_type').order_by('-created_at')
         return Response(ProvenanceRecordSerializer(records, many=True).data)
 
-    @action(detail=False, methods=['get', 'patch'], permission_classes=[ScopedTokenPermission])
+    @action(detail=False, methods=['get', 'patch', 'delete'], permission_classes=[PatientDeletePermission, PatientSelfScopePermission])
     def me(self, request):
-        """GET/PATCH /api/patient-info/me/ — current user's own PatientRecord."""
+        """GET/PATCH/DELETE /api/patient-info/me/ — current user's own PatientRecord."""
+        if request.method == 'DELETE':
+            return self._delete_patient_account(request)
+
         from patient_portal.models import PatientUser
         from patient_portal.services import resolve_or_create_person
 
@@ -619,7 +622,72 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=False, methods=['post'], permission_classes=[ScopedTokenPermission])
+    def _delete_patient_account(self, request):
+        """DELETE /api/patient-info/me/ — permanently delete the patient's account and all data."""
+        from patient_portal.services import patient_person_for
+        from patient_portal.models import PatientUser
+
+        patient_person = patient_person_for(request.user)
+        if patient_person is None:
+            return Response(
+                {'detail': 'Only patients can delete their own account.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        confirm = request.data.get('confirm')
+        if confirm != 'DELETE':
+            return Response(
+                {'detail': 'Request body must include {"confirm": "DELETE"}.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        person_id = patient_person.person_id
+        identity = request.user
+
+        with transaction.atomic():
+            # Delete EpisodeEvent rows — bare integer FK, not covered by CASCADE
+            episode_ids = list(
+                Episode.objects.filter(person=patient_person)
+                .values_list('episode_id', flat=True)
+            )
+            if episode_ids:
+                EpisodeEvent.objects.filter(episode_id__in=episode_ids).delete()
+
+            # Delete Person — cascades to all OMOP tables, PatientRecord, PatientUser
+            patient_person.delete()
+
+            # Delete the Identity (auth credential)
+            identity.delete()
+
+        logger.info(
+            'patient_account_deleted person_id=%s identity_email=%s',
+            person_id, getattr(identity, 'email', '?'),
+        )
+
+        return Response({'detail': 'Account and all associated data have been permanently deleted.'})
+
+    @action(detail=True, methods=['get'], url_path='export-fhir',
+            permission_classes=[ScopedTokenPermission, PatientSelfScopePermission])
+    def export_fhir(self, request, pk=None):
+        """GET /api/v1/patient-records/{person_id}/export-fhir/ — export as FHIR R4 Bundle.
+
+        ``pk`` is interpreted as ``person_id`` (consistent with ``retrieve``).
+        """
+        from omop_core.services.fhir_export import build_fhir_bundle
+
+        try:
+            person = Person.objects.get(person_id=pk)
+            patient_record = PatientRecord.objects.get(person=person)
+        except (Person.DoesNotExist, PatientRecord.DoesNotExist):
+            return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        # Object-level permission check (PatientSelfScopePermission)
+        self.check_object_permissions(request, patient_record)
+
+        bundle = build_fhir_bundle(person)
+        return Response(bundle, content_type='application/fhir+json')
+
+    @action(detail=False, methods=['post'], permission_classes=[ScopedTokenPermission, PatientSelfScopePermission])
     def upload_csv(self, request):
         """Upload patients from CSV file"""
         if 'file' not in request.FILES:
@@ -695,7 +763,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         except Exception as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
     
-    @action(detail=False, methods=['post'], permission_classes=[ScopedTokenPermission])
+    @action(detail=False, methods=['post'], permission_classes=[ScopedTokenPermission, PatientSelfScopePermission])
     def upload_fhir(self, request):
         """Upload patients from FHIR JSON file"""
         if 'file' not in request.FILES:
@@ -3444,7 +3512,7 @@ class PersonViewSet(viewsets.GenericViewSet):
       POST /api/persons/find_or_create/  — resolve OIDC identity to a Person row
       PATCH /api/persons/{person_id}/    — fill-if-empty demographic patch
     """
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Person.objects.all()
     lookup_field = 'person_id'
 
@@ -3660,21 +3728,21 @@ class _ProvenanceMixin:
 @method_decorator(csrf_exempt, name='dispatch')
 class ConditionOccurrenceViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ConditionOccurrenceSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = ConditionOccurrence.objects.all()
 
 
 @method_decorator(csrf_exempt, name='dispatch')
 class DrugExposureViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = DrugExposureSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = DrugExposure.objects.all()
 
 
 @method_decorator(csrf_exempt, name='dispatch')
 class MeasurementViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = MeasurementSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Measurement.objects.all()
     ordering_fields = ['measurement_date', 'measurement_id']
     ordering = ['-measurement_date']
@@ -3710,28 +3778,28 @@ class MeasurementViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewS
 @method_decorator(csrf_exempt, name='dispatch')
 class ObservationViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ObservationSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Observation.objects.all()
 
 
 @method_decorator(csrf_exempt, name='dispatch')
 class ProcedureOccurrenceViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ProcedureOccurrenceSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = ProcedureOccurrence.objects.all()
 
 
 @method_decorator(csrf_exempt, name='dispatch')
 class EpisodeViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = EpisodeSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Episode.objects.all()
 
 
 @method_decorator(csrf_exempt, name='dispatch')
 class EpisodeEventViewSet(viewsets.ModelViewSet):
     serializer_class = EpisodeEventSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
 
     def list(self, request, *args, **kwargs):
         if not request.query_params.get('episode_id'):
@@ -4413,7 +4481,7 @@ def vocabulary_list(request, model_name):
 @method_decorator(csrf_exempt, name='dispatch')
 class PatientDocumentViewSet(_OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = PatientDocumentSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = PatientDocument.objects.all()
 
 
@@ -4426,7 +4494,7 @@ class PatientTrialEnrollmentViewSet(_OmopFilterMixin, viewsets.ModelViewSet):
     Filter by person: GET /api/trial-enrollments/?person_id=42
     """
     serializer_class = PatientTrialEnrollmentSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = PatientTrialEnrollment.objects.all()
 
 
@@ -4514,7 +4582,7 @@ class PatientSurveyResponseViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.
     PUT is disabled: values/values_dates are append-only dicts; use PATCH.
     """
     serializer_class = PatientSurveyResponseSerializer
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = PatientSurveyResponse.objects.select_related('survey').all()
     http_method_names = ['get', 'post', 'patch', 'head', 'options']
 

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -10697,3 +10697,435 @@ class ConceptSynonymApiTest(_SmartBase):
         resp = self.client.get('/api/v1/concepts/synonyms/?q=VRd')
         self.assertIn(resp.status_code,
                       [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+
+# ---------------------------------------------------------------------------
+# PatientSelfScopePermission tests
+# ---------------------------------------------------------------------------
+
+class PatientSelfScopePermissionTest(TestCase):
+    """Test that PatientSelfScopePermission blocks cross-patient object access."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+        from omop_core.models import GroupAccess, Organization
+
+        _make_vocab_fixtures()
+        condition_concept = Concept.objects.get(concept_id=4112853)
+        type_concept = Concept.objects.get(concept_id=32817)
+
+        # Patient A
+        cls.person_a = Person.objects.create(person_id=93001, family_name='Able', given_name='Amy')
+        cls.patient_a_rec = PatientRecord.objects.create(person=cls.person_a)
+        cls.identity_a = Identity.objects.create_user(email='scope-a@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_a, person=cls.person_a)
+
+        # Patient B
+        cls.person_b = Person.objects.create(person_id=93002, family_name='Baker', given_name='Bob')
+        cls.patient_b_rec = PatientRecord.objects.create(person=cls.person_b)
+        cls.identity_b = Identity.objects.create_user(email='scope-b@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_b, person=cls.person_b)
+
+        # A ConditionOccurrence belonging to patient B
+        cls.condition_b = ConditionOccurrence.objects.create(
+            condition_occurrence_id=93901,
+            person=cls.person_b,
+            condition_concept=condition_concept,
+            condition_start_date=date.today(),
+            condition_type_concept=type_concept,
+        )
+
+        # Superuser
+        cls.superuser = Identity.objects.create_superuser(email='su-scope@test.com', password='pw')
+
+        # Staff
+        cls.staff = Identity.objects.create_user(email='staff-scope@test.com', password='pw', is_staff=True)
+
+        # Provider with GroupAccess (bypasses patient scope)
+        cls.provider = Identity.objects.create_user(email='prov-scope@test.com', password='pw')
+        cls.org = Organization.objects.create(name='Scope Org', slug='scope-org-93')
+        GroupAccess.objects.create(identity=cls.provider, org=cls.org, role='doctor')
+
+    def _client_as(self, identity):
+        c = APIClient()
+        c.force_authenticate(user=identity)
+        return c
+
+    def test_patient_can_access_own_condition(self):
+        """Patient B can access their own condition via detail endpoint."""
+        resp = self._client_as(self.identity_b).get(
+            f'/api/v1/conditions/{self.condition_b.condition_occurrence_id}/'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_patient_cannot_access_other_patients_condition(self):
+        """Patient A cannot access patient B's condition — gets 404 (queryset filtered)."""
+        resp = self._client_as(self.identity_a).get(
+            f'/api/v1/conditions/{self.condition_b.condition_occurrence_id}/'
+        )
+        # _OmopFilterMixin filters the queryset to the user's own records,
+        # so the object is not found rather than forbidden.
+        self.assertIn(resp.status_code, [status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND])
+
+    def test_superuser_bypasses_scope(self):
+        """Superuser can access any patient's condition."""
+        resp = self._client_as(self.superuser).get(
+            f'/api/v1/conditions/{self.condition_b.condition_occurrence_id}/'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_staff_bypasses_scope(self):
+        """Staff can access any patient's condition."""
+        resp = self._client_as(self.staff).get(
+            f'/api/v1/conditions/{self.condition_b.condition_occurrence_id}/'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_provider_bypasses_patient_scope(self):
+        """Provider with GroupAccess is not treated as a patient by PatientSelfScopePermission.
+
+        Note: providers access data via org-scoped OAuth tokens in production.
+        With session auth, _OmopFilterMixin filters by PatientUser (returning 404
+        if the provider has no PatientUser link). This test verifies that
+        PatientSelfScopePermission itself does not block the provider — the 404
+        comes from queryset filtering, not from the object-level permission.
+        """
+        resp = self._client_as(self.provider).get(
+            f'/api/v1/conditions/{self.condition_b.condition_occurrence_id}/'
+        )
+        # 404 from queryset filtering (no PatientUser link, no org token) — NOT 403 from scope
+        self.assertIn(resp.status_code, [status.HTTP_200_OK, status.HTTP_404_NOT_FOUND])
+
+
+# ---------------------------------------------------------------------------
+# Patient Account Deletion tests
+# ---------------------------------------------------------------------------
+
+class PatientAccountDeletionTest(TestCase):
+    """Test DELETE /api/v1/patient-records/me/ for GDPR right to erasure."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+        from omop_core.models import Organization
+
+        _make_vocab_fixtures()
+        condition_concept = Concept.objects.get(concept_id=4112853)
+        type_concept = Concept.objects.get(concept_id=32817)
+
+        # Patient to be deleted
+        cls.person = Person.objects.create(person_id=94001, family_name='Doomed', given_name='Dan')
+        cls.patient_rec = PatientRecord.objects.create(person=cls.person)
+        cls.identity = Identity.objects.create_user(email='doomed@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity, person=cls.person)
+
+        # Clinical data for the patient
+        cls.condition = ConditionOccurrence.objects.create(
+            condition_occurrence_id=94901,
+            person=cls.person,
+            condition_concept=condition_concept,
+            condition_start_date=date.today(),
+            condition_type_concept=type_concept,
+        )
+
+        # Unrelated patient (should be untouched)
+        cls.other_person = Person.objects.create(person_id=94002, family_name='Safe', given_name='Sue')
+        cls.other_rec = PatientRecord.objects.create(person=cls.other_person)
+        cls.other_identity = Identity.objects.create_user(email='safe@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.other_identity, person=cls.other_person)
+
+        # Staff user
+        cls.staff = Identity.objects.create_user(email='staff-del@test.com', password='pw', is_staff=True)
+
+    def _client_as(self, identity):
+        c = APIClient()
+        c.force_authenticate(user=identity)
+        return c
+
+    def test_delete_account_success(self):
+        """DELETE with valid confirm removes all patient data."""
+        from patient_portal.models import PatientUser
+
+        # Create fresh data for this test (setUpTestData data is shared, can't delete once)
+        person = Person.objects.create(person_id=94101, family_name='Fresh', given_name='Fran')
+        PatientRecord.objects.create(person=person)
+        identity = Identity.objects.create_user(email='fresh-del@test.com', password='pw')
+        PatientUser.objects.create(identity=identity, person=person)
+        identity_pk = identity.pk
+
+        resp = self._client_as(identity).delete(
+            '/api/v1/patient-records/me/',
+            data={'confirm': 'DELETE'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # Person and all clinical data gone
+        self.assertFalse(Person.objects.filter(person_id=94101).exists())
+        self.assertFalse(PatientRecord.objects.filter(person_id=94101).exists())
+        self.assertFalse(PatientUser.objects.filter(person__person_id=94101).exists())
+        # Identity gone
+        self.assertFalse(Identity.objects.filter(pk=identity_pk).exists())
+
+    def test_delete_missing_confirm(self):
+        """DELETE without confirm body → 400."""
+        person = Person.objects.create(person_id=94102, family_name='NoConf', given_name='Ned')
+        PatientRecord.objects.create(person=person)
+        identity = Identity.objects.create_user(email='noconf-del@test.com', password='pw')
+        from patient_portal.models import PatientUser
+        PatientUser.objects.create(identity=identity, person=person)
+
+        resp = self._client_as(identity).delete(
+            '/api/v1/patient-records/me/',
+            data={},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        # Person still exists
+        self.assertTrue(Person.objects.filter(person_id=94102).exists())
+
+    def test_delete_wrong_confirm(self):
+        """DELETE with wrong confirm value → 400."""
+        person = Person.objects.create(person_id=94103, family_name='Wrong', given_name='Will')
+        PatientRecord.objects.create(person=person)
+        identity = Identity.objects.create_user(email='wrong-del@test.com', password='pw')
+        from patient_portal.models import PatientUser
+        PatientUser.objects.create(identity=identity, person=person)
+
+        resp = self._client_as(identity).delete(
+            '/api/v1/patient-records/me/',
+            data={'confirm': 'delete'},  # lowercase — should fail
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_staff_cannot_delete_own_account(self):
+        """Non-patient (staff) cannot use the account deletion endpoint."""
+        resp = self._client_as(self.staff).delete(
+            '/api/v1/patient-records/me/',
+            data={'confirm': 'DELETE'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_other_patients_data_untouched(self):
+        """Deleting one patient does not affect another patient's data."""
+        from patient_portal.models import PatientUser
+
+        person = Person.objects.create(person_id=94104, family_name='Gone', given_name='Gus')
+        PatientRecord.objects.create(person=person)
+        identity = Identity.objects.create_user(email='gone-del@test.com', password='pw')
+        PatientUser.objects.create(identity=identity, person=person)
+
+        self._client_as(identity).delete(
+            '/api/v1/patient-records/me/',
+            data={'confirm': 'DELETE'},
+            format='json',
+        )
+
+        # Other patient still intact
+        self.assertTrue(Person.objects.filter(person_id=94002).exists())
+        self.assertTrue(PatientRecord.objects.filter(person=self.other_person).exists())
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — FHIR Export tests
+# ---------------------------------------------------------------------------
+
+class FhirExportServiceTest(TestCase):
+    """Unit tests for omop_core.services.fhir_export.build_fhir_bundle."""
+
+    @classmethod
+    def setUpTestData(cls):
+        _make_vocab_fixtures()
+        cls.condition_concept = Concept.objects.get(concept_id=4112853)  # Breast cancer
+        cls.type_concept = Concept.objects.get(concept_id=32817)  # EHR
+        cls.lab_concept = Concept.objects.get(concept_id=3000963)  # Lab test result
+
+        cls.person = Person.objects.create(
+            person_id=95001, family_name='Export', given_name='Eve',
+            year_of_birth=1985, month_of_birth=3, day_of_birth=15,
+            gender_concept_id=8532,
+        )
+        cls.patient_rec = PatientRecord.objects.create(person=cls.person)
+
+        # Clinical data
+        cls.condition = ConditionOccurrence.objects.create(
+            condition_occurrence_id=95901,
+            person=cls.person,
+            condition_concept=cls.condition_concept,
+            condition_start_date=date(2022, 6, 1),
+            condition_type_concept=cls.type_concept,
+            condition_source_value='Breast cancer',
+        )
+        cls.measurement = Measurement.objects.create(
+            measurement_id=95902,
+            person=cls.person,
+            measurement_concept=cls.lab_concept,
+            measurement_date=date(2023, 1, 10),
+            measurement_type_concept=cls.type_concept,
+            value_as_number=12.5,
+            unit_source_value='g/dL',
+            measurement_source_value='Hemoglobin',
+        )
+
+    def test_bundle_structure(self):
+        from omop_core.services.fhir_export import build_fhir_bundle
+        bundle = build_fhir_bundle(self.person)
+
+        self.assertEqual(bundle['resourceType'], 'Bundle')
+        self.assertEqual(bundle['type'], 'searchset')
+        self.assertIsInstance(bundle['total'], int)
+        self.assertIsInstance(bundle['entry'], list)
+        self.assertGreater(bundle['total'], 0)
+
+    def test_patient_resource_present(self):
+        from omop_core.services.fhir_export import build_fhir_bundle
+        bundle = build_fhir_bundle(self.person)
+
+        patient_entries = [
+            e for e in bundle['entry']
+            if e['resource']['resourceType'] == 'Patient'
+        ]
+        self.assertEqual(len(patient_entries), 1)
+        patient = patient_entries[0]['resource']
+        self.assertEqual(patient['name'][0]['family'], 'Export')
+        self.assertEqual(patient['name'][0]['given'], ['Eve'])
+        self.assertEqual(patient['birthDate'], '1985-03-15')
+        self.assertEqual(patient['gender'], 'female')
+
+    def test_condition_exported(self):
+        from omop_core.services.fhir_export import build_fhir_bundle
+        bundle = build_fhir_bundle(self.person)
+
+        conditions = [
+            e for e in bundle['entry']
+            if e['resource']['resourceType'] == 'Condition'
+        ]
+        self.assertGreaterEqual(len(conditions), 1)
+        cond = conditions[0]['resource']
+        self.assertIn('code', cond)
+        self.assertEqual(cond['onsetDateTime'], '2022-06-01')
+
+    def test_measurement_exported_as_observation(self):
+        from omop_core.services.fhir_export import build_fhir_bundle
+        bundle = build_fhir_bundle(self.person)
+
+        observations = [
+            e for e in bundle['entry']
+            if e['resource']['resourceType'] == 'Observation'
+        ]
+        self.assertGreaterEqual(len(observations), 1)
+        # Find the one with a valueQuantity
+        quant_obs = [o for o in observations if 'valueQuantity' in o['resource']]
+        self.assertGreaterEqual(len(quant_obs), 1)
+        obs = quant_obs[0]['resource']
+        self.assertEqual(obs['valueQuantity']['value'], 12.5)
+        self.assertEqual(obs['valueQuantity']['unit'], 'g/dL')
+
+    def test_empty_patient_returns_patient_only(self):
+        from omop_core.services.fhir_export import build_fhir_bundle
+        empty_person = Person.objects.create(
+            person_id=95099, family_name='Empty', given_name='Em',
+            gender_concept_id=8507,
+        )
+        bundle = build_fhir_bundle(empty_person)
+        self.assertEqual(bundle['total'], 1)
+        self.assertEqual(bundle['entry'][0]['resource']['resourceType'], 'Patient')
+
+
+class FhirExportApiTest(TestCase):
+    """Test the export-fhir API endpoint."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+
+        _make_vocab_fixtures()
+        cls.condition_concept = Concept.objects.get(concept_id=4112853)
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+
+        # Patient A — will export their own record
+        cls.person_a = Person.objects.create(
+            person_id=96001, family_name='Able', given_name='Amy',
+            gender_concept_id=8532,
+        )
+        cls.patient_a_rec = PatientRecord.objects.create(person=cls.person_a)
+        cls.identity_a = Identity.objects.create_user(email='export-a@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_a, person=cls.person_a)
+
+        ConditionOccurrence.objects.create(
+            condition_occurrence_id=96901,
+            person=cls.person_a,
+            condition_concept=cls.condition_concept,
+            condition_start_date=date.today(),
+            condition_type_concept=cls.type_concept,
+        )
+
+        # Patient B — another patient
+        cls.person_b = Person.objects.create(
+            person_id=96002, family_name='Baker', given_name='Bob',
+            gender_concept_id=8507,
+        )
+        cls.patient_b_rec = PatientRecord.objects.create(person=cls.person_b)
+        cls.identity_b = Identity.objects.create_user(email='export-b@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_b, person=cls.person_b)
+
+        # Staff
+        cls.staff = Identity.objects.create_user(
+            email='export-staff@test.com', password='pw', is_staff=True,
+        )
+
+    def _client_as(self, identity):
+        c = APIClient()
+        c.force_authenticate(user=identity)
+        return c
+
+    def test_patient_can_export_own_record(self):
+        """Patient A can export their own FHIR bundle."""
+        resp = self._client_as(self.identity_a).get(
+            f'/api/v1/patient-records/{self.person_a.person_id}/export-fhir/'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        bundle = resp.json()
+        self.assertEqual(bundle['resourceType'], 'Bundle')
+        self.assertEqual(bundle['type'], 'searchset')
+        resource_types = {e['resource']['resourceType'] for e in bundle['entry']}
+        self.assertIn('Patient', resource_types)
+        self.assertIn('Condition', resource_types)
+
+    def test_patient_cannot_export_other_patients_record(self):
+        """Patient A cannot export patient B's record."""
+        resp = self._client_as(self.identity_a).get(
+            f'/api/v1/patient-records/{self.person_b.person_id}/export-fhir/'
+        )
+        self.assertIn(resp.status_code, [
+            status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND,
+        ])
+
+    def test_staff_can_export_any_record(self):
+        """Staff can export any patient's record."""
+        resp = self._client_as(self.staff).get(
+            f'/api/v1/patient-records/{self.person_a.person_id}/export-fhir/'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        bundle = resp.json()
+        self.assertEqual(bundle['resourceType'], 'Bundle')
+
+    def test_nonexistent_person_returns_404(self):
+        """Export of nonexistent person_id returns 404."""
+        resp = self._client_as(self.staff).get(
+            '/api/v1/patient-records/999999/export-fhir/'
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_unauthenticated_returns_403(self):
+        """Unauthenticated request to export returns 401/403."""
+        c = APIClient()
+        resp = c.get(
+            f'/api/v1/patient-records/{self.person_a.person_id}/export-fhir/'
+        )
+        self.assertIn(resp.status_code, [
+            status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN,
+        ])


### PR DESCRIPTION
## Summary

- **PatientSelfScopePermission** — centralized object-level permission applied to all 12 OMOP viewsets as belt-and-suspenders on top of queryset filtering. Uses `_resolve_person_id()` to extract `person_id` from any OMOP model (including `EpisodeEvent` via bare `episode_id` → `Episode` lookup). Bypasses for service tokens, staff, superusers, and non-patient identities.
- **Patient account deletion (GDPR right to erasure)** — `DELETE /api/v1/patient-records/me/` with `{"confirm": "DELETE"}`. Hard-deletes all patient data (Person cascade + orphan EpisodeEvent cleanup + Identity removal) inside `transaction.atomic()`. Frontend: `ProfileDropdown` replaces standalone "Sign out" button; `DeleteAccountDialog` with typed confirmation.
- **FHIR R4 export** — `GET /api/v1/patient-records/{person_id}/export-fhir/` converts OMOP data to a FHIR Bundle (Patient, Condition, Observation, MedicationStatement, Procedure, Encounter). Management command `export_fhir_bundle` for bulk/CLI use. Frontend "Download my record (FHIR)" button on PatientHome.

**FM coverage:** PH.1, PH.2, PH.2.4, S.3, TI.1, TI.1.7

## Test plan

- [x] 20 new backend tests: `PatientSelfScopePermissionTest` (5), `PatientAccountDeletionTest` (5), `FhirExportServiceTest` (5), `FhirExportApiTest` (5)
- [x] 2 new frontend tests: FHIR download button presence/absence
- [x] Full backend suite: 854 tests pass (1 skipped)
- [x] Full frontend suite: 76 tests pass
- [ ] Manual: log in as patient → verify profile dropdown (Sign out + Delete my account) → verify FHIR download → verify cross-patient access blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)