### PR TITLE
feat: loader writes VocabularyRelease + loads STCM

### DIFF
--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -9,11 +9,16 @@ csv.field_size_limit(sys.maxsize)
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 
+import logging
+
 from omop_core.models import (
     Vocabulary, Domain, ConceptClass, Concept,
     Relationship, ConceptRelationship, ConceptAncestor, CdmSource,
     VocabularyVersionHistory, record_vocabulary_version_history,
+    VocabularyRelease,
 )
+
+logger = logging.getLogger(__name__)
 
 VOCAB_SCOPE = frozenset({
     'HemOnc', 'RxNorm', 'RxNorm Extension', 'ATC', 'LOINC', 'UCUM',
@@ -145,10 +150,19 @@ class Command(BaseCommand):
             self._log(f'Loading from gs://{bucket_name}/ (download-one-process-delete)')
 
         t0 = time.monotonic()
+        self._build_start = time.time()  # wall-clock for VocabularyRelease
 
         self._base = base
 
         self._direct = replace and not dry_run
+
+        if replace:
+            logger.warning(
+                '--replace uses TRUNCATE CASCADE and will destroy clinical '
+                'data in tables that FK to concept (drug_exposure, measurement, '
+                'condition_occurrence, etc.). The default upsert path (no flag) '
+                'is safe for databases with clinical data.'
+            )
 
         if self._direct:
             self._clear()
@@ -163,11 +177,13 @@ class Command(BaseCommand):
             'concept_ancestor':     self._load_concept_ancestors(dry_run),
             'concept_synonym':      self._load_concept_synonym(dry_run),
             'drug_strength':        self._load_drug_strength(dry_run),
+            'source_to_concept_map': self._load_source_to_concept_map(dry_run),
         }
         if not dry_run:
             self._seed_concept_zero()
             self._sync_cdm_source_metadata()
             self._record_version_history(replace)
+            self._publish_release(counts)
         elapsed = time.monotonic() - t0
         verb = 'would load' if dry_run else 'loaded'
         total = sum(counts.values())
@@ -736,3 +752,105 @@ class Command(BaseCommand):
             )
             recorded += 1
         self._log(f'  vocabulary_version_history: recorded {recorded} {action} row(s)')
