### PR TITLE
TI.1.1#09: wire the must_change_password force-change flag (closes #319)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ db.sqlite3.backup
 
 # Generated Synthea export artifacts
 /synthea_bc_*.json
+
+# Large synthea CLI jar (not tracked)
+synthea-with-dependencies.jar

--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -101,6 +101,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'patient_portal.api.middleware.AuditLogMiddleware',
+    'patient_portal.api.middleware.ForcePasswordChangeMiddleware',
     'patient_portal.api.middleware.DeprecationWarningMiddleware',
 ]
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/components/Auth/AuthCallback", () => ({ AuthCallback: () => <div>AUTH
 vi.mock("@/components/Auth/AcceptInvite", () => ({ default: () => <div>ACCEPT_INVITE</div> }));
 vi.mock("@/components/Auth/AcceptPatientInvite", () => ({ default: () => <div>ACCEPT_PATIENT_INVITE</div> }));
 vi.mock("@/components/Auth/ResetPassword", () => ({ default: () => <div>RESET_PASSWORD</div> }));
+vi.mock("@/components/Auth/ChangePassword", () => ({ default: () => <div>CHANGE_PASSWORD</div> }));
 
 const baseAuth = { loading: false, refresh: vi.fn(), logout: vi.fn(), login: vi.fn() };
 
