### PR TITLE
feat: audit-event retention/archival command (TI.2.2, #298)

### DIFF
--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -152,6 +152,14 @@ LOGGING = {
     },
 }
 
+# Audit-event retention (HL7 PHR-S FM TI.2.2 — Audit Log Management).
+# AuditEvent rows older than this many days are eligible for pruning by the
+# `prune_audit_events` management command (typically run as a scheduled job).
+# Default 2190 days (~6 years): a common minimum retention for healthcare audit
+# logs (e.g. HIPAA record-retention practice). Override per-deployment via the
+# AUDIT_EVENT_RETENTION_DAYS env var, or per-run via `--days N`.
+AUDIT_EVENT_RETENTION_DAYS = int(os.environ.get('AUDIT_EVENT_RETENTION_DAYS', '2190'))
+
 ROOT_URLCONF = 'ctomop.urls'
 
 TEMPLATES = [

--- a/docs/phrs-fm-roadmap.md
+++ b/docs/phrs-fm-roadmap.md
@@ -282,9 +282,9 @@ all, patients see only their own — filterable by `event_type` / `method` / `us
 
 ## Cross-cutting
 
-- **FM traceability:** maintain a short mapping of each shipped capability to its FM
-  function ID (PH.1.x, etc.) so scope stays visible and a future conformance pass has a
-  starting point.
+- **FM traceability:** ✅ done — see [`phrs-fm-traceability.md`](phrs-fm-traceability.md),
+  the capability-to-FM-function-ID mapping (PH.1.x, TI.2.x, etc.). Keep it current as
+  capabilities land so scope stays visible and a future conformance pass has a starting point.
 
 ## Verification (per phase)
 

--- a/docs/phrs-fm-traceability.md
+++ b/docs/phrs-fm-traceability.md
@@ -1,0 +1,106 @@
+# PHR-S FM Traceability Matrix
+
+Maps HL7 **Personal Health Record System Functional Model R2**
+(PHR-S FM, <https://build.fhir.org/ig/HL7/phrsfm-ig/en/>) functions to promop's
+as-built capabilities. This is the conformance-posture map referenced as the
+"FM traceability" cross-cutting item in [`phrs-fm-roadmap.md`](phrs-fm-roadmap.md);
+update it whenever a capability lands so a future formal conformance pass has a
+starting point.
+
+**Status legend**
+
+| | Meaning |
+|---|---|
+| ✅ | Implemented — a concrete promop capability satisfies the function |
+| ◐ | Partial — some of the function is covered; gaps noted |
+| ○ | Not yet / deferred — no capability, or intentionally out of the pragmatic subset |
+
+Scope note: promop targets a **pragmatic, oncology-focused subset** of the FM
+(patient/account-holder-facing functions), not full-FM conformance. Sections with
+no account-holder-facing driver (much of Supportive / Record-Infrastructure) are
+intentionally ○.
+
+---
+
+## PH — Personal Health
+
+| FM ID | Function | Status | promop capability | Ref |
+|---|---|---|---|---|
+| **PH.1** | **PHR Account Holder Profile** | ✅ | First-class patient role | #264 |
+| PH.1.1 | Identify & maintain account-holder record | ✅ | `Identity` + `PatientUser`↔`Person`; provisioning via staff invite (`/api/v1/patients/{id}/invite/` + `/patient-invitations/accept/`) and app signup (`/api/v1/patients/signup/`); `patient_person_for()` | #264 |
+| PH.1.2 | Manage demographic information | ✅ | `PatientRecord` + `PatientHome` General tab (PATCH `/api/patient-info/{id}/`) | #264 |
+| PH.1.3 | Manage account-holder & family preferences | ○ | No dedicated preferences store | — |
+| PH.1.4 | Manage advance directives | ✅ | `PatientDocument` `ADVANCE_DIRECTIVE` type + `doc_type` filter; `AdvanceDirectives.tsx` | #292 |
+| PH.1.5 | Manage consents & authorizations | ✅ | `PatientConsentViewSet` `/api/v1/consents/` (list + toggle), self-scoped; 3 consent types | #278/#283 |
+| PH.1.6 | Manage account status | ◐ | Account deletion / right-to-erasure done (see TI.1.7); no suspend/reactivate lifecycle states | #264 |
+| **PH.2** | **Manage historical & current-state data** | ✅ | | #2xx |
+| PH.2.1 | Account-holder-originated data | ✅ | Surveys/PROs in patient mode (`/api/v1/survey-responses/`); HealthKit device sync (`fhir/sync.py`) | 4a |
+| PH.2.2 | Data from external administrative sources | ◐ | FHIR import ingests admin/demographic data; no dedicated admin-source workflow | — |
+| PH.2.3 | Data/documentation from external clinical sources | ✅ | Three FHIR R4 import paths (`upload_fhir`, `import_fhir_bundle`, `fhir/sync.py`) | — |
+| PH.2.4 | Produce & present ad-hoc views | ✅ | `PatientHome` tabbed views; **FHIR export** `GET /api/v1/patient-records/{id}/export-fhir/` + `export_fhir_bundle` command | Phase 2 |
+| PH.2.5 | Manage historical/current-state lists | ◐ | Problems (`ConditionOccurrence`), meds (`DrugExposure`/LoT), **allergy list** (`/api/v1/allergies/`), **immunization list** (`/api/v1/immunizations/`); family/genetic/social history partial | #292 |
+| **PH.3** | **Wellness, preventive medicine & self-care** | ◐ | | — |
+| PH.3.1 | Personal clinical measurements & observations | ✅ | HealthKit/device `Measurement` sync + wearable summaries | — |
+| PH.3.4 | Manage medications | ◐ | `DrugExposure` + line-of-therapy fields; no patient-managed active-med reconciliation | — |
+| PH.3.2/3.3 | Care plans (account- & provider-initiated) | ○ | Deferred — no concrete oncology driver | — |
+| **PH.4** | Manage health education | ○ | Not started | — |
+| **PH.5** | Account-holder decision support | ○ | Not started (candidate: drug-interaction / guideline alerts) | — |
+| **PH.6** | **Manage encounters with providers** | ◐ | | — |
+| PH.6.3 | Provider ↔ account-holder communications | ✅ | Bidirectional secure messaging `/api/v1/messages/` (threads, read-state) | #287/#289 |
+| PH.6.1–6.8 | Administrative/financial, referrals, care plans, assessments | ○ | Not started | — |
+
+---
+
+## S — Supportive
+
+| FM ID | Function | Status | promop capability | Ref |
+|---|---|---|---|---|
+| S.1 | Provider information | ○ | Not started | — |
+| S.2 | Financial management | ○ | Not started (out of oncology scope) | — |
+| S.3 | Administration management | ◐ | | — |
+| S.3.6 | Information import/export | ✅ | FHIR R4 import (3 paths) + FHIR export (Phase 2); raw OMOP JSON export command | — |
+| S.4.1 | Manage clinical research information | ◐ | `PatientTrialEnrollment` + EXACT trial-matching (backend); **patient-facing trial surfacing pending** (candidate next area) | — |
+
+---
+
+## RI — Record Infrastructure
+
+| FM ID | Function | Status | promop capability | Ref |
+|---|---|---|---|---|
+| RI.1 | Record lifecycle & lifespan | ◐ | `ProvenanceRecord` captures source/actor/reason on writes; `previous_values` returned on PATCH; no full lifecycle-event ledger | — |
+| RI.2 | Record synchronization | ◐ | FHIR sync/patient-sync endpoints ingest & reconcile external EHR/device data | — |
+| RI.3 | Record archive & restore | ○ | Not started (audit-log archival addressed separately under TI.2.2, #298) | — |
+
+---
+
+## TI — Trust Infrastructure
+
+| FM ID | Function | Status | promop capability | Ref |
+|---|---|---|---|---|
+| **TI.1** | **Security** | ✅ | | — |
+| TI.1.1 | Authentication | ✅ | OAuth2 / SMART-on-FHIR (PKCE), partner JWT (OIDC/Firebase), session, HMAC service token | — |
+| TI.1.2 | Authorization / access control | ✅ | `ScopedTokenPermission` (SMART scopes), `GroupAccess` roles, `can_access_patient`/`can_write_patient`, `PatientSelfScopePermission` (per-Person object scoping), org/trust scoping | #264 |
+| TI.1.7 | Account-holder data deletion (erasure) | ✅ | `DELETE /api/v1/patient-records/me/` (typed confirm; Person cascade + Identity removal, atomic) | #264 |
+| TI.1.x | Privacy / data masking / routing | ◐ | Org-scoping, trust maps, `hide_from_patient` groundwork; no field-level masking | — |
+| **TI.2** | **Audit** | ✅ | | #295 |
+| TI.2.1 | Audit triggers | ✅ | `AuditLogMiddleware` audits every API/OAuth request; classified `record_view`/`record_create`/`record_update`/`record_delete`/`auth`/`consent` | #295 |
+| TI.2.2 | Audit log management (retention) | ◐→✅ | Immutable `AuditEvent` rows (admin view-only); **retention/archival command in progress** | #298 |
+| TI.2.3 | Audit notification & review | ✅ | Read-only `GET /api/v1/audit-events/` — staff see all, patients see own; filter by type/method/user/time | #295 |
+| TI.4 | Standard terminology & services | ✅ | OMOP concept model; vocabulary endpoints; concept search/lookup/ancestors/descendants/graph/synonyms | #239 |
+| TI.5 | Standards-based interoperability | ✅ | FHIR R4 (import/export), OMOP CDM v5.4, SMART-on-FHIR / OAuth2, `.well-known/smart-configuration` | — |
+| TI.3 / TI.6–TI.10 | Registry, business rules, workflow, backup, terminology models | ○ | Not separately implemented (infra-level; partly delegated to platform) | — |
+
+---
+
+## Summary
+
+- **Complete (✅):** the account-holder core — PH.1 profile & provisioning, PH.1.4 directives,
+  PH.1.5 consent, PH.2 data management incl. FHIR export, PH.6.3 messaging, TI.1 security,
+  TI.2 audit (retention landing via #298), TI.4/TI.5 terminology & interoperability.
+- **Partial (◐):** PH.2.5 clinical lists (family/genetic/social history gaps), PH.3 wellness,
+  RI.1/RI.2 record infrastructure, S.4.1 research (backend only), TI.1.x privacy masking.
+- **Not yet / deferred (○):** PH.4 education, PH.5 decision support, PH.6 referrals, most of
+  Supportive (S.1/S.2), RI.3 archive, TI.3/TI.6–TI.10.
+- **Highest-value open candidates** (from the roadmap): **S.4.1** patient-facing trial matching
+  (big head start from the EXACT integration), **PH.5** oncology decision support, and closing
+  the **PH.2.5** history gaps.

--- a/patient_portal/management/commands/prune_audit_events.py
+++ b/patient_portal/management/commands/prune_audit_events.py
@@ -1,0 +1,171 @@
+"""
+Prune (and optionally archive) old AuditEvent rows — HL7 PHR-S FM TI.2.2.
+
+The `audit_event` table grows by one row per audited API/OAuth request and would
+otherwise grow unbounded. This command enforces a retention window: rows whose
+`timestamp` is strictly older than `now - retention_days` are eligible for
+deletion. Newer rows are NEVER touched.
+
+Retention window (in days) resolution order:
+  1. `--days N` (per-run override)
+  2. settings.AUDIT_EVENT_RETENTION_DAYS (env: AUDIT_EVENT_RETENTION_DAYS)
+
+Deletion happens in PK-ordered batches (`--batch-size`, default 1000) to avoid a
+single huge DELETE holding a long lock on the table. When `--archive <path>` is
+given, each batch is appended to the file as JSON Lines (one JSON object per row,
+ISO-8601 timestamp) BEFORE it is deleted, so nothing is lost.
+
+Usage:
+    python manage.py prune_audit_events --dry-run
+    python manage.py prune_audit_events --days 365
+    python manage.py prune_audit_events --archive /path/to/audit-archive.jsonl
+    python manage.py prune_audit_events --batch-size 5000
+"""
+
+import json
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from patient_portal.models import AuditEvent
+
+
+# Columns serialized to the archive (one JSON object per row). Kept explicit so
+# the archive format is stable and independent of model-field ordering.
+_ARCHIVE_FIELDS = [
+    'id',
+    'event_type',
+    'timestamp',
+    'method',
+    'path',
+    'status_code',
+    'user_id',
+    'user_email',
+    'client_id',
+    'resource_id',
+    'ip_address',
+    'duration_ms',
+    'detail',
+]
+
+
+class Command(BaseCommand):
+    help = "Delete (and optionally archive) AuditEvent rows older than the retention window (TI.2.2)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days',
+            type=int,
+            default=None,
+            help=(
+                'Retention window in days for this run. Rows older than '
+                'now - days are pruned. Defaults to settings.AUDIT_EVENT_RETENTION_DAYS.'
+            ),
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Report how many rows WOULD be pruned without deleting anything.',
+        )
+        parser.add_argument(
+            '--batch-size',
+            type=int,
+            default=1000,
+            help='Number of rows to delete per batch (default 1000).',
+        )
+        parser.add_argument(
+            '--archive',
+            type=str,
+            default=None,
+            help=(
+                'Path to a JSON Lines file. Each batch is appended here (one JSON '
+                'object per row) BEFORE it is deleted, so nothing is lost.'
+            ),
+        )
+
+    def handle(self, *args, **options):
+        days = options['days']
+        if days is None:
+            days = getattr(settings, 'AUDIT_EVENT_RETENTION_DAYS', 2190)
+        if days < 0:
+            raise CommandError('--days must be a non-negative integer.')
+
+        batch_size = options['batch_size']
+        if batch_size < 1:
+            raise CommandError('--batch-size must be a positive integer.')
+
+        dry_run = options['dry_run']
+        archive_path = options['archive']
+
+        cutoff = timezone.now() - timedelta(days=days)
+
+        matched_qs = AuditEvent.objects.filter(timestamp__lt=cutoff)
+        matched = matched_qs.count()
+
+        self.stdout.write(f"Retention window: {days} day(s)")
+        self.stdout.write(f"Cutoff (delete rows with timestamp <): {cutoff.isoformat()}")
+        self.stdout.write(f"Matched (older than cutoff): {matched}")
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING(
+                f"Dry run: {matched} row(s) would be pruned; nothing was deleted."
+            ))
+            return
+
+        if matched == 0:
+            self.stdout.write(self.style.SUCCESS("Nothing to prune."))
+            return
+
+        archive_file = None
+        archived = 0
+        deleted = 0
+        try:
+            if archive_path:
+                # Append mode so repeated runs accumulate into one archive file.
+                archive_file = open(archive_path, 'a', encoding='utf-8')
+
+            while True:
+                # Re-filter by cutoff every batch; only ever select rows strictly
+                # older than the cutoff. Order by PK for stable batching.
+                batch = list(
+                    AuditEvent.objects.filter(timestamp__lt=cutoff)
+                    .order_by('pk')[:batch_size]
+                )
+                if not batch:
+                    break
+
+                if archive_file is not None:
+                    for row in batch:
+                        archive_file.write(json.dumps(self._serialize(row)) + '\n')
+                    archive_file.flush()
+                    archived += len(batch)
+
+                batch_ids = [row.pk for row in batch]
+                AuditEvent.objects.filter(pk__in=batch_ids).delete()
+                deleted += len(batch_ids)
+        finally:
+            if archive_file is not None:
+                archive_file.close()
+
+        self.stdout.write(f"Archived: {archived}")
+        self.stdout.write(f"Deleted: {deleted}")
+        if archive_path:
+            self.stdout.write(self.style.SUCCESS(
+                f"Pruned {deleted} audit event(s); archived to {archive_path}."
+            ))
+        else:
+            self.stdout.write(self.style.SUCCESS(f"Pruned {deleted} audit event(s)."))
+
+    @staticmethod
+    def _serialize(row):
+        """Return a JSON-serializable dict for one AuditEvent row."""
+        data = {}
+        for field in _ARCHIVE_FIELDS:
+            value = getattr(row, field)
+            if field == 'timestamp' and value is not None:
+                value = value.isoformat()
+            data[field] = value
+        return data

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -12085,3 +12085,133 @@ class AllergyListTest(TestCase):
         self.assertGreater(allergy_obs.count(), 0, 'No ALLERGY-tagged observation created')
         obs = allergy_obs.first()
         self.assertEqual(obs.value_as_string, 'high')
+
+
+class AuditRetentionTest(TestCase):
+    """prune_audit_events management command — HL7 PHR-S FM TI.2.2.
+
+    Verifies retention-window pruning: old rows deleted, newer rows kept,
+    --dry-run is a no-op, --days overrides the setting, --archive writes JSONL
+    before deleting, and batching handles more rows than the batch size.
+    """
+
+    def _make_event(self, days_ago, **kwargs):
+        from patient_portal.models import AuditEvent
+        ts = timezone.now() - timedelta(days=days_ago)
+        defaults = dict(
+            event_type=AuditEvent.EVENT_VIEW,
+            method='GET',
+            path='/api/v1/patient-records/',
+            status_code=200,
+        )
+        defaults.update(kwargs)
+        return AuditEvent.objects.create(timestamp=ts, **defaults)
+
+    def _run(self, **opts):
+        from django.core.management import call_command
+        out = io.StringIO()
+        call_command('prune_audit_events', stdout=out, **opts)
+        return out.getvalue()
+
+    def test_deletes_older_and_keeps_newer(self):
+        from patient_portal.models import AuditEvent
+        old = self._make_event(days_ago=3000)
+        recent = self._make_event(days_ago=10)
+        self._run(days=2190)
+        self.assertFalse(AuditEvent.objects.filter(pk=old.pk).exists())
+        self.assertTrue(AuditEvent.objects.filter(pk=recent.pk).exists())
+
+    def test_boundary_row_just_inside_window_is_kept(self):
+        from patient_portal.models import AuditEvent
+        # 100 days ago, window 200 days -> not older than cutoff -> kept.
+        row = self._make_event(days_ago=100)
+        self._run(days=200)
+        self.assertTrue(AuditEvent.objects.filter(pk=row.pk).exists())
+
+    def test_dry_run_deletes_nothing(self):
+        from patient_portal.models import AuditEvent
+        old = self._make_event(days_ago=3000)
+        out = self._run(days=2190, dry_run=True)
+        self.assertTrue(AuditEvent.objects.filter(pk=old.pk).exists())
+        self.assertIn('Dry run', out)
+
+    def test_days_override(self):
+        from patient_portal.models import AuditEvent
+        # 400 days old; default 2190 would keep it, but --days 365 prunes it.
+        old = self._make_event(days_ago=400)
+        self._run(days=365)
+        self.assertFalse(AuditEvent.objects.filter(pk=old.pk).exists())
+
+    def test_empty_table_is_noop(self):
+        from patient_portal.models import AuditEvent
+        self.assertEqual(AuditEvent.objects.count(), 0)
+        out = self._run(days=2190)
+        self.assertIn('Nothing to prune', out)
+
+    def test_all_newer_keeps_everything(self):
+        from patient_portal.models import AuditEvent
+        for _ in range(5):
+            self._make_event(days_ago=1)
+        self._run(days=30)
+        self.assertEqual(AuditEvent.objects.count(), 5)
+
+    def test_archive_writes_jsonl_then_deletes(self):
+        from patient_portal.models import AuditEvent
+        e1 = self._make_event(days_ago=3000, user_id='42', user_email='a@example.org',
+                              detail={'note': 'x'})
+        e2 = self._make_event(days_ago=2500, resource_id='rec-1')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive_path = os.path.join(tmpdir, 'audit-archive.jsonl')
+            self._run(days=2190, archive=archive_path)
+            with open(archive_path, encoding='utf-8') as fh:
+                lines = [line for line in fh.read().splitlines() if line]
+        self.assertEqual(len(lines), 2)
+        records = [json.loads(line) for line in lines]
+        ids = {r['id'] for r in records}
+        self.assertEqual(ids, {e1.pk, e2.pk})
+        # timestamp serialized as ISO string
+        for r in records:
+            self.assertIsInstance(r['timestamp'], str)
+            self.assertIn('T', r['timestamp'])
+        # rows actually deleted
+        self.assertFalse(AuditEvent.objects.filter(pk__in=[e1.pk, e2.pk]).exists())
+
+    def test_archive_only_contains_matched_rows(self):
+        from patient_portal.models import AuditEvent
+        old = self._make_event(days_ago=3000)
+        recent = self._make_event(days_ago=5)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive_path = os.path.join(tmpdir, 'a.jsonl')
+            self._run(days=2190, archive=archive_path)
+            with open(archive_path, encoding='utf-8') as fh:
+                records = [json.loads(line) for line in fh.read().splitlines() if line]
+        self.assertEqual({r['id'] for r in records}, {old.pk})
+        self.assertTrue(AuditEvent.objects.filter(pk=recent.pk).exists())
+
+    def test_batching_handles_more_than_batch_size(self):
+        from patient_portal.models import AuditEvent
+        for _ in range(7):
+            self._make_event(days_ago=3000)
+        self._run(days=2190, batch_size=2)
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_batching_with_archive_captures_all_rows(self):
+        from patient_portal.models import AuditEvent
+        created = [self._make_event(days_ago=3000).pk for _ in range(5)]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive_path = os.path.join(tmpdir, 'a.jsonl')
+            self._run(days=2190, batch_size=2, archive=archive_path)
+            with open(archive_path, encoding='utf-8') as fh:
+                records = [json.loads(line) for line in fh.read().splitlines() if line]
+        self.assertEqual({r['id'] for r in records}, set(created))
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_uses_settings_default_when_no_days(self):
+        from django.test import override_settings
+        from patient_portal.models import AuditEvent
+        old = self._make_event(days_ago=400)
+        recent = self._make_event(days_ago=100)
+        with override_settings(AUDIT_EVENT_RETENTION_DAYS=200):
+            self._run()
+        self.assertFalse(AuditEvent.objects.filter(pk=old.pk).exists())
+        self.assertTrue(AuditEvent.objects.filter(pk=recent.pk).exists())


### PR DESCRIPTION
Closes #298

Enforces a retention/archival policy on the `audit_event` table (added in #296), which otherwise grows unbounded at one row per audited request. Implements HL7 PHR-S FM **TI.2.2 (Audit Log Management)**.

## What's added

**Management command** `patient_portal/management/commands/prune_audit_events.py` — deletes `AuditEvent` rows older than a retention window.

Flags:
- `--days N` — retention window for this run (overrides the setting).
- `--dry-run` — reports how many rows WOULD be pruned; deletes nothing.
- `--batch-size N` (default 1000) — deletes in PK-ordered batches so no single long-locking `DELETE`; loops until no rows older than the cutoff remain.
- `--archive <path>` — appends each batch to a JSON Lines file (one object per row, ISO-8601 timestamp) **before** deleting it, so nothing is lost.

Cutoff = `timezone.now() - timedelta(days=window)`; only rows with `timestamp < cutoff` are ever touched. A clear summary (cutoff, matched, archived, deleted) is printed.

**Setting** `AUDIT_EVENT_RETENTION_DAYS` in `ctomop/settings.py` — env-configurable (`AUDIT_EVENT_RETENTION_DAYS`), default **2190 days (~6 years)**, a common healthcare audit-log retention minimum. Resolution order: `--days` > setting.

No schema change / migration required.

## Tests

`AuditRetentionTest` in `patient_portal/tests.py` (11 cases): older-than-cutoff deleted / newer kept, window boundary, `--dry-run` no-op, `--days` override, settings default, empty + all-newer tables, `--archive` JSONL contents + deletion, and batching beyond `--batch-size` (with and without archive). Full backend suite: 915 passing.

## Docs

Also folds in `docs/phrs-fm-traceability.md` (PHR-S FM capability-to-function-ID map; companion to #295/#298) and marks the "FM traceability" cross-cutting item done in `docs/phrs-fm-roadmap.md`.

Suggested scheduled job (Render cron): `python manage.py prune_audit_events --archive /var/audit/audit-archive.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)