+
+    def _load_source_to_concept_map(self, dry_run):
+        self._log('Loading SOURCE_TO_CONCEPT_MAP.csv...')
+        t = time.monotonic()
+        try:
+            f = self._open('SOURCE_TO_CONCEPT_MAP.csv')
+        except CommandError:
+            self._log('  SOURCE_TO_CONCEPT_MAP.csv not found, skipping.')
+            return 0
+        loaded_ids = set(Concept.objects.values_list('concept_id', flat=True))
+        count = scanned = 0
+        rows = []
+        cols_out = (
+            'source_code', 'source_concept_id', 'source_vocabulary_id',
+            'source_code_description', 'target_concept_id', 'target_vocabulary_id',
+            'valid_start_date', 'valid_end_date', 'invalid_reason',
+        )
+        with f:
+            reader = csv.reader(f, delimiter='\t')
+            idx = _header_index(next(reader))
+            i_src_code = idx['source_code']
+            i_src_cid = idx['source_concept_id']
+            i_src_vid = idx['source_vocabulary_id']
+            i_src_desc = idx['source_code_description']
+            i_tgt_cid = idx['target_concept_id']
+            i_tgt_vid = idx['target_vocabulary_id']
+            i_start = idx['valid_start_date']
+            i_end = idx['valid_end_date']
+            i_inv = idx['invalid_reason']
+            for row in reader:
+                scanned += 1
+                if scanned % PROGRESS_EVERY == 0:
+                    self._log(f'  stcm: scanned {scanned:,}, {count:,} matched ({time.monotonic() - t:.0f}s)...')
+                try:
+                    src_cid = int(row[i_src_cid])
+                    tgt_cid = int(row[i_tgt_cid])
+                except (ValueError, IndexError):
+                    continue
+                if src_cid not in loaded_ids or tgt_cid not in loaded_ids:
+                    continue
+                count += 1
+                if not dry_run:
+                    rows.append((
+                        row[i_src_code][:50],
+                        src_cid,
+                        row[i_src_vid][:20],
+                        (row[i_src_desc] or None) if i_src_desc < len(row) else None,
+                        tgt_cid,
+                        row[i_tgt_vid][:20],
+                        _parse_date(row[i_start]),
+                        _parse_date(row[i_end]),
+                        row[i_inv][:1] if row[i_inv] else None,
+                    ))
+                    if len(rows) >= BATCH:
+                        _copy_rows('source_to_concept_map', cols_out, rows, self._log, direct=self._direct)
+                        rows = []
+        if not dry_run:
+            _copy_rows('source_to_concept_map', cols_out, rows, self._log, direct=self._direct)
+        self._cleanup('SOURCE_TO_CONCEPT_MAP.csv')
+        self._log(f'  stcm: {count:,} loaded from {scanned:,} rows in {time.monotonic() - t:.0f}s')
+        return count
+
+    def _publish_release(self, counts):
+        """Create a published VocabularyRelease row capturing this load."""
+        from datetime import datetime as dt, timezone as _tz
+        from django.utils import timezone
+
+        vocab_versions = dict(
+            Vocabulary.objects.order_by('vocabulary_id')
+            .values_list('vocabulary_id', 'vocabulary_version')
+        )
+        checksums = {}
+        for table_name in counts:
+            try:
+                with connection.cursor() as cur:
+                    cur.execute(
+                        f'SELECT COUNT(*), MIN(ctid::text), MAX(ctid::text) '
+                        f'FROM {table_name}'
+                    )
+                    row = cur.fetchone()
+                    checksums[table_name] = {
+                        'count': row[0],
+                        'min_ctid': row[1],
+                        'max_ctid': row[2],
+                    }
+            except Exception:
+                checksums[table_name] = {'count': counts[table_name]}
+
+        now = timezone.now()
+        build_ts = dt.fromtimestamp(self._build_start, tz=_tz.utc)
+        release = VocabularyRelease.objects.create(
+            schema_version='5.4',
+            scope=sorted(VOCAB_SCOPE),
+            build_timestamp=build_ts,
+            athena_version=getattr(self, '_cdm_vocab_version', None),
+            vocab_versions=vocab_versions,
+            row_counts=counts,
+            checksums=checksums,
+            status='published',
+            published_at=now,
+        )
+        self._log(f'  vocabulary_release: published release pk={release.pk}')

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -1777,3 +1777,117 @@ class VocabularyReleaseServiceTest(TestCase):
         )
         self.assertNotEqual(get_release_etag(vr1), get_release_etag(vr2))
 
