### PR TITLE
chore(ci): use npm ci for frontend so installs are deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,11 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: cd frontend && npm install
+        # npm ci installs exactly the versions pinned in package-lock.json.
+        # `npm install` re-resolves `^` ranges to the latest match, so a new
+        # transitive/patch release (e.g. an eslint plugin) could change lint
+        # behaviour between runs and diverge from local — use the lockfile.
+        run: cd frontend && npm ci
 
       - name: Lint
         run: cd frontend && npm run lint

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -103,6 +103,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -626,7 +627,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -671,9 +671,29 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2439,7 +2459,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2528,7 +2549,6 @@
       "version": "20.19.41",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2537,7 +2557,6 @@
       "version": "19.2.15",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2546,7 +2565,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2590,7 +2608,6 @@
       "version": "8.59.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -2887,7 +2904,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2946,6 +2962,7 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2954,6 +2971,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3057,7 +3075,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3369,7 +3386,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3491,7 +3509,6 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4546,6 +4563,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4763,7 +4781,6 @@
     "node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4809,6 +4826,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4821,7 +4839,8 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4854,7 +4873,6 @@
     "node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4862,7 +4880,6 @@
     "node_modules/react-dom": {
       "version": "19.2.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5325,7 +5342,6 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5460,7 +5476,6 @@
     "node_modules/vite": {
       "version": "8.1.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5701,7 +5716,6 @@
     "node_modules/ws": {
       "version": "8.21.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5745,7 +5759,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Why

The **Frontend lint & build** job ran `npm install`, which re-resolves `^` version ranges to the newest matching release at run time and ignores the committed lockfile. That let `eslint-plugin-react-refresh` drift from the locked **0.5.2** to **0.5.3** in CI while local installs stayed on 0.5.2 — so a lint result could pass locally and fail in CI (this is exactly what happened in #280, where the failure was hard to reproduce locally).

## What

- `.github/workflows/ci.yml`: frontend install `npm install` → **`npm ci`** — installs exactly the versions pinned in `package-lock.json`, so CI and local match and a new transitive/patch release can't silently change lint behaviour.
- `frontend/package-lock.json`: regenerated so `npm ci` succeeds. It previously failed with *"Missing @emnapi/* from lock file"*. The diff is a pure reconciliation — **zero version changes**, `lockfileVersion` stays 3; it only adds the two missing `optional` entries (`@emnapi/core`, `@emnapi/runtime`) and recomputes `peer`/`optional` flags on existing entries.

## Verification (node 24, the CI runtime)

- `rm -rf node_modules && npm ci` → exit 0 (425 packages)
- `npm run lint` → clean · `npm run build` (`tsc -b && vite build`) → succeeds

2-self-review: Claude fresh-context review (separate subagent) + Codex — both LGTM, no blocking issues. (Non-blocking: `npm ci` surfaces 8 pre-existing dependency vulns, inherited not introduced — worth a separate `npm audit` follow-up.)

## Stacking

Branched on top of **#280** (`fix/accept-invite-lint`) so this PR's own CI is green. Base is set to that branch — **merge #280 first**, then this retargets/rebases cleanly onto `dev`. (Alternatively squash-merge #280, then rebase this on `dev`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