@@ -74,5 +75,37 @@ describe("App role-gated routing", () => {
     mockUseAuth.mockReturnValue({ ...baseAuth, currentUser: { id: 2, is_org_admin: true } });
     renderAt("/org-admin");
     expect(screen.getByText("ORG_ADMIN")).toBeInTheDocument();
+  });
+});
+
+describe("App force-password-change gate (TI.1.1#09)", () => {
+  it("holds a flagged user on the change-password screen instead of their route", () => {
+    mockUseAuth.mockReturnValue({
+      ...baseAuth,
+      currentUser: { id: 1, is_patient: true, person_id: 5, must_change_password: true },
+    });
+    renderAt("/");
+    expect(screen.getByText("CHANGE_PASSWORD")).toBeInTheDocument();
+    expect(screen.queryByText("PATIENT_HOME")).not.toBeInTheDocument();
+  });
+
+  it("gates provider routes too", () => {
+    mockUseAuth.mockReturnValue({
+      ...baseAuth,
+      currentUser: { id: 2, is_org_admin: true, must_change_password: true },
+    });
+    renderAt("/org-admin");
+    expect(screen.getByText("CHANGE_PASSWORD")).toBeInTheDocument();
+    expect(screen.queryByText("ORG_ADMIN")).not.toBeInTheDocument();
+  });
+
+  it("does not gate the public reset-password page", () => {
+    mockUseAuth.mockReturnValue({
+      ...baseAuth,
+      currentUser: { id: 1, is_patient: true, person_id: 5, must_change_password: true },
+    });
+    renderAt("/reset-password");
+    expect(screen.getByText("RESET_PASSWORD")).toBeInTheDocument();
+    expect(screen.queryByText("CHANGE_PASSWORD")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { AuthCallback } from "@/components/Auth/AuthCallback";
 import AcceptInvite from "@/components/Auth/AcceptInvite";
 import AcceptPatientInvite from "@/components/Auth/AcceptPatientInvite";
 import ResetPassword from "@/components/Auth/ResetPassword";
+import ChangePassword from "@/components/Auth/ChangePassword";
 import PatientList from "@/components/Patient/PatientList";
 import PatientDetail from "@/components/Patient/PatientDetail";
 import PatientHome from "@/components/Patient/PatientHome";
@@ -38,6 +39,19 @@ function AppRoutes() {
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
       </div>
     );
+  }
+
+  // Force-change gate (PHR-S FM TI.1.1#09): a signed-in account flagged for a
+  // password change is held on a blocking screen until it sets a new one. The
+  // backend independently refuses every other /api/ request meanwhile, so this
+  // is a UX affordance over a server-enforced rule. Public auth pages (reset
+  // link, invite acceptance) are exempt so those flows can still complete.
+  const forceChangeExemptPaths = ['/reset-password', '/accept-invite', '/accept-patient-invite'];
+  if (
+    currentUser?.must_change_password &&
+    !forceChangeExemptPaths.includes(location.pathname)
+  ) {
+    return <ChangePassword onChanged={refresh} onLogout={logout} />;
   }
 
   const isPatient = !!currentUser?.is_patient;

--- a/frontend/src/components/Auth/ChangePassword.tsx
+++ b/frontend/src/components/Auth/ChangePassword.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import api from '@/api/axios';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const msg = (err as { response?: { data?: { error?: string } } }).response?.data?.error;
+    if (msg) return msg;
+  }
+  return fallback;
+}
+
+interface Props {
+  /** Called after the password is changed so the app can re-fetch the (now
+   *  cleared) force-change flag and resume normal routing. */
+  onChanged: () => void;
+  onLogout: () => void;
+}
+
+/**
+ * Blocking change-password screen shown when the account is flagged
+ * must_change_password (PHR-S FM TI.1.1#09). The backend refuses every other
+ * /api/ request until the password is changed, so this is a hard gate.
+ */
+export default function ChangePassword({ onChanged, onLogout }: Props) {
+  const [current, setCurrent] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (password !== confirm) {
+      setMessage('Passwords do not match.');
+      return;
+    }
+    setMessage('');
+    setSubmitting(true);
+    try {
+      await api.post('/auth/change-password/', { current_password: current, new_password: password });
+      onChanged();
+    } catch (err: unknown) {
+      setMessage(errorMessage(err, 'Could not change your password.'));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-8 max-w-md w-full space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Choose a new password</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Your account requires a password change before you can continue.
+          </p>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="current" className="block text-sm font-medium text-gray-700">Current password</label>
+            <input
+              id="current"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={current}
+              onChange={(e) => setCurrent(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="new-password" className="block text-sm font-medium text-gray-700">New password</label>
+            <input
+              id="new-password"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              placeholder="At least 8 characters"
+            />
+          </div>
+          <div>
+            <label htmlFor="confirm" className="block text-sm font-medium text-gray-700">Confirm new password</label>
+            <input
+              id="confirm"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              placeholder="Re-enter your new password"
+            />
+          </div>
+          {message && (
+            <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-3">{message}</p>
+          )}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+          >
+            {submitting ? 'Saving…' : 'Change password'}
+          </button>
+        </form>
+
+        <button
+          onClick={onLogout}
+          className="w-full py-2 px-4 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50"
+        >
+          Sign out
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -21,6 +21,10 @@ export interface User {
   // true, person_id is the patient's own record and the UI runs in patient mode.
   is_patient?: boolean;
   person_id?: number | null;
+  // Force-change-at-next-login (PHR-S FM TI.1.1#09). When true, the backend
+  // refuses every /api/ request except change-password until the password is
+  // reset, and the SPA shows a blocking change-password screen.
+  must_change_password?: boolean;
 }
 
 export const useAuth = () => {

--- a/patient_portal/admin.py
+++ b/patient_portal/admin.py
@@ -10,11 +10,12 @@ class IdentityAdmin(UserAdmin):
     search_fields = ['email', 'name', 'sub']
     ordering = ['email']
     readonly_fields = ['uid', 'issuer', 'sub', 'created_at']
-    actions = ['grant_premium', 'revoke_premium', 'reset_password']
+    actions = ['grant_premium', 'revoke_premium', 'reset_password', 'require_password_change']
 
     fieldsets = (
         (None,          {'fields': ('uid', 'issuer', 'sub', 'email', 'name')}),
         ('Access',      {'fields': ('is_active', 'is_staff', 'is_superuser', 'is_premium')}),
+        ('Security',    {'fields': ('must_change_password',)}),
         ('Timestamps',  {'fields': ('created_at',)}),
     )
     add_fieldsets = ()
@@ -46,6 +47,14 @@ class IdentityAdmin(UserAdmin):
         self.message_user(request, f'Sent {sent} password-reset email(s).')
         if failed:
             self.message_user(request, f'Could not email: {", ".join(failed)}', level=messages.WARNING)
+
+    @admin.action(description='Require password change at next login')
+    def require_password_change(self, request, queryset):
+        """Force a password change (PHR-S FM TI.1.1#09): set the force-change flag so
+        the account is refused every /api/ request except change-password until it sets
+        a new password. Enforced by ForcePasswordChangeMiddleware."""
+        updated = queryset.update(must_change_password=True)
+        self.message_user(request, f'Flagged {updated} account(s) to change password at next login.')
 
 @admin.register(PatientMessage)
 class PatientMessageAdmin(admin.ModelAdmin):

--- a/patient_portal/api/middleware.py
+++ b/patient_portal/api/middleware.py
@@ -4,6 +4,8 @@ import logging
 import time
 from email.utils import parsedate_to_datetime
 
+from django.http import JsonResponse
+
 logger = logging.getLogger('audit')
 
 _SUNSET_DATE = 'Tue, 01 Sep 2026 00:00:00 GMT'
@@ -201,3 +203,55 @@ class AuditLogMiddleware:
             ip_address=(entry['ip_address'] or '')[:64] or None,
             duration_ms=entry['duration_ms'],
         )
+
+
+# Endpoints that stay reachable while a force-change is pending, so the client
+# can read the flag (/user/), clear it (change-password), or leave (logout/login).
+# Matched as substrings after /api/ so both /api/ and /api/v1/ forms are covered.
+_FORCE_CHANGE_EXEMPT = (
+    '/auth/change-password',
+    '/auth/logout',
+    '/auth/login',
+    '/auth/reset-password',
+    '/user/',
+)
+
+
+class ForcePasswordChangeMiddleware:
+    """
+    Enforce Identity.must_change_password (HL7 PHR-S FM TI.1.1#09).
+
+    When a session-authenticated account is flagged for a forced password change
+    (e.g. after an administrative reset), every /api/ request is refused with 403
+    and a machine-readable ``code: password_change_required`` until the password
+    is changed — except the handful of endpoints the client needs to resolve the
+    state (read the flag, change the password, or sign out).
+
+    Only session-authenticated identities are gated. Token/OAuth clients
+    authenticate inside the view (request.user is anonymous here) and carry an
+    unusable local password, so the flag never applies to them.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if self._is_blocked(request):
+            return JsonResponse(
+                {'detail': 'Password change required before continuing.',
+                 'code': 'password_change_required'},
+                status=403,
+            )
+        return self.get_response(request)
+
+    @staticmethod
+    def _is_blocked(request):
+        path = request.path
+        if not path.startswith('/api/'):
+            return False
+        user = getattr(request, 'user', None)
+        if not (user and user.is_authenticated):
+            return False
+        if not getattr(user, 'must_change_password', False):
+            return False
+        return not any(frag in path for frag in _FORCE_CHANGE_EXEMPT)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -12778,6 +12778,47 @@ class AuthControlsTest(TestCase):
         self.identity.refresh_from_db()
         self.assertFalse(self.identity.must_change_password)
 
+    # --- force-change enforcement (TI.1.1#09) — via a real session so the
+    #     ForcePasswordChangeMiddleware sees the resolved request.user. ---
+
+    def test_force_change_blocks_api_and_change_clears_it(self):
+        from patient_portal.services import set_new_password
+        set_new_password(self.identity, 'Tmp-reset-9021', must_change=True)
+        # Login itself is allowed; the block applies to subsequent /api/ calls.
+        self.assertEqual(self._login('Tmp-reset-9021').status_code, status.HTTP_200_OK)
+        blocked = self.client.get('/api/v1/patient-records/')
+        self.assertEqual(blocked.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(blocked.json().get('code'), 'password_change_required')
+        # Exempt endpoints stay reachable so the client can resolve the state.
+        self.assertEqual(self.client.get('/api/v1/user/').status_code, status.HTTP_200_OK)
+        # Changing the password clears the flag and unblocks the API.
+        changed = self.client.post('/api/v1/auth/change-password/',
+                                   {'current_password': 'Tmp-reset-9021', 'new_password': 'Cq2-badger-mint'},
+                                   format='json')
+        self.assertEqual(changed.status_code, status.HTTP_200_OK, changed.data)
+        self.identity.refresh_from_db()
+        self.assertFalse(self.identity.must_change_password)
+        self.assertNotEqual(self.client.get('/api/v1/patient-records/').status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unflagged_session_is_not_blocked(self):
+        self.assertEqual(self._login(self.password).status_code, status.HTTP_200_OK)
+        resp = self.client.get('/api/v1/patient-records/')
+        self.assertNotEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_action_sets_force_change_flag(self):
+        from django.contrib.admin.sites import site
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.test import RequestFactory
+        from patient_portal.admin import IdentityAdmin
+        request = RequestFactory().post('/admin/')
+        request.user = self.identity
+        setattr(request, 'session', 'session')
+        setattr(request, '_messages', FallbackStorage(request))
+        IdentityAdmin(Identity, site).require_password_change(
+            request, Identity.objects.filter(pk=self.identity.pk))
+        self.identity.refresh_from_db()
+        self.assertTrue(self.identity.must_change_password)
+
 
 @override_settings(
     EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',


### PR DESCRIPTION
Closes #319 — the last residual from the 2026-07-27 conformance re-verification (claim §7.6).

## Problem
`Identity.must_change_password` existed and was exposed read-only via `/api/v1/user/`, but was **never set** and **never enforced** — a completely inert flag.

## Change (set → enforce → clear)
- **Set** — new `IdentityAdmin` action *"Require password change at next login"* (`must_change_password=True`); the flag is also now visible in an admin **Security** fieldset.
- **Enforce** — `ForcePasswordChangeMiddleware`: a session-authenticated flagged account is refused every `/api/` request with `403 {code: "password_change_required"}`, except the endpoints needed to resolve the state (`change-password`, `user`, `logout`, `login`, `reset-password`). Registered **after** `AuditLogMiddleware` so the blocked request is still audited (TI.2).
- **Clear** — `change-password` already clears the flag via `set_new_password(must_change=False)`.
- **Frontend** — the `User` type carries `must_change_password`; a blocking `ChangePassword` screen gates **both** patient and provider routes until the password is changed, after which `refresh()` re-reads the cleared flag and routing resumes. Public auth pages (reset link, invite acceptance) are exempt.

## Scope / threat model
Only **session-authenticated local accounts** are gated — the only accounts the flag can ever apply to. Token/OAuth clients authenticate inside the view (anonymous at middleware time) and carry an unusable local password, so they are never affected. Enforcement is scoped to `/api/` (not `/admin/` or `/o/`).

## No migration
The field predates this work (migration `0010`); only behavior + admin/UI wiring changed.

## Tests
- **Backend** `AuthControlsTest`: blocked-until-changed over a **real session** (so the middleware sees `request.user`), exempt endpoints stay reachable, unflagged sessions unaffected, admin action sets the flag.
- **Frontend** `App.test.tsx`: gate holds flagged users off their route, gates provider routes, exempts the public reset page.
- Suites: **backend 1013**, **frontend 119** — both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)