+
+# ---------------------------------------------------------------------------
+# TEST-08: STCM loader + VocabularyRelease publication from loader
+# ---------------------------------------------------------------------------
+
+class LoadSTCMTest(_OmopBase):
+    """Test _load_source_to_concept_map in the Athena loader."""
+
+    PERSON_ID = 90290
+
+    def _run_loader(self, method_name, filename, header, rows):
+        import os
+        import tempfile
+        from io import StringIO
+        from omop_core.management.commands.load_athena_vocabularies import Command
+        d = tempfile.mkdtemp()
+        with open(os.path.join(d, filename), 'w', encoding='utf-8', newline='') as f:
+            f.write('\t'.join(header) + '\n')
+            for r in rows:
+                f.write('\t'.join(str(x) for x in r) + '\n')
+        cmd = Command(stdout=StringIO())
+        cmd._base = d
+        cmd._gcs_bucket = None
+        cmd._direct = False
+        return getattr(cmd, method_name)(False)
+
+    def test_stcm_loads_and_filters_unloaded_refs(self):
+        from omop_core.models import SourceToConceptMap
+        src = _concept(960001, 'Source concept', self.dom_meas, self.vocab, self.cc, code='SRC1')
+        tgt = _concept(960002, 'Target concept', self.dom_meas, self.vocab, self.cc, code='TGT1')
+        header = [
+            'source_code', 'source_concept_id', 'source_vocabulary_id',
+            'source_code_description', 'target_concept_id', 'target_vocabulary_id',
+            'valid_start_date', 'valid_end_date', 'invalid_reason',
+        ]
+        count = self._run_loader(
+            '_load_source_to_concept_map', 'SOURCE_TO_CONCEPT_MAP.csv', header,
+            [
+                ('ABC', 960001, 'OMOP_TEST', 'desc', 960002, 'OMOP_TEST', '19700101', '20991231', ''),
+                ('DEF', 999998, 'OMOP_TEST', '', 960002, 'OMOP_TEST', '19700101', '20991231', ''),  # src not loaded
+                ('GHI', 960001, 'OMOP_TEST', '', 999997, 'OMOP_TEST', '19700101', '20991231', ''),  # tgt not loaded
+            ],
+        )
+        self.assertEqual(count, 1)
+        self.assertEqual(SourceToConceptMap.objects.count(), 1)
+        row = SourceToConceptMap.objects.first()
+        self.assertEqual(row.source_code, 'ABC')
+        self.assertEqual(row.source_concept_id, 960001)
+        self.assertEqual(row.target_concept_id, 960002)
+
+    def test_stcm_dry_run_returns_count_without_writing(self):
+        import os
+        import tempfile
+        from io import StringIO
+        from omop_core.models import SourceToConceptMap
+        from omop_core.management.commands.load_athena_vocabularies import Command
+        _concept(960001, 'Source concept', self.dom_meas, self.vocab, self.cc, code='SRC1')
+        _concept(960002, 'Target concept', self.dom_meas, self.vocab, self.cc, code='TGT1')
+        header = [
+            'source_code', 'source_concept_id', 'source_vocabulary_id',
+            'source_code_description', 'target_concept_id', 'target_vocabulary_id',
+            'valid_start_date', 'valid_end_date', 'invalid_reason',
+        ]
+        d = tempfile.mkdtemp()
+        with open(os.path.join(d, 'SOURCE_TO_CONCEPT_MAP.csv'), 'w', encoding='utf-8', newline='') as f:
+            f.write('\t'.join(header) + '\n')
+            f.write('\t'.join(str(x) for x in ('ABC', 960001, 'OMOP_TEST', '', 960002, 'OMOP_TEST', '19700101', '20991231', '')) + '\n')
+        cmd = Command(stdout=StringIO())
+        cmd._base = d
+        cmd._gcs_bucket = None
+        cmd._direct = False
+        count = cmd._load_source_to_concept_map(True)  # dry_run=True
+        self.assertEqual(count, 1)
+        self.assertEqual(SourceToConceptMap.objects.count(), 0)
+
+    def test_stcm_missing_file_returns_zero(self):
+        import tempfile
+        from io import StringIO
+        from omop_core.management.commands.load_athena_vocabularies import Command
+        d = tempfile.mkdtemp()  # empty dir, no SOURCE_TO_CONCEPT_MAP.csv
+        cmd = Command(stdout=StringIO())
+        cmd._base = d
+        cmd._gcs_bucket = None
+        cmd._direct = False
+        count = cmd._load_source_to_concept_map(False)
+        self.assertEqual(count, 0)
+
+
+class PublishReleaseTest(_OmopBase):
+    """Test _publish_release creates a VocabularyRelease row."""
+
+    PERSON_ID = 90291
+
+    def test_publish_release_creates_row(self):
+        import time as _time
+        from io import StringIO
+        from omop_core.management.commands.load_athena_vocabularies import Command
+        from omop_core.models import VocabularyRelease
+
+        cmd = Command(stdout=StringIO())
+        cmd._build_start = _time.time()
+        cmd._cdm_vocab_version = 'v5.0 2024-07-01'
+        counts = {'concept': 100, 'vocabulary': 5}
+        cmd._publish_release(counts)
+
+        self.assertEqual(VocabularyRelease.objects.count(), 1)
+        release = VocabularyRelease.objects.first()
+        self.assertEqual(release.status, 'published')
+        self.assertIsNotNone(release.published_at)
+        self.assertEqual(release.athena_version, 'v5.0 2024-07-01')
+        self.assertEqual(release.row_counts, {'concept': 100, 'vocabulary': 5})
+        self.assertIn('concept', release.checksums)
+        self.assertIn('vocabulary', release.checksums)
+


### PR DESCRIPTION
## Summary
- Adds `_load_source_to_concept_map()` to the Athena vocabulary loader — follows the same FK-filter + batch COPY pattern as `concept_synonym`
- Adds `_publish_release()` — writes a `VocabularyRelease` row (status=published) after every non-dry-run load, capturing scope, vocab versions, row counts, and lightweight checksums
- Adds deprecation warning when `--replace` is used (TRUNCATE CASCADE destroys clinical data)
- 4 new tests: STCM load with FK filtering, STCM dry-run, STCM missing file graceful skip, release publication

## Test plan
- [x] 4 new tests pass locally
- [x] Full backend suite (1028 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)