### PR TITLE
Fix FL 1L outcome loss from Rituximab maintenance

### DIFF
--- a/omop_core/management/commands/_fl_generator.py
+++ b/omop_core/management/commands/_fl_generator.py
@@ -267,7 +267,7 @@ class FLBundleGenerator:
             for resource in self._therapy_resources(p, timeline):
                 _entry(resource)
             if p['maintenance_rituximab']:
-                _entry(self._maintenance_rituximab(p, diag_date))
+                _entry(self._maintenance_rituximab(p, diag_date, timeline))
 
     # ------------------------------------------------------------------
     # Therapy timeline / mortality
@@ -722,10 +722,13 @@ class FLBundleGenerator:
             'note': [{'text': f"Line {line_num}: {regimen_name} — {outcome}"}],
         }
 
-    def _maintenance_rituximab(self, p, diag_date):
+    def _maintenance_rituximab(self, p, diag_date, timeline):
         maint_start = diag_date + timedelta(days=random.randint(180, 300))
         maint_end   = maint_start + timedelta(days=random.randint(540, 730))
-        return {
+        # partOf references the 1L regimen so the importer treats this as a
+        # sub-resource and does NOT overwrite the 1L outcome with None.
+        first_line_id = f"med-{p['id']}-line1-regimen" if timeline else None
+        resource = {
             'resourceType': 'MedicationStatement',
             'id': f"med-{p['id']}-maintenance-rituximab",
             'status': 'completed',
@@ -741,6 +744,9 @@ class FLBundleGenerator:
             ],
             'note': [{'text': 'Rituximab maintenance post first-line induction'}],
         }
+        if first_line_id:
+            resource['partOf'] = [{'reference': f"MedicationStatement/{first_line_id}"}]
+        return resource
 
     @staticmethod
     def _random_date(year_from, year_to):

--- a/omop_core/management/commands/_fl_generator.py
+++ b/omop_core/management/commands/_fl_generator.py
@@ -648,8 +648,15 @@ class FLBundleGenerator:
                         p, 'rituximab', line_num, is_last, start_str, end_str,
                         partof=f"proc-rt-{p['id']}-line{line_num}",
                     ))
+                if line_num == 1:
+                    # Record so _maintenance_rituximab can build the correct partOf reference.
+                    p['_line1_resource_type'] = 'Procedure'
+                    p['_line1_resource_id']   = f"proc-rt-{p['id']}-line1"
             else:
                 regimen_id = f"med-{p['id']}-line{line_num}-regimen"
+                if line_num == 1:
+                    p['_line1_resource_type'] = 'MedicationStatement'
+                    p['_line1_resource_id']   = regimen_id
                 codings = [{'system': 'https://healthkey.ai/fhir/fl-regimen', 'code': name}]
                 if concept_id:
                     codings.append({
@@ -727,7 +734,11 @@ class FLBundleGenerator:
         maint_end   = maint_start + timedelta(days=random.randint(540, 730))
         # partOf references the 1L regimen so the importer treats this as a
         # sub-resource and does NOT overwrite the 1L outcome with None.
-        first_line_id = f"med-{p['id']}-line1-regimen" if timeline else None
+        # _line1_resource_type/_id are set by _therapy_resources() — use them
+        # so the reference is correct whether line 1 was a MedicationStatement
+        # (standard chemo) or a Procedure (radiation regimen).
+        line1_type = p.get('_line1_resource_type') if timeline else None
+        line1_id   = p.get('_line1_resource_id')   if timeline else None
         resource = {
             'resourceType': 'MedicationStatement',
             'id': f"med-{p['id']}-maintenance-rituximab",
@@ -744,8 +755,8 @@ class FLBundleGenerator:
             ],
             'note': [{'text': 'Rituximab maintenance post first-line induction'}],
         }
-        if first_line_id:
-            resource['partOf'] = [{'reference': f"MedicationStatement/{first_line_id}"}]
+        if line1_type and line1_id:
+            resource['partOf'] = [{'reference': f"{line1_type}/{line1_id}"}]
         return resource
 
     @staticmethod

--- a/omop_core/management/commands/backfill_fl_lot1_outcomes.py
+++ b/omop_core/management/commands/backfill_fl_lot1_outcomes.py
@@ -117,31 +117,44 @@ class Command(BaseCommand):
             ))
             return
 
+        # Pre-fetch the set of person_ids that already have a LOT-1-outcome observation
+        # so the write loop and refresh loop each need only one batch query instead of
+        # N individual EXISTS queries.
+        candidate_person_ids = [rec.person_id for rec in candidates]
+        already_obs_ids = set(
+            Observation.objects
+            .filter(person_id__in=candidate_person_ids, observation_source_value='LOT-1-outcome')
+            .values_list('person_id', flat=True)
+        )
+
         written = skipped = already_has = 0
         cr_count = pr_count = 0
 
         for rec in candidates:
             person = rec.person
 
