### PR TITLE
docs(adr): vocabulary SoT access mechanism = API + cache (all data clients)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,11 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: cd frontend && npm install
+        # npm ci installs exactly the versions pinned in package-lock.json.
+        # `npm install` re-resolves `^` ranges to the latest match, so a new
+        # transitive/patch release (e.g. an eslint plugin) could change lint
+        # behaviour between runs and diverge from local — use the lockfile.
+        run: cd frontend && npm ci
 
       - name: Lint
         run: cd frontend && npm run lint

--- a/docs/adr/0001-vocabulary-source-of-truth.md
+++ b/docs/adr/0001-vocabulary-source-of-truth.md
@@ -1,6 +1,6 @@
 # ADR 0001 — promop is the vocabulary source of truth
 
-**Status:** Proposed (2026-07-22)
+**Status:** Proposed (2026-07-22; access mechanism — API + cache — folded in 2026-07-24).
 **Supersedes:** `exact/docs/adr/0001-cross-vocabulary-mapping.md`,
 `soc/docs/adr/0001-cross-vocabulary-mapping.md` (both to be marked *Superseded* with a
 link here).
@@ -28,37 +28,78 @@ institutionalises the drift and the divergence-safety surface (SoC #198, EXACT #
 1. **promop is the single source of truth for ALL vocabulary data**: `concept`,
    `concept_relationship`, `concept_synonym`, `concept_ancestor`, `drug_strength`,
    `source_to_concept_map`, and vocabulary/release versions.
-2. **Consumers (EXACT, SoC) pull vocabulary from promop and cache it locally.** Local
-   vocabulary stores become versioned **caches** of a promop release, not sources of
-   truth. Consumers do not independently vendor or curate vocabulary content.
+2. **All data clients (EXACT, SoC, and any future consumer) access promop vocabulary and
+   concept-graph data exclusively through promop's HTTP API, backed by a client-side
+   cache.** The cache is a transient performance/availability layer keyed on the promop
+   **release id**, **not** a replicated release store or a second source of truth. No
+   consumer vendors, curates, or bulk-replicates vocabulary content. (See *Access
+   mechanism* below.)
 3. **One temporary exception:** the **`cb_code ↔ concept_id`** mapping stays inside CB
    (EXACT) for the transition period only. It is `cb_code`-keyed (`TherapyOmopMapping`),
    tied to CB-specific category matching semantics, and is scheduled for retirement
    (see *CB exception* below).
 
+## Access mechanism: API + cache
+
+promop's HTTP API **is** the synchronization contract; consumers hold a transient cache, not
+a snapshot. Rejected alternatives (recorded so they are not re-litigated): (a) hourly/bulk
+**download** of a full `concept*` replica — contradicts "remove local copies," is
+disproportionate to consumer needs, and promop exposes no bulk edge export today; (b) a
+promop-published versioned **snapshot/delta artifact** — deferred; API + cache is the
+committed mechanism. This decision replaces the snapshot/delta distribution mechanism the
+original draft required; the concrete API guarantees are folded into *Consequences* below.
+
+**EXACT #233 is the first consumer to conform** (informative):
+- Patient side: promop is to pre-expand component concept_ids onto the patient record
+  (`therapy_component_ids`, promop#189) so EXACT reads them without request-path traversal.
+  **Not yet wired:** the EXACT matcher still derives components locally today, and
+  `therapy_component_ids` is not yet release-stamped.
+- Trial side: regimen→component expansion via the graph API at **backfill**, cached,
+  release-pinned, fail-closed; stored in a **dedicated** column, never unioned into authored
+  component requirements.
+- Matching: the expansion is a regimen-level **OR-alternative** evaluated by **superset**
+  (a complete patient therapy line ⊇ a per-regimen expansion group), not any-overlap;
+  **excluded** regimens are not expanded.
+- **Data-model prerequisites this exposes for promop** (resolve before EXACT Phase T ships):
+  (1) `therapy_component_ids` is today an **unstamped aggregate union across all therapy
+  lines** — superset on the aggregate mis-infers a regimen; promop must emit
+  **line/episode-scoped component groups** with completeness and release/provenance stamping;
+  (2) components are **mixed-vocabulary** (HemOnc / RxNorm / ingredient), and distinct
+  regimens can share a drug *set* (e.g. VRd vs VRd Lite), so a component-set superset alone
+  can equate different regimens. promop must supply **source-asserted regimen identity**, not
+  only the component concept set, and the expansion output and patient components must be
+  reconcilable at a common concept granularity.
+
 ## Consequences (what promop must build)
 
 The decision is not satisfied by the existing query endpoints. promop is today a
-partial vocabulary database with browse/traversal endpoints, not a distributable,
-cacheable vocabulary contract. To honour the decision, promop must provide:
+partial vocabulary database with browse/traversal endpoints, not a versioned, cacheable
+API contract. To honour the decision, promop must provide:
 
 ### Release construction & publication
-- Immutable, content-addressed **release manifests**: release ID, per-vocabulary
+- Immutable, content-addressed **release manifests**: a **release id**, per-vocabulary
   versions, schema version, corpus scope, build timestamp, checksums.
 - **Atomic publication** (stage → validate → publish). The current
   `load_athena_vocabularies` can `TRUNCATE`-and-reload (cascading clinical tables) with
-  no publish boundary; consumers must never sync an in-progress database.
+  no publish boundary; consumers must never read an in-progress database.
 - Retention of prior releases; rollback.
 
-### Distribution surface
-- **Version-addressable full snapshots** and **release-to-release deltas** with
-  tombstones and replacement records.
-- A **latest-release pointer** with `ETag`/`If-None-Match`; explicit **version pinning**.
-- Coverage of `concept` (incl. `valid_start_date`/`valid_end_date`/`invalid_reason`),
-  `concept_synonym` (no endpoint today), `concept_relationship` (incl. edge validity),
-  `concept_ancestor`, `drug_strength`, `source_to_concept_map`, and vocabulary metadata.
-- **Every concept/graph/lookup/search response carries the release/vocabulary version**
-  (`Vocabulary.vocabulary_version` exists but is not currently returned).
+### API contract (what a cache pins and validates against)
+- **Every concept / graph / lookup / search response carries the immutable promop release
+  id** (plus the per-vocabulary versions it draws on). Today only
+  `Vocabulary.vocabulary_version` exists as a model field, surfaced on some responses (e.g.
+  `include_versions` on lookup, per-node on graph, promop#240); a **release-level id, a
+  current-release pointer, and explicit version pinning are NOT yet built** — they are the
+  core of this work. A cache keyed on per-vocabulary version alone is unsafe: a graph can
+  span vocabularies and relationship state, so cache identity must be `release_id`.
+- **Version pinning**: a client can pin one release for the duration of an operation and
+  detect a release change (`ETag` / `If-None-Match`, or an explicit release parameter).
+- Batch traversal (graph endpoint, ≤200 sources / ≤1000 nodes per source) with an explicit
+  **truncation** signal that consumers treat as fail-closed, never silent.
+- API coverage of `concept` (incl. `valid_start_date`/`valid_end_date`/`invalid_reason`),
+  `concept_synonym`, `concept_relationship` (incl. edge validity), `concept_ancestor`,
+  `drug_strength`, `source_to_concept_map`, and vocabulary metadata — with source-asserted
+  identity preserved.
 
 ### Corpus boundary
 - The loader currently scopes `concept` to selected vocabularies/classes,
@@ -67,25 +108,35 @@ cacheable vocabulary contract. To honour the decision, promop must provide:
   **narrow this ADR's scope** explicitly. "All" must not remain aspirational.
 
 ### Integrity / no poisoning
-- **No locally-minted concepts inside a licensed `vocabulary_id`.** FHIR import today
-  mints `FHIR-*` rows under `vocabulary_id='HemOnc'` (before even attempting a real
-  HemOnc name match). Local/unmatched content must live under a distinct local
-  vocabulary id and be surfaced in a mapping-gap report. A cache must be able to trust
-  that "HemOnc" means licensed Athena HemOnc.
+- **No locally-minted concepts inside a licensed `vocabulary_id`.** Unmatched/local content
+  (e.g. FHIR-imported drugs with no HemOnc match) must live under a distinct local
+  vocabulary id and be surfaced in a mapping-gap report — never minted under
+  `vocabulary_id='HemOnc'`. A cache must be able to trust that "HemOnc" means licensed
+  Athena HemOnc. (Confirm the current FHIR import path already quarantines such content.)
 - Validate inbound HemOnc concept_ids (vocabulary / class / standard / validity) before
   persisting them from FHIR.
 
-### Deprecation / migration semantics
+### Migration semantics
 - Deprecation & replacement policy: whether consumers may auto-migrate.
-- A release delta must classify each referenced id as **retained / invalidated /
-  uniquely-replaced / ambiguous / unmapped**. Consumers must never blindly rewrite ids.
-- Ontology changes (a relationship retired or re-validated) change cached
-  expansions even when concept ids are unchanged — deltas must express this.
+- Via the API, each referenced id must be classifiable as **retained / invalidated /
+  uniquely-replaced / ambiguous / unmapped** across releases; consumers must never blindly
+  rewrite ids.
+- Ontology changes (a relationship retired or re-validated) change cached expansions even
+  when concept ids are unchanged — the release id must change so caches invalidate.
 
 ### Consumer conformance
+- A **shared cache**, not per-process. On Redis-less deployments (e.g. EXACT staging on
+  Cloud Run) use a **DB-backed cache** so entries are shared across instances and survive
+  recycles; a per-process `LocMemCache` is near-inert there.
+- Cache key includes the **release id**; **pin the release per operation**, and where two
+  sides are matched (e.g. patient vs trial) **assert equal release ids** — cross-side skew
+  is a correctness bug, not a nuisance.
+- **Fail-closed**: on cache miss + promop unavailable → `unknown`, never fail-open to
+  matched; a batch/backfill fails rather than persisting a partial projection.
+- **Request-scoped memoization** for repeated per-request expansions.
 - Cache freshness rules: last-known-good retention, max staleness per decision class,
   bootstrap behavior, and the **clinical fail-safe when no valid cache exists**.
-- Record the cache release id + age on every match/recommendation (staleness is a
+- Record the cache **release id + age** on every match/recommendation (staleness is a
   clinical input; cross-consumer version skew must be observable).
 - Consumer conformance tests + a release compatibility policy.
 
@@ -118,8 +169,8 @@ cacheable vocabulary contract. To honour the decision, promop must provide:
 ## Status of related decisions
 
 - EXACT #232/#233 ("don't store HemOnc locally; use promop's concept graph API") are
-  **aligned** with this ADR (they become "pull + cache" rather than "call live per
-  request"). The concept graph API is an interactive/reconciliation tool, **not** the
-  synchronization contract — the release/snapshot/delta surface above is.
+  **aligned** with this ADR: the concept graph / query API **is** the synchronization
+  contract, consumed through a release-pinned client cache (fetch-on-demand at backfill /
+  read of pre-expanded fields at request time), **not** a bulk snapshot/delta replica.
 - EXACT #174 (vocabulary-bridge information loss) and SoC #198 (silent-drop, closed)
   are the safety motivations for fail-closed cache semantics.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -103,6 +103,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -626,7 +627,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -671,9 +671,29 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2439,7 +2459,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2528,7 +2549,6 @@
       "version": "20.19.41",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2537,7 +2557,6 @@
       "version": "19.2.15",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2546,7 +2565,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2590,7 +2608,6 @@
       "version": "8.59.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -2887,7 +2904,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2946,6 +2962,7 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2954,6 +2971,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3057,7 +3075,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3369,7 +3386,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3491,7 +3509,6 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4546,6 +4563,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4763,7 +4781,6 @@
     "node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4809,6 +4826,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4821,7 +4839,8 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4854,7 +4873,6 @@
     "node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4862,7 +4880,6 @@
     "node_modules/react-dom": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5325,7 +5342,6 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5460,7 +5476,6 @@
     "node_modules/vite": {
       "version": "8.1.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5701,7 +5716,6 @@
     "node_modules/ws": {
       "version": "8.21.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5745,7 +5759,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/Auth/AcceptInvite.tsx
+++ b/frontend/src/components/Auth/AcceptInvite.tsx
@@ -11,7 +11,9 @@ const publicApi = axios.create({
   },
 });
 
-export function redirectBrowser(url: string) {
+// Module-local (not exported): the file must export only the component so
+// react-refresh/only-export-components / Fast Refresh stays happy.
+function redirectBrowser(url: string) {
   window.location.assign(url);
 }
 


### PR DESCRIPTION
## Summary

Amends **ADR 0001 — promop is the vocabulary source of truth** (Status: Proposed) to fix the
**access mechanism**: all data clients (EXACT, SoC, and future consumers) access promop
vocabulary + concept-graph data **exclusively via the HTTP API, backed by a client-side
cache**. promop's API **is** the synchronization contract. This replaces the original draft's
snapshot/delta distribution mechanism.

## What changed

- **Decision point 2** → all data clients via API + cache; the cache is transient, keyed on
  the promop **release id**, not a replica or second source of truth.
- New **Access mechanism** section (folded in, not layered as a superseding revision):
  rejected alternatives on record (bulk `concept*` download replica; snapshot/delta artifact,
  deferred); **EXACT #233** as the first conformant consumer + the data-model prerequisites
  it exposes for promop.
- **Consequences** reworked to an API contract instead of a distribution surface:
  - "Distribution surface" (full snapshots + release-to-release deltas) **replaced** by an
    **API contract** section — every response carries the **release id**, version pinning
    (`ETag`/pin param), batch + explicit truncation, source-asserted identity.
  - "Migration semantics" reframed from delta-artifact classification to
    **API-detectable** release changes.
  - **Consumer conformance** consolidated into one list: shared/DB-backed cache (not
    per-process — Redis-less deploys like EXACT staging on Cloud Run), cache key = release id
    + cross-side release assert, fail-closed, request-scoped memoization, record release id +
    age.

## Review

Two independent reviews (OpenAI Codex + a fresh-context Claude reviewer) were run on the
draft and reconciled before this PR. Their P1s are addressed:
- **Self-contradiction removed** — the doc no longer both rejects and mandates snapshot/delta.
- **Version contract corrected** — cache identity is the immutable **release id**, not
  per-vocabulary `vocabulary_version` (a graph spans vocabularies); the release-level id +
  current-release pointer + pinning are flagged as **not yet built** (the core of the work),
  not as existing.
- **EXACT #233 status corrected** — patient-side pre-expansion is **not yet wired** and
  `therapy_component_ids` is **not yet release-stamped**; the prerequisite is strengthened to
  require **source-asserted regimen identity** (a component-set superset alone can equate
  distinct regimens sharing a drug set, e.g. VRd vs VRd Lite), plus line/episode-scoped groups
  and common concept granularity.

## Open items for deciders (@adamblum)

- Confirm the current FHIR import path already quarantines unmatched content under a distinct
  local vocabulary id (the "no poisoning" requirement is written as a requirement; a stale
  "today mints under HemOnc" claim was softened).
- Whether the retained **Consequences → Release construction** section (immutable release
  manifests, atomic publication) is the right scope now that API + cache is the mechanism —
  a release id + atomic publish are still needed for the cache to pin against.

Derived from a cross-repo design review (promop + EXACT: `healthkey-ai/exact#233`,
`healthkey-ai/promop#232`), including adversarial cross-model review of the access mechanism
and the Phase T matching semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
