### PR TITLE
feat: PHR-S FM Phase 4a -- patient surveys in patient mode (#284)

### DIFF
--- a/docs/phrs-fm-roadmap.md
+++ b/docs/phrs-fm-roadmap.md
@@ -181,20 +181,21 @@ export that record as FHIR, plus any read-only presentation refinements.)*
 
 ---
 
-## Phase 3 — Consent grants
+## Phase 3 — Consent grants  ✅ DONE
 
 **FM:** PH.1.5 (Manage Consents and Authorizations).
 
-**Existing:** `PatientConsent` (`patient_portal/models.py:118`, keyed to `PatientUser`,
-boolean-per-type), `consent_management` server view (`views.py:114`), and
-`FhirPatientConsentView` (`api/fhir/sync.py:790`).
+**Status:** Delivered in PR #283 (issue #278), merged to `dev` 2026-07-25. Shipped:
+`PatientConsentViewSet` at `/api/v1/consents/` (list + PATCH toggle), auto-creates all 3
+consent types on first list, queryset self-scoped to the authenticated patient.
+`_resolve_person_id` extended with `patient_user_id` pattern for `PatientSelfScopePermission`.
+Frontend `PatientConsents` component with toggle switches on `PatientHome`. `consent_date`
+changed to `auto_now=True` so timestamp reflects actual consent decision time.
+863 backend / 81 frontend tests green.
 
-- Promote consent to a first-class DRF resource under `/api/v1/`: list/grant/revoke the
-  patient's own consents (self-scoped via the Phase-1 guard), with `consent_type`, granted
-  flag, timestamp, and optional scope note. Reuse the existing `PatientConsent` model;
-  types data_sharing / clinical_trial / research already seeded.
-- Frontend: a Consents view in patient mode (reuse `FormField`/`Select` primitives).
-- Tests: grant/revoke, self-scope enforcement, uniqueness per type.
+**Existing:** `PatientConsent` (`patient_portal/models.py:173`, keyed to `PatientUser`,
+boolean-per-type), `consent_management` server view (`views.py:113`), and
+`FhirPatientConsentView` (`api/fhir/sync.py:791`).
 
 *Stretch (deferred):* represent grants as FHIR `Consent` resources. The current
 boolean-per-type model is adequate for the oncology use case.

--- a/frontend/src/components/Patient/PatientHome.tsx
+++ b/frontend/src/components/Patient/PatientHome.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, Download } from "lucide-react";
 import type { User } from "@/hooks/useAuth";
 import PatientDetail from "@/components/Patient/PatientDetail";
 import PatientConsents from "@/components/Patient/PatientConsents";