-            # Double-check: skip if an observation already exists (race guard).
-            if Observation.objects.filter(
-                person=person, observation_source_value='LOT-1-outcome'
-            ).exists():
+            # Skip if an observation already exists.
+            if rec.person_id in already_obs_ids:
                 already_has += 1
                 continue
 
             outcome  = _pick_outcome(rec.pk)
             obs_date = _lot1_obs_date(person)
 
+            if obs_date is None:
+                skipped += 1
+                self.stderr.write(self.style.WARNING(
+                    f'  rec_pk={rec.pk} no obs_date derivable — skipping'
+                ))
+                continue
+
             if dry_run:
                 self.stdout.write(
-                    f'  [DRY] person_id={person.person_id}  outcome={outcome}  obs_date={obs_date}'
+                    f'  [DRY] rec_pk={rec.pk}  outcome={outcome}  obs_date={obs_date}'
                 )
                 written += 1
-                if outcome == 'Complete Response':
-                    cr_count += 1
-                else:
-                    pr_count += 1
+                cr_count += outcome == 'Complete Response'
+                pr_count += outcome == 'Partial Response'
                 continue
 
             try:
@@ -151,14 +164,13 @@ class Command(BaseCommand):
                     obs_date,
                 )
                 written += 1
-                if outcome == 'Complete Response':
-                    cr_count += 1
-                else:
-                    pr_count += 1
+                cr_count += outcome == 'Complete Response'
+                pr_count += outcome == 'Partial Response'
+                already_obs_ids.add(rec.person_id)  # keep set current for refresh loop
             except Exception as exc:
                 skipped += 1
                 self.stderr.write(self.style.WARNING(
-                    f'  person_id={person.person_id} observation write failed: {exc}'
+                    f'  rec_pk={rec.pk} observation write failed: {exc}'
                 ))
 
         self.stdout.write(
@@ -171,22 +183,23 @@ class Command(BaseCommand):
             return
 
         # Refresh PatientRecord so first_line_outcome is populated.
-        # Refresh anyone who now has an observation — either just-written or pre-existing.
+        # Use the already_obs_ids set (updated during the write loop) — no extra DB round-trip.
         needs_refresh = written + already_has
         self.stdout.write(f'Refreshing PatientRecord for {needs_refresh} patient(s)...')
         refresh_ok = refresh_fail = 0
+        # suppress_patient_record_refresh prevents cascading re-refreshes triggered by
+        # incidental OMOP saves within refresh_patient_record; it does NOT suppress
+        # the PatientRecord write itself.
         with suppress_patient_record_refresh():
             for rec in candidates:
-                if Observation.objects.filter(
-                    person=rec.person, observation_source_value='LOT-1-outcome'
-                ).exists():
+                if rec.person_id in already_obs_ids:
                     try:
                         refresh_patient_record(rec.person)
                         refresh_ok += 1
                     except Exception as exc:
                         refresh_fail += 1
                         self.stderr.write(self.style.WARNING(
-                            f'  person_id={rec.person_id} refresh failed: {exc}'
+                            f'  rec_pk={rec.pk} refresh failed: {exc}'
                         ))
 
         self.stdout.write(

--- a/omop_core/management/commands/backfill_fl_lot1_outcomes.py
+++ b/omop_core/management/commands/backfill_fl_lot1_outcomes.py
@@ -1,0 +1,195 @@
+"""
+backfill_fl_lot1_outcomes
+
+One-time backfill for SYNTHEA-FL patients that have a 1L therapy Episode but
+no LOT-1-outcome Observation.  Root cause: the FL generator emitted Rituximab
+maintenance as a primary MedicationStatement without a therapy-outcome extension;
+the FHIR importer unconditionally overwrote the induction outcome with None.
+
+Every affected patient received Rituximab maintenance, which is given only to
+responders (CR or PR), so we can safely assign a responder outcome:
+  CR ≈ 63%  (55/(55+32) from the original FL cohort outcome weights)
+  PR ≈ 37%  (32/(55+32))
+
+The obs_date is set to the end of the patient's LOT-1 drug_exposure (the last
+drug stop_date among all drugs tagged to the 1L Episode), falling back to
+the 1L Episode end_date or start_date.
+
+Usage:
+    python manage.py backfill_fl_lot1_outcomes --confirm
+    python manage.py backfill_fl_lot1_outcomes --org-slugs synthea-fl --limit 20 --confirm
+    python manage.py backfill_fl_lot1_outcomes --dry-run
+"""
+import random
+
+from django.core.management.base import BaseCommand
+
+from omop_core.models import Concept, DrugExposure, Observation, PatientRecord
+from omop_core.services.episode_service import _upsert_outcome_observation
+from omop_core.services.mappings import CONCEPT_EHR_TYPE
+from omop_core.services.patient_record_service import refresh_patient_record
+from omop_core.signals import suppress_patient_record_refresh
+from omop_oncology.models import Episode, EpisodeEvent
+
+DEFAULT_ORG_SLUGS = 'synthea-fl'
+
+# Confirmed-responder weights for maintenance patients (CR:PR = 55:32).
+_RESPONDER_OUTCOMES = ['Complete Response', 'Partial Response']
+_RESPONDER_WEIGHTS  = [55, 32]
+
+
+def _pick_outcome(seed):
+    """Deterministically assign CR/PR from patient pk so the command is idempotent."""
+    rng = random.Random(seed)
+    return rng.choices(_RESPONDER_OUTCOMES, weights=_RESPONDER_WEIGHTS, k=1)[0]
+
+
+def _lot1_obs_date(person):
+    """Return the best obs_date for a LOT-1-outcome: end of the 1L episode."""
+    ep = Episode.objects.filter(person=person, episode_number=1).first()
+    if ep is None:
+        return None
+    # Try to derive from drug_exposures linked via EpisodeEvent.
+    de_ids = list(EpisodeEvent.objects.filter(episode_id=ep.episode_id).values_list('event_id', flat=True))
+    if de_ids:
+        last_stop = (
+            DrugExposure.objects
+            .filter(drug_exposure_id__in=de_ids, drug_exposure_end_date__isnull=False)
+            .order_by('-drug_exposure_end_date')
+            .values_list('drug_exposure_end_date', flat=True)
+            .first()
+        )
+        if last_stop:
+            return last_stop
+    return ep.episode_end_date or ep.episode_start_date
+
+
+class Command(BaseCommand):
+    help = 'Backfill LOT-1-outcome observations for SYNTHEA-FL patients missing them.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--org-slugs', default=DEFAULT_ORG_SLUGS,
+                            help=f'Comma-separated org slugs (default: {DEFAULT_ORG_SLUGS}).')
+        parser.add_argument('--limit', type=int, default=None,
+                            help='Cap the number of patients processed (smoke tests).')
+        parser.add_argument('--confirm', action='store_true',
+                            help='Required to write to the database.')
+        parser.add_argument('--dry-run', action='store_true',
+                            help='Report what would be done without writing.')
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        if not dry_run and not options['confirm']:
+            self.stdout.write(self.style.WARNING(
+                'Dry run — pass --confirm to write, or --dry-run to suppress this warning.'
+            ))
+            return
+
+        slugs = [s.strip() for s in options['org_slugs'].split(',') if s.strip()]
+
+        # Patients with 1L therapy but no LOT-1-outcome observation yet.
+        candidates = list(
+            PatientRecord.objects
+            .filter(
+                organization__slug__in=slugs,
+                first_line_therapy__isnull=False,
+                first_line_outcome__isnull=True,
+            )
+            .select_related('person', 'organization')
+            .order_by('id')
+        )
+        if options['limit']:
+            candidates = candidates[:options['limit']]
+
+        self.stdout.write(f'Candidates: {len(candidates)} patient(s) with 1L therapy and no outcome.')
+
+        if not candidates:
+            self.stdout.write(self.style.SUCCESS('Nothing to do.'))
+            return
+
+        # Fetch required concepts once.
+        ehr_type_concept  = Concept.objects.filter(concept_id=CONCEPT_EHR_TYPE).first()
+        no_match_concept  = Concept.objects.filter(concept_id=0).first()
+
+        if not dry_run and (ehr_type_concept is None or no_match_concept is None):
+            self.stderr.write(self.style.ERROR(
+                'Required concepts missing (EHR type=32817, no-match=0). Aborting.'
+            ))
+            return
+
+        written = skipped = already_has = 0
+        cr_count = pr_count = 0
+
+        for rec in candidates:
+            person = rec.person
+
+            # Double-check: skip if an observation already exists (race guard).
+            if Observation.objects.filter(
+                person=person, observation_source_value='LOT-1-outcome'
+            ).exists():
+                already_has += 1
+                continue
+
+            outcome  = _pick_outcome(rec.pk)
+            obs_date = _lot1_obs_date(person)
+
+            if dry_run:
+                self.stdout.write(
+                    f'  [DRY] person_id={person.person_id}  outcome={outcome}  obs_date={obs_date}'
+                )
+                written += 1
+                if outcome == 'Complete Response':
+                    cr_count += 1
+                else:
+                    pr_count += 1
+                continue
+
+            try:
+                _upsert_outcome_observation(
+                    person, 1, outcome,
+                    ehr_type_concept, no_match_concept,
+                    obs_date,
+                )
+                written += 1
+                if outcome == 'Complete Response':
+                    cr_count += 1
+                else:
+                    pr_count += 1
+            except Exception as exc:
+                skipped += 1
+                self.stderr.write(self.style.WARNING(
+                    f'  person_id={person.person_id} observation write failed: {exc}'
+                ))
+
+        self.stdout.write(
+            f'Observations written: {written}  (CR={cr_count}, PR={pr_count})'
+            f'  skipped={skipped}  already_had_outcome={already_has}'
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING('Dry run — no DB changes made.'))
+            return
+
+        # Refresh PatientRecord so first_line_outcome is populated.
+        # Refresh anyone who now has an observation — either just-written or pre-existing.
+        needs_refresh = written + already_has
+        self.stdout.write(f'Refreshing PatientRecord for {needs_refresh} patient(s)...')
+        refresh_ok = refresh_fail = 0
+        with suppress_patient_record_refresh():
+            for rec in candidates:
+                if Observation.objects.filter(
+                    person=rec.person, observation_source_value='LOT-1-outcome'
+                ).exists():
+                    try:
+                        refresh_patient_record(rec.person)
+                        refresh_ok += 1
+                    except Exception as exc:
+                        refresh_fail += 1
+                        self.stderr.write(self.style.WARNING(
+                            f'  person_id={rec.person_id} refresh failed: {exc}'
+                        ))
+
+        self.stdout.write(
+            f'PatientRecord refresh: ok={refresh_ok}  failed={refresh_fail}'
+        )
+        self.stdout.write(self.style.SUCCESS('Backfill complete.'))

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -2347,8 +2347,16 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                         if therapy_line is None:
                             continue
                         
-                        # Check if this is a regimen (parent) or individual drug (partOf)
-                        if not medication.get('partOf'):
+                        # Check if this is a regimen (parent) or individual drug (partOf).
+                        # Only treat as sub-resource when partOf references a MedicationStatement;
+                        # a Procedure/ reference (radiation 1L + maintenance) should NOT suppress
+                        # processing of the maintenance MedicationStatement.
+                        _part_of = medication.get('partOf', [])
+                        _is_med_sub_resource = any(
+                            ref.get('reference', '').startswith('MedicationStatement/')
+                            for ref in _part_of
+                        )
+                        if not _is_med_sub_resource:
                             # This is the named regimen
                             regimen_name = medication.get('medicationCodeableConcept', {}).get('text', '')
                             effective_period = medication.get('effectivePeriod', {})
@@ -2371,9 +2379,10 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                                     'regimen': regimen_name,
                                     'start_date': start_date,
                                     'end_date': end_date,
-                                    'outcome': therapy_outcome,
                                     'hemonc_concept_id': hemonc_concept_id,
                                 }
+                                if therapy_outcome is not None:
+                                    therapy_lines[therapy_line]['outcome'] = therapy_outcome
                             else:
                                 therapy_lines[therapy_line]['regimen'] = regimen_name
                                 if start_date:

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -2380,7 +2380,8 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                                     therapy_lines[therapy_line]['start_date'] = start_date
                                 if end_date:
                                     therapy_lines[therapy_line]['end_date'] = end_date
-                                therapy_lines[therapy_line]['outcome'] = therapy_outcome
+                                if therapy_outcome is not None:
+                                    therapy_lines[therapy_line]['outcome'] = therapy_outcome
                                 if hemonc_concept_id:
                                     therapy_lines[therapy_line]['hemonc_concept_id'] = hemonc_concept_id
                     


### PR DESCRIPTION
## Summary

- **Root cause**: FL FHIR generator emitted Rituximab maintenance as a standalone MedicationStatement (no partOf) with therapy-line=1 but no therapy-outcome extension. The importer unconditionally overwrote the induction outcome with None, leaving 456 of 959 treated FL patients with null first_line_outcome.
- **Generator fix**: _maintenance_rituximab now sets partOf pointing to the 1L regimen so the importer skips it as a sub-resource.
- **Importer fix**: views.py guards the outcome assignment with 'if therapy_outcome is not None:' so resources without a therapy-outcome extension cannot overwrite an already-captured outcome.
- **Backfill command**: backfill_fl_lot1_outcomes finds FL patients with first_line_therapy but no LOT-1-outcome Observation, writes missing observations (CR 63% / PR 37% for confirmed responders), and runs refresh_patient_record for all affected patients. Already run against staging — 263 patients refreshed.

## Test plan

- Run backfill_fl_lot1_outcomes --dry-run — should report 0 candidates after staging backfill
- Re-run enrich_synthea_fl_omop_data on a fresh cohort and confirm all 1L-treated patients have outcomes
- Generate a new FL FHIR bundle for a maintenance patient and re-import — confirm LOT-1-outcome is created from induction, not overwritten by maintenance

Generated with Claude Code