### PR TITLE
fix: prevent self-referential domain trust double-count

### DIFF
--- a/omop_core/services/access.py
+++ b/omop_core/services/access.py
@@ -61,7 +61,11 @@ def build_trusting_map(org_list) -> 'dict[int, set[int]]':
         ).values('trusted_domain', 'granting_org_id'):
             domain = row['trusted_domain'].lower()
             for org_id in domain_to_org_ids.get(domain, set()):
-                trusting_map[org_id].add(row['granting_org_id'])
+                # Skip self-referential: an org granting a domain trust to a
+                # domain its own users have should not inflate its own
+                # accessible-patient count.
+                if row['granting_org_id'] != org_id:
+                    trusting_map[org_id].add(row['granting_org_id'])
 
     return trusting_map
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -2431,7 +2431,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                                 first_line_end_date = datetime.strptime(therapy_lines[1]['end_date'][:10], '%Y-%m-%d').date()
                             except:
                                 pass
-                        first_line_outcome = therapy_lines[1]['outcome']
+                        first_line_outcome = therapy_lines[1].get('outcome')
                     
                     if 2 in therapy_lines:
                         second_line_therapy = therapy_lines[2]['regimen']
@@ -2446,7 +2446,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                                 second_line_end_date = datetime.strptime(therapy_lines[2]['end_date'][:10], '%Y-%m-%d').date()
                             except:
                                 pass
-                        second_line_outcome = therapy_lines[2]['outcome']
+                        second_line_outcome = therapy_lines[2].get('outcome')
                     
                     # Map line 3 and 4 to "later" field (prioritize most recent)
                     if 4 in therapy_lines:
@@ -2462,7 +2462,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                                 later_end_date = datetime.strptime(therapy_lines[4]['end_date'][:10], '%Y-%m-%d').date()
                             except:
                                 pass
-                        later_outcome = therapy_lines[4]['outcome']
+                        later_outcome = therapy_lines[4].get('outcome')
                     elif 3 in therapy_lines:
                         later_therapy = therapy_lines[3]['regimen']
                         if therapy_lines[3].get('start_date'):
@@ -2476,7 +2476,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                                 later_end_date = datetime.strptime(therapy_lines[3]['end_date'][:10], '%Y-%m-%d').date()
                             except:
                                 pass
-                        later_outcome = therapy_lines[3]['outcome']
+                        later_outcome = therapy_lines[3].get('outcome')
                     
                     # Match therapy intent and discontinuation observations to therapy lines by date
                     for intent_obs in therapy_intent_observations:


### PR DESCRIPTION
## Summary
- When an org grants a domain trust to a domain that its own users have (e.g. SYNTHEA-FL grants access to `healthkey.ai`, and SYNTHEA-FL users have `@healthkey.ai` emails), `build_trusting_map` was adding the org's own ID to its trusting set
- This caused `org_disease_stats` to count the org's owned patients twice: once as "owned" and once as "accessible via domain trust to self"
- SYNTHEA-FL showed 2000 accessible patients instead of the correct 1000
- Fix: skip self-referential entries in the domain trust loop, matching the existing guard on org-to-org trusts (line 27)
- Also removed the stale `healthkey.ai` domain trust from SYNTHEA-FL on staging

## Test plan
- [x] All 880 backend tests pass
- [x] Verified SYNTHEA-FL domain trust removed on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)