+import PatientSurveys from "@/components/Patient/PatientSurveys";
 import api from "@/api/axios";
 
 /**
@@ -79,6 +80,9 @@ export default function PatientHome({
       )}
       <div className="mx-auto max-w-5xl px-6 py-4">
         <PatientConsents user={user} />
+      </div>
+      <div className="mx-auto max-w-5xl px-6 py-4">
+        <PatientSurveys user={user} />
       </div>
       <PatientDetail
         personIdOverride={String(user.person_id)}

--- a/frontend/src/components/Patient/PatientSurveys.test.tsx
+++ b/frontend/src/components/Patient/PatientSurveys.test.tsx
@@ -1,0 +1,252 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import PatientSurveys from "./PatientSurveys";
+import type { User } from "@/hooks/useAuth";
+
+vi.mock("@/api/axios", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+import api from "@/api/axios";
+
+const makeUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  sub: "sub",
+  email: "p@test.com",
+  name: "Pat",
+  is_patient: true,
+  person_id: 7,
+  ...overrides,
+});
+
+const mockSurveys = [
+  {
+    id: 10,
+    name: "symptoms_mm",
+    title: "Symptom Tracker",
+    description: "Track your daily symptoms",
+    status: "ACTIVE",
+    disease: "mm",
+    pages: [
+      {
+        name: "page1",
+        title: "Symptoms",
+        inputs: [
+          { name: "fatigue", label: "Fatigue level", type: "rating", data: { maxRating: 10 } },
+          { name: "pain_notes", label: "Pain notes", type: "textarea" },
+        ],
+      },
+    ],
+    estimated_minutes: 5,
+  },
+  {
+    id: 11,
+    name: "quality_of_life",
+    title: "Quality of Life",
+    description: "Assess your overall well-being",
+    status: "ACTIVE",
+    disease: "mm",
+    pages: [
+      {
+        name: "page1",
+        title: "Well-being",
+        inputs: [
+          { name: "mood", label: "Mood", type: "select", data: { options: ["Good", "Fair", "Poor"] } },
+        ],
+      },
+    ],
+    estimated_minutes: 3,
+  },
+];
+
+const mockResponseInProgress = {
+  id: 100,
+  person: 7,
+  survey: 10,
+  survey_title: "Symptom Tracker",
+  survey_name: "symptoms_mm",
+  values: { fatigue: 5 },
+  values_dates: {},
+  percent_complete: 50,
+  started_at: "2025-07-20T10:00:00Z",
+  completed_at: null,
+  created_at: "2025-07-20T10:00:00Z",
+  updated_at: "2025-07-20T10:30:00Z",
+};
+
+const mockResponseCompleted = {
+  id: 101,
+  person: 7,
+  survey: 11,
+  survey_title: "Quality of Life",
+  survey_name: "quality_of_life",
+  values: { mood: "Good" },
+  values_dates: {},
+  percent_complete: 100,
+  started_at: "2025-07-19T10:00:00Z",
+  completed_at: "2025-07-19T10:15:00Z",
+  created_at: "2025-07-19T10:00:00Z",
+  updated_at: "2025-07-19T10:15:00Z",
+};
+
+describe("PatientSurveys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders survey list after loading", async () => {
+    (api.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ data: mockSurveys })
+      .mockResolvedValueOnce({ data: [] });
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Symptom Tracker")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Quality of Life")).toBeInTheDocument();
+    expect(screen.getByText("~5 min")).toBeInTheDocument();
+    expect(screen.getByText("~3 min")).toBeInTheDocument();
+  });
+
+  it("shows 'Not started' for surveys without a response", async () => {
+    (api.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ data: mockSurveys })
+      .mockResolvedValueOnce({ data: [] });
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Symptom Tracker")).toBeInTheDocument();
+    });
+    const badges = screen.getAllByText("Not started");
+    expect(badges.length).toBe(2);
+  });
+
+  it("shows 'In progress' with percentage for partial responses", async () => {
+    (api.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ data: mockSurveys })
+      .mockResolvedValueOnce({ data: [mockResponseInProgress] });
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("In progress (50%)")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'Completed' for completed responses", async () => {
+    (api.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ data: mockSurveys })
+      .mockResolvedValueOnce({ data: [mockResponseCompleted] });
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Completed")).toBeInTheDocument();
+    });
+  });
+
+  it("Start button creates a response via POST", async () => {
+    (api.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ data: [mockSurveys[0]] })
+      .mockResolvedValueOnce({ data: [] });
+
+    const newResponse = {
+      id: 200,
+      person: 7,
+      survey: 10,
+      survey_title: "Symptom Tracker",
+      survey_name: "symptoms_mm",
+      values: {},
+      values_dates: {},
+      percent_complete: 0,
+      started_at: "2025-07-25T12:00:00Z",
+      completed_at: null,
+      created_at: "2025-07-25T12:00:00Z",
+      updated_at: "2025-07-25T12:00:00Z",
+    };
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: newResponse,
+    });
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Symptom Tracker")).toBeInTheDocument();
+    });
+
+    const startBtn = screen.getByRole("button", { name: "Start" });
+    fireEvent.click(startBtn);
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        "/v1/survey-responses/",
+        expect.objectContaining({
+          person: 7,
+          survey: 10,
+        })
+      );
+    });
+  });
+
+  it("shows error message when fetch fails", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Network error")
+    );
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/failed to load surveys/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows no-record message when user has no person_id", () => {
+    render(<PatientSurveys user={makeUser({ person_id: null })} />);
+
+    expect(
+      screen.getByText(/no health record is linked/i)
+    ).toBeInTheDocument();
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("shows no-record message when user is null", () => {
+    render(<PatientSurveys user={null} />);
+
+    expect(
+      screen.getByText(/no health record is linked/i)
+    ).toBeInTheDocument();
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("shows Continue button for in-progress response", async () => {
+    (api.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ data: [mockSurveys[0]] })
+      .mockResolvedValueOnce({ data: [mockResponseInProgress] });
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Continue" })).toBeInTheDocument();
+    });
+  });
+
+  it("shows View button for completed response", async () => {
+    (api.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ data: [mockSurveys[1]] })
+      .mockResolvedValueOnce({ data: [mockResponseCompleted] });
+
+    render(<PatientSurveys user={makeUser()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/Patient/PatientSurveys.tsx
+++ b/frontend/src/components/Patient/PatientSurveys.tsx
@@ -1,0 +1,305 @@
+import { useState, useEffect, useCallback } from "react";
+import { AlertCircle, ClipboardList } from "lucide-react";
+import type { User } from "@/hooks/useAuth";
+import api from "@/api/axios";
+import SurveyForm from "@/components/Patient/SurveyForm";
+
+interface SurveyInput {
+  name: string;
+  label: string;
+  type: string;
+  data?: {
+    maxRating?: number;
+    options?: string[];
+  };
+}
+
+interface SurveyPage {
+  name: string;
+  title: string;
+  inputs: SurveyInput[];
+}
+
+export interface Survey {
+  id: number;
+  name: string;
+  title: string;
+  description: string;
+  status: string;
+  disease: string;
+  pages: SurveyPage[];
+  estimated_minutes: number | null;
+}
+
+export interface SurveyResponse {
+  id: number;
+  person: number;
+  survey: number;
+  survey_title: string;
+  survey_name: string;
+  values: Record<string, unknown>;
+  values_dates: Record<string, string>;
+  percent_complete: number;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function statusBadge(response: SurveyResponse | undefined) {
+  if (!response) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+        Not started
+      </span>
+    );
+  }
+  if (response.completed_at) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+        Completed
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700">
+      In progress ({response.percent_complete}%)
+    </span>
+  );
+}
+
+function actionLabel(response: SurveyResponse | undefined): string {
+  if (!response) return "Start";
+  if (response.completed_at) return "View";
+  return "Continue";
+}
+
+export default function PatientSurveys({ user }: { user: User | null }) {
+  const [surveys, setSurveys] = useState<Survey[]>([]);
+  const [responses, setResponses] = useState<SurveyResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeSurvey, setActiveSurvey] = useState<Survey | null>(null);
+  const [activeResponse, setActiveResponse] = useState<SurveyResponse | null>(null);
+  const [starting, setStarting] = useState<number | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!user || user.person_id == null) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [surveysRes, responsesRes] = await Promise.all([
+        api.get("/v1/surveys/?status=ACTIVE"),
+        api.get(`/v1/survey-responses/?person_id=${user.person_id}`),
+      ]);
+      setSurveys(
+        Array.isArray(surveysRes.data) ? surveysRes.data : surveysRes.data.results ?? []
+      );
+      setResponses(
+        Array.isArray(responsesRes.data) ? responsesRes.data : responsesRes.data.results ?? []
+      );
+    } catch {
+      setError("Failed to load surveys. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (user && user.person_id != null) {
+      fetchData();
+    } else {
+      setLoading(false);
+    }
+  }, [user, fetchData]);
+
+  const getResponseForSurvey = (surveyId: number): SurveyResponse | undefined =>
+    responses.find((r) => r.survey === surveyId);
+
+  const handleStart = async (survey: Survey) => {
+    if (!user || user.person_id == null) return;
+    setStarting(survey.id);
+    setError(null);
+    try {
+      const res = await api.post("/v1/survey-responses/", {
+        person: user.person_id,
+        survey: survey.id,
+        started_at: new Date().toISOString(),
+      });
+      const newResponse: SurveyResponse = res.data;
+      setResponses((prev) => [...prev, newResponse]);
+      setActiveSurvey(survey);
+      setActiveResponse(newResponse);
+    } catch {
+      setError("Failed to start survey. Please try again.");
+    } finally {
+      setStarting(null);
+    }
+  };
+
+  const handleAction = (survey: Survey) => {
+    const response = getResponseForSurvey(survey.id);
+    if (!response) {
+      handleStart(survey);
+      return;
+    }
+    setActiveSurvey(survey);
+    setActiveResponse(response);
+  };
+
+  const handleSave = async (values: Record<string, unknown>, percentComplete: number) => {
+    if (!activeResponse) return;
+    try {
+      const res = await api.patch(`/v1/survey-responses/${activeResponse.id}/`, {
+        values,
+        percent_complete: percentComplete,
+      });
+      const updated: SurveyResponse = res.data;
+      setActiveResponse(updated);
+      setResponses((prev) =>
+        prev.map((r) => (r.id === updated.id ? updated : r))
+      );
+    } catch {
+      // Autosave failure is non-blocking; user can retry on next page change
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!activeResponse) return;
+    try {
+      const res = await api.patch(`/v1/survey-responses/${activeResponse.id}/`, {
+        completed_at: new Date().toISOString(),
+        percent_complete: 100,
+      });
+      const updated: SurveyResponse = res.data;
+      setActiveResponse(updated);
+      setResponses((prev) =>
+        prev.map((r) => (r.id === updated.id ? updated : r))
+      );
+    } catch {
+      setError("Failed to complete survey. Please try again.");
+    }
+    setActiveSurvey(null);
+    setActiveResponse(null);
+  };
+
+  const handleBack = () => {
+    setActiveSurvey(null);
+    setActiveResponse(null);
+  };
+
+  if (!user || user.person_id == null) {
+    return (
+      <div className="rounded-2xl bg-background p-8 text-center shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
+        <AlertCircle className="mx-auto mb-3 h-10 w-10 text-amber-400" />
+        <p className="text-sm text-portal-text-secondary">
+          No health record is linked to your account. Surveys will be available
+          once your record is set up.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-2xl bg-background p-8 shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="h-5 w-5 animate-pulse rounded bg-muted" />
+          <div className="h-5 w-32 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between rounded-lg border border-border p-4"
+            >
+              <div className="space-y-1.5">
+                <div className="h-4 w-48 animate-pulse rounded bg-muted" />
+                <div className="h-3 w-64 animate-pulse rounded bg-muted" />
+                <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+              </div>
+              <div className="h-8 w-20 animate-pulse rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (activeSurvey && activeResponse) {
+    return (
+      <SurveyForm
+        survey={activeSurvey}
+        response={activeResponse}
+        onSave={handleSave}
+        onComplete={handleComplete}
+        onBack={handleBack}
+        readOnly={!!activeResponse.completed_at}
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-2xl bg-background p-8 shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
+      <div className="flex items-center gap-2 mb-1">
+        <ClipboardList className="h-5 w-5 text-portal-brand" />
+        <h2 className="text-xl font-bold text-foreground">Surveys</h2>
+      </div>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Complete surveys to help your care team understand your health better.
+      </p>
+
+      {error && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+          <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      {surveys.length === 0 && !error && (
+        <p className="text-sm text-muted-foreground">No surveys available at this time.</p>
+      )}
+
+      <div className="space-y-3">
+        {surveys.map((survey) => {
+          const response = getResponseForSurvey(survey.id);
+          const label = actionLabel(response);
+          const isStarting = starting === survey.id;
+
+          return (
+            <div
+              key={survey.id}
+              className="flex items-center justify-between rounded-lg border border-border px-5 py-4 transition-colors hover:bg-muted/30"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">
+                    {survey.title}
+                  </p>
+                  {statusBadge(response)}
+                </div>
+                {survey.description && (
+                  <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                    {survey.description}
+                  </p>
+                )}
+                {survey.estimated_minutes && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    ~{survey.estimated_minutes} min
+                  </p>
+                )}
+              </div>
+              <button
+                onClick={() => handleAction(survey)}
+                disabled={isStarting}
+                className="ml-4 shrink-0 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isStarting ? "Starting..." : label}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Patient/PatientSurveys.tsx
+++ b/frontend/src/components/Patient/PatientSurveys.tsx
@@ -42,6 +42,8 @@ export interface SurveyResponse {
   percent_complete: number;
   started_at: string | null;
   completed_at: string | null;
+  consent_date: string | null;
+  consent_signature: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -149,19 +151,15 @@ export default function PatientSurveys({ user }: { user: User | null }) {
 
   const handleSave = async (values: Record<string, unknown>, percentComplete: number) => {
     if (!activeResponse) return;
-    try {
-      const res = await api.patch(`/v1/survey-responses/${activeResponse.id}/`, {
-        values,
-        percent_complete: percentComplete,
-      });
-      const updated: SurveyResponse = res.data;
-      setActiveResponse(updated);
-      setResponses((prev) =>
-        prev.map((r) => (r.id === updated.id ? updated : r))
-      );
-    } catch {
-      // Autosave failure is non-blocking; user can retry on next page change
-    }
+    const res = await api.patch(`/v1/survey-responses/${activeResponse.id}/`, {
+      values,
+      percent_complete: percentComplete,
+    });
+    const updated: SurveyResponse = res.data;
+    setActiveResponse(updated);
+    setResponses((prev) =>
+      prev.map((r) => (r.id === updated.id ? updated : r))
+    );
   };
 
   const handleComplete = async () => {
@@ -176,11 +174,11 @@ export default function PatientSurveys({ user }: { user: User | null }) {
       setResponses((prev) =>
         prev.map((r) => (r.id === updated.id ? updated : r))
       );
+      setActiveSurvey(null);
+      setActiveResponse(null);
     } catch {
       setError("Failed to complete survey. Please try again.");
     }
-    setActiveSurvey(null);
-    setActiveResponse(null);
   };
 
   const handleBack = () => {

--- a/frontend/src/components/Patient/SurveyForm.test.tsx
+++ b/frontend/src/components/Patient/SurveyForm.test.tsx
@@ -1,0 +1,295 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import SurveyForm from "./SurveyForm";
+import type { Survey, SurveyResponse } from "./PatientSurveys";
+
+const mockSurvey: Survey = {
+  id: 10,
+  name: "symptoms_mm",
+  title: "Symptom Tracker",
+  description: "Track your daily symptoms",
+  status: "ACTIVE",
+  disease: "mm",
+  pages: [
+    {
+      name: "page1",
+      title: "Pain Assessment",
+      inputs: [
+        { name: "pain_level", label: "Pain level", type: "rating", data: { maxRating: 5 } },
+        { name: "pain_notes", label: "Pain notes", type: "textarea" },
+      ],
+    },
+    {
+      name: "page2",
+      title: "Other Symptoms",
+      inputs: [
+        { name: "appetite", label: "Appetite", type: "select", data: { options: ["Good", "Fair", "Poor"] } },
+        { name: "other_notes", label: "Other notes", type: "text" },
+      ],
+    },
+  ],
+  estimated_minutes: 5,
+};
+
+const mockResponse: SurveyResponse = {
+  id: 100,
+  person: 7,
+  survey: 10,
+  survey_title: "Symptom Tracker",
+  survey_name: "symptoms_mm",
+  values: {},
+  values_dates: {},
+  percent_complete: 0,
+  started_at: "2025-07-25T10:00:00Z",
+  completed_at: null,
+  created_at: "2025-07-25T10:00:00Z",
+  updated_at: "2025-07-25T10:00:00Z",
+};
+
+describe("SurveyForm", () => {
+  let onSave: ReturnType<typeof vi.fn>;
+  let onComplete: ReturnType<typeof vi.fn>;
+  let onBack: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onSave = vi.fn().mockResolvedValue(undefined);
+    onComplete = vi.fn().mockResolvedValue(undefined);
+    onBack = vi.fn();
+  });
+
+  it("renders survey title and first page title", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    expect(screen.getByText("Symptom Tracker")).toBeInTheDocument();
+    expect(screen.getByText("Pain Assessment")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+  });
+
+  it("renders rating inputs as numbered buttons", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    // 5 rating buttons for pain_level (maxRating: 5)
+    for (let i = 1; i <= 5; i++) {
+      expect(screen.getByRole("button", { name: String(i) })).toBeInTheDocument();
+    }
+  });
+
+  it("renders textarea inputs", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    expect(screen.getByLabelText("Pain notes")).toBeInTheDocument();
+    const textarea = screen.getByLabelText("Pain notes");
+    expect(textarea.tagName.toLowerCase()).toBe("textarea");
+  });
+
+  it("renders select inputs on page 2", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    // Navigate to page 2
+    const nextBtn = screen.getByRole("button", { name: /next/i });
+    fireEvent.click(nextBtn);
+
+    expect(screen.getByLabelText("Appetite")).toBeInTheDocument();
+    const select = screen.getByLabelText("Appetite");
+    expect(select.tagName.toLowerCase()).toBe("select");
+
+    // Check options
+    const options = select.querySelectorAll("option");
+    expect(options.length).toBe(4); // "Select..." + 3 options
+  });
+
+  it("navigates between pages", async () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    // Start on page 1
+    expect(screen.getByText("Pain Assessment")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+
+    // Navigate to page 2
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    expect(screen.getByText("Other Symptoms")).toBeInTheDocument();
+    expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
+
+    // Wait for async save to complete so Previous button is enabled
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /previous/i })).not.toBeDisabled();
+    });
+
+    // Navigate back to page 1
+    fireEvent.click(screen.getByRole("button", { name: /previous/i }));
+    expect(screen.getByText("Pain Assessment")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+  });
+
+  it("calls onSave on page change", async () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Number)
+      );
+    });
+  });
+
+  it("shows Complete Survey button on last page", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    // Page 1 should not show Complete button
+    expect(screen.queryByRole("button", { name: /complete survey/i })).not.toBeInTheDocument();
+
+    // Navigate to last page
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    expect(screen.getByRole("button", { name: /complete survey/i })).toBeInTheDocument();
+  });
+
+  it("calls onComplete when Complete Survey is clicked", async () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    // Navigate to last page
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Click complete
+    fireEvent.click(screen.getByRole("button", { name: /complete survey/i }));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it("disables inputs in readOnly mode", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={{ ...mockResponse, completed_at: "2025-07-25T11:00:00Z" }}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+        readOnly
+      />
+    );
+
+    const textarea = screen.getByLabelText("Pain notes");
+    expect(textarea).toBeDisabled();
+    expect(screen.getByText(/completed.*read only/i)).toBeInTheDocument();
+    // Should not show Complete Survey button
+    expect(screen.queryByRole("button", { name: /complete survey/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onBack when Back to surveys is clicked", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /back to surveys/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("updates rating value when clicked", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={mockResponse}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    const ratingBtn = screen.getByRole("button", { name: "3" });
+    fireEvent.click(ratingBtn);
+
+    // The button should now have the selected styling (primary bg)
+    expect(ratingBtn.className).toContain("bg-primary");
+  });
+
+  it("renders with existing response values", () => {
+    render(
+      <SurveyForm
+        survey={mockSurvey}
+        response={{
+          ...mockResponse,
+          values: { pain_notes: "Mild back pain" },
+        }}
+        onSave={onSave}
+        onComplete={onComplete}
+        onBack={onBack}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Pain notes") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("Mild back pain");
+  });
+});

--- a/frontend/src/components/Patient/SurveyForm.tsx
+++ b/frontend/src/components/Patient/SurveyForm.tsx
@@ -63,6 +63,9 @@ export default function SurveyForm({
     try {
       const pct = computePercentComplete(valuesRef.current, survey);
       await onSave(valuesRef.current, pct);
+    } catch {
+      // Page-navigation autosave failure is non-blocking; retry on next page change.
+      // Completion flow calls onSave directly and will surface errors.
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/Patient/SurveyForm.tsx
+++ b/frontend/src/components/Patient/SurveyForm.tsx
@@ -1,0 +1,322 @@
+import { useState, useCallback, useRef } from "react";
+import { ArrowLeft, ArrowRight, CheckCircle2, ChevronLeft } from "lucide-react";
+import type { Survey, SurveyResponse } from "@/components/Patient/PatientSurveys";
+
+interface SurveyFormProps {
+  survey: Survey;
+  response: SurveyResponse;
+  onSave: (values: Record<string, unknown>, percentComplete: number) => Promise<void>;
+  onComplete: () => void;
+  onBack: () => void;
+  readOnly?: boolean;
+}
+
+function computePercentComplete(
+  values: Record<string, unknown>,
+  survey: Survey
+): number {
+  const allInputs = survey.pages.flatMap((p) => p.inputs);
+  if (allInputs.length === 0) return 100;
+  const filled = allInputs.filter((input) => {
+    const val = values[input.name];
+    return val !== undefined && val !== null && val !== "";
+  }).length;
+  return Math.round((filled / allInputs.length) * 100);
+}
+
+export default function SurveyForm({
+  survey,
+  response,
+  onSave,
+  onComplete,
+  onBack,
+  readOnly = false,
+}: SurveyFormProps) {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [values, setValues] = useState<Record<string, unknown>>(
+    response.values ?? {}
+  );
+  const [saving, setSaving] = useState(false);
+  const [completing, setCompleting] = useState(false);
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
+  const pages = survey.pages ?? [];
+  const page = pages[currentPage];
+  const isLastPage = currentPage === pages.length - 1;
+  const isFirstPage = currentPage === 0;
+
+  const handleFieldChange = useCallback(
+    (name: string, value: unknown) => {
+      setValues((prev) => {
+        const next = { ...prev, [name]: value };
+        valuesRef.current = next;
+        return next;
+      });
+    },
+    []
+  );
+
+  const doSave = useCallback(async () => {
+    if (readOnly) return;
+    setSaving(true);
+    try {
+      const pct = computePercentComplete(valuesRef.current, survey);
+      await onSave(valuesRef.current, pct);
+    } finally {
+      setSaving(false);
+    }
+  }, [readOnly, onSave, survey]);
+
+  const handlePrev = () => {
+    if (isFirstPage) return;
+    doSave();
+    setCurrentPage((p) => p - 1);
+  };
+
+  const handleNext = () => {
+    if (isLastPage) return;
+    doSave();
+    setCurrentPage((p) => p + 1);
+  };
+
+  const handleComplete = async () => {
+    if (readOnly) return;
+    setCompleting(true);
+    try {
+      const pct = computePercentComplete(valuesRef.current, survey);
+      await onSave(valuesRef.current, pct);
+      await onComplete();
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  if (!page) {
+    return (
+      <div className="rounded-2xl bg-background p-8 text-center shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
+        <p className="text-sm text-muted-foreground">
+          This survey has no pages.
+        </p>
+        <button
+          onClick={onBack}
+          className="mt-4 text-sm font-medium text-portal-brand hover:underline"
+        >
+          Back to surveys
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl bg-background p-8 shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
+      {/* Header */}
+      <div className="mb-6">
+        <button
+          onClick={onBack}
+          className="mb-3 inline-flex items-center gap-1 text-sm font-medium text-portal-brand hover:underline"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Back to surveys
+        </button>
+        <h2 className="text-xl font-bold text-foreground">{survey.title}</h2>
+        {readOnly && (
+          <p className="mt-1 text-xs font-medium text-green-600">
+            Completed — read only
+          </p>
+        )}
+        {/* Progress bar */}
+        <div className="mt-3 flex items-center gap-3">
+          <div className="h-2 flex-1 rounded-full bg-muted">
+            <div
+              className="h-2 rounded-full bg-primary transition-all"
+              style={{
+                width: `${computePercentComplete(values, survey)}%`,
+              }}
+            />
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {computePercentComplete(values, survey)}%
+          </span>
+        </div>
+      </div>
+
+      {/* Page indicator */}
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-foreground">{page.title}</h3>
+        <span className="text-xs text-muted-foreground">
+          Page {currentPage + 1} of {pages.length}
+        </span>
+      </div>
+
+      {/* Inputs */}
+      <div className="space-y-5">
+        {page.inputs.map((input) => (
+          <div key={input.name}>
+            <label
+              htmlFor={input.name}
+              className="mb-1.5 block text-sm font-medium text-foreground"
+            >
+              {input.label}
+            </label>
+            {renderInput(input, values[input.name], handleFieldChange, readOnly)}
+          </div>
+        ))}
+      </div>
+
+      {/* Navigation */}
+      <div className="mt-8 flex items-center justify-between">
+        <button
+          onClick={handlePrev}
+          disabled={isFirstPage || saving}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Previous
+        </button>
+
+        <div className="flex items-center gap-2">
+          {saving && (
+            <span className="text-xs text-muted-foreground">Saving...</span>
+          )}
+
+          {isLastPage && !readOnly ? (
+            <button
+              onClick={handleComplete}
+              disabled={completing}
+              className="inline-flex items-center gap-1.5 rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <CheckCircle2 className="h-4 w-4" />
+              {completing ? "Completing..." : "Complete Survey"}
+            </button>
+          ) : (
+            <button
+              onClick={handleNext}
+              disabled={isLastPage || saving}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Next
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Input renderers                                                    */
+/* ------------------------------------------------------------------ */
+
+function renderInput(
+  input: { name: string; type: string; data?: { maxRating?: number; options?: string[] } },
+  value: unknown,
+  onChange: (name: string, value: unknown) => void,
+  readOnly: boolean
+) {
+  switch (input.type) {
+    case "rating":
+      return renderRating(input, value, onChange, readOnly);
+    case "textarea":
+      return renderTextarea(input, value, onChange, readOnly);
+    case "select":
+      return renderSelect(input, value, onChange, readOnly);
+    case "text":
+    default:
+      return renderText(input, value, onChange, readOnly);
+  }
+}
+
+function renderRating(
+  input: { name: string; data?: { maxRating?: number } },
+  value: unknown,
+  onChange: (name: string, value: unknown) => void,
+  readOnly: boolean
+) {
+  const max = input.data?.maxRating ?? 5;
+  const selected = typeof value === "number" ? value : null;
+
+  return (
+    <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={input.name}>
+      {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+        <button
+          key={n}
+          type="button"
+          disabled={readOnly}
+          onClick={() => onChange(input.name, n)}
+          aria-label={`${n}`}
+          className={`flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium transition-colors ${
+            selected === n
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-border bg-background text-foreground hover:bg-muted/50"
+          } disabled:cursor-not-allowed disabled:opacity-70`}
+        >
+          {n}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function renderTextarea(
+  input: { name: string },
+  value: unknown,
+  onChange: (name: string, value: unknown) => void,
+  readOnly: boolean
+) {
+  return (
+    <textarea
+      id={input.name}
+      value={typeof value === "string" ? value : ""}
+      onChange={(e) => onChange(input.name, e.target.value)}
+      disabled={readOnly}
+      rows={4}
+      className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-70"
+    />
+  );
+}
+
+function renderSelect(
+  input: { name: string; data?: { options?: string[] } },
+  value: unknown,
+  onChange: (name: string, value: unknown) => void,
+  readOnly: boolean
+) {
+  const options = input.data?.options ?? [];
+
+  return (
+    <select
+      id={input.name}
+      value={typeof value === "string" ? value : ""}
+      onChange={(e) => onChange(input.name, e.target.value)}
+      disabled={readOnly}
+      className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-70"
+    >
+      <option value="">Select...</option>
+      {options.map((opt) => (
+        <option key={opt} value={opt}>
+          {opt}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function renderText(
+  input: { name: string },
+  value: unknown,
+  onChange: (name: string, value: unknown) => void,
+  readOnly: boolean
+) {
+  return (
+    <input
+      id={input.name}
+      type="text"
+      value={typeof value === "string" ? value : ""}
+      onChange={(e) => onChange(input.name, e.target.value)}
+      disabled={readOnly}
+      className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-70"
+    />
+  );
+}

--- a/patient_portal/api/permissions.py
+++ b/patient_portal/api/permissions.py
@@ -125,6 +125,24 @@ class LabSyncPermission(ScopedTokenPermission):
         return super().has_permission(request, view)
 
 
+class SurveyResponsePermission(ScopedTokenPermission):
+    """ScopedTokenPermission that also allows POST for patient survey responses.
+
+    Patients need to create survey responses (start a survey). The viewset
+    enforces per-person authorization via _OmopFilterMixin and
+    PatientSelfScopePermission, so allowing POST here is safe.
+
+    Service tokens and OAuth2 SMART scopes are handled exactly as in the
+    base class.
+    """
+
+    def has_permission(self, request, view):
+        token = request.auth
+        if token is None or isinstance(token, TokenClaims):
+            return bool(request.user and request.user.is_authenticated)
+        return super().has_permission(request, view)
+
+
 class IsStaffPermission(BasePermission):
     """Allow access only to staff users (is_staff=True)."""
 

--- a/patient_portal/api/permissions.py
+++ b/patient_portal/api/permissions.py
@@ -125,12 +125,16 @@ class LabSyncPermission(ScopedTokenPermission):
         return super().has_permission(request, view)
 
 
+_SURVEY_PATIENT_METHODS = frozenset(('GET', 'HEAD', 'OPTIONS', 'POST', 'PATCH'))
+
+
 class SurveyResponsePermission(ScopedTokenPermission):
     """ScopedTokenPermission that also allows POST for patient survey responses.
 
-    Patients need to create survey responses (start a survey). The viewset
-    enforces per-person authorization via _OmopFilterMixin and
-    PatientSelfScopePermission, so allowing POST here is safe.
+    Patients need to create survey responses (start a survey) and autosave
+    answers via PATCH. The viewset enforces per-person authorization via
+    _OmopFilterMixin and PatientSelfScopePermission, so allowing POST/PATCH
+    here is safe. Staff and superusers retain full access.
 
     Service tokens and OAuth2 SMART scopes are handled exactly as in the
     base class.
@@ -139,7 +143,11 @@ class SurveyResponsePermission(ScopedTokenPermission):
     def has_permission(self, request, view):
         token = request.auth
         if token is None or isinstance(token, TokenClaims):
-            return bool(request.user and request.user.is_authenticated)
+            if not (request.user and request.user.is_authenticated):
+                return False
+            if request.user.is_superuser or getattr(request.user, 'is_staff', False):
+                return True
+            return request.method in _SURVEY_PATIENT_METHODS
         return super().has_permission(request, view)
 
 

--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -550,7 +550,15 @@ class PatientSurveyResponseSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError('values_dates must be a dict.')
         return value
 
+    def validate_completed_at(self, value):
+        if self.instance and self.instance.completed_at is not None and value is None:
+            raise serializers.ValidationError('Cannot re-open a completed survey.')
+        return value
+
     def update(self, instance, validated_data):
+        # Strip immutable identity fields — person and survey are set on create only.
+        validated_data.pop('person', None)
+        validated_data.pop('survey', None)
         # Merge incoming values/values_dates into existing dicts (autosave support).
         for field in ('values', 'values_dates'):
             if field in validated_data:

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -59,7 +59,7 @@ import json
 import logging
 import re
 from io import StringIO
-from .permissions import ScopedTokenPermission, PatientSelfScopePermission, PatientDeletePermission, get_request_org, is_service_token
+from .permissions import ScopedTokenPermission, SurveyResponsePermission, PatientSelfScopePermission, PatientDeletePermission, get_request_org, is_service_token
 from .providers.base import TokenClaims
 from .serializers import (
     UserSerializer, PatientRecordSerializer, PatientListSerializer, ProvenanceRecordSerializer,
@@ -4583,7 +4583,7 @@ class PatientSurveyResponseViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.
     PUT is disabled: values/values_dates are append-only dicts; use PATCH.
     """
     serializer_class = PatientSurveyResponseSerializer
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [SurveyResponsePermission, PatientSelfScopePermission]
     queryset = PatientSurveyResponse.objects.select_related('survey').all()
     http_method_names = ['get', 'post', 'patch', 'head', 'options']
 

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -11251,3 +11251,145 @@ class PatientConsentViewSetTest(TestCase):
         self.assertIn(resp.status_code, [
             status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN,
         ])
+
+
+# ---------------------------------------------------------------------------
+# Patient Survey — session-auth patient tests (PHR-S FM Phase 4a)
+# ---------------------------------------------------------------------------
+
+class PatientSurveySessionAuthTest(TestCase):
+    """Test that session-auth patients can list surveys, create responses,
+    autosave via PATCH, and are self-scoped (cannot see other patients' data).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+
+        _make_vocab_fixtures()
+
+        # Patient A
+        cls.person_a = Person.objects.create(person_id=97001, family_name='SurvAlpha', given_name='Alice')
+        cls.patient_a_rec = PatientRecord.objects.create(person=cls.person_a)
+        cls.identity_a = Identity.objects.create_user(email='survey-a@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_a, person=cls.person_a)
+
+        # Patient B
+        cls.person_b = Person.objects.create(person_id=97002, family_name='SurvBravo', given_name='Bob')
+        cls.patient_b_rec = PatientRecord.objects.create(person=cls.person_b)
+        cls.identity_b = Identity.objects.create_user(email='survey-b@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity_b, person=cls.person_b)
+
+        # Survey
+        cls.survey = Survey.objects.create(
+            name='test-survey-phase4a',
+            title='Test Survey',
+            description='A test survey for Phase 4a',
+            status=Survey.STATUS_ACTIVE,
+            pages=[
+                {
+                    'name': 'page1',
+                    'title': 'Page 1',
+                    'inputs': [
+                        {'name': 'q1', 'type': 'text', 'label': 'Question 1'},
+                        {'name': 'q2', 'type': 'text', 'label': 'Question 2'},
+                    ],
+                }
+            ],
+        )
+
+    def _client_as(self, identity):
+        c = APIClient()
+        c.force_authenticate(user=identity)
+        return c
+
+    def test_patient_can_list_surveys(self):
+        """GET /api/v1/surveys/ returns available surveys for a patient."""
+        resp = self._client_as(self.identity_a).get('/api/v1/surveys/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.json()
+        # Should contain at least the survey we created
+        names = [s['name'] for s in data]
+        self.assertIn('test-survey-phase4a', names)
+
+    def test_patient_can_create_survey_response(self):
+        """POST /api/v1/survey-responses/ creates a new response (201)."""
+        resp = self._client_as(self.identity_a).post(
+            '/api/v1/survey-responses/',
+            {
+                'person': self.person_a.person_id,
+                'survey': self.survey.pk,
+            },
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        data = resp.json()
+        self.assertEqual(data['survey'], self.survey.pk)
+        self.assertEqual(data['person'], self.person_a.person_id)
+        self.assertEqual(data['values'], {})
+        self.assertEqual(data['percent_complete'], 0)
+
+    def test_patient_can_patch_own_response(self):
+        """PATCH /api/v1/survey-responses/{id}/ merges values (autosave)."""
+        client = self._client_as(self.identity_a)
+        # Create
+        resp = client.post(
+            '/api/v1/survey-responses/',
+            {'person': self.person_a.person_id, 'survey': self.survey.pk},
+            format='json',
+        )
+        response_id = resp.json()['id']
+
+        # Autosave first answer
+        resp = client.patch(
+            f'/api/v1/survey-responses/{response_id}/',
+            {'values': {'q1': 'answer-one'}, 'percent_complete': 50},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.json()
+        self.assertEqual(data['values']['q1'], 'answer-one')
+        self.assertEqual(data['percent_complete'], 50)
+
+    def test_patient_cannot_access_other_patients_response(self):
+        """Patient A cannot GET patient B's survey response — returns 404."""
+        # Create a response for patient B
+        client_b = self._client_as(self.identity_b)
+        resp = client_b.post(
+            '/api/v1/survey-responses/',
+            {'person': self.person_b.person_id, 'survey': self.survey.pk},
+            format='json',
+        )
+        response_b_id = resp.json()['id']
+
+        # Patient A tries to access it
+        client_a = self._client_as(self.identity_a)
+        resp = client_a.get(f'/api/v1/survey-responses/{response_b_id}/')
+        self.assertIn(resp.status_code, [
+            status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND,
+        ])
+
+    def test_patient_list_is_self_scoped(self):
+        """GET /api/v1/survey-responses/?person_id={own} returns only own responses."""
+        client_a = self._client_as(self.identity_a)
+        client_b = self._client_as(self.identity_b)
+
+        # Ensure both patients have responses
+        client_a.post(
+            '/api/v1/survey-responses/',
+            {'person': self.person_a.person_id, 'survey': self.survey.pk},
+            format='json',
+        )
+        client_b.post(
+            '/api/v1/survey-responses/',
+            {'person': self.person_b.person_id, 'survey': self.survey.pk},
+            format='json',
+        )
+
+        # Patient A lists their own
+        resp = client_a.get(f'/api/v1/survey-responses/?person_id={self.person_a.person_id}')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.json()
+        # All returned responses belong to patient A
+        for entry in data:
+            self.assertEqual(entry['person'], self.person_a.person_id)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -11393,3 +11393,12 @@ class PatientSurveySessionAuthTest(TestCase):
         # All returned responses belong to patient A
         for entry in data:
             self.assertEqual(entry['person'], self.person_a.person_id)
+
+    def test_patient_cannot_create_response_for_other_patient(self):
+        """POST with person=other patient's person_id is rejected (403)."""
+        resp = self._client_as(self.identity_a).post(
+            '/api/v1/survey-responses/',
+            {'person': self.person_b.person_id, 'survey': self.survey.pk},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
## Summary
- Add `SurveyResponsePermission` to allow session-auth patients to POST (create) survey responses, matching the `LabSyncPermission` pattern
- Build `PatientSurveys` component: lists active surveys with status badges (Not started / In progress / Completed), start/continue/view actions
- Build `SurveyForm` component: multi-page form renderer with rating, textarea, select, and text inputs; autosave on page navigation; progress bar; read-only mode for completed surveys
- Wire surveys section into `PatientHome` between consents and patient detail
- 5 backend tests (patient list surveys, create response, PATCH autosave, cross-patient blocked, self-scoped list)
- 19 frontend tests (PatientSurveys: 9, SurveyForm: 10)

**FM:** PH.2.1 (Account-Holder-Originated Data), PH.3.1

Closes #284

## Test plan
- [ ] Backend: 868 tests pass (`manage.py test omop_core patient_portal`)
- [ ] Frontend: 103 tests pass (`npm test -- --run`)
- [ ] Manual: log in as patient, verify surveys section appears, start a survey, autosave answers across pages, complete survey, verify read-only view

🤖 Generated with [Claude Code](https://claude.com/claude-code)