### PR TITLE
fix(api): don't 500 patient-record endpoints for a userless (OAuth) token

### DIFF
--- a/omop_core/authorization.py
+++ b/omop_core/authorization.py
@@ -117,6 +117,11 @@ def get_actor_role(actor_identity, target_person_id: int) -> str | None:
     """
     from patient_portal.models import PatientUser
 
+    # No actor (e.g. a userless OAuth client_credentials token) has no role —
+    # fail closed instead of dereferencing None below.
+    if actor_identity is None:
+        return None
+
     try:
         if actor_identity.patient_user.person_id == target_person_id:
             return 'self'

--- a/omop_core/authorization.py
+++ b/omop_core/authorization.py
@@ -20,6 +20,12 @@ def can_access_patient(actor_identity, target_person_id: int) -> bool:
     """Check if actor has access to target patient's data."""
     from patient_portal.models import PatientUser
 
+    # No actor (e.g. an OAuth client_credentials token, whose AccessToken has no
+    # resource owner) has no per-patient access — fail closed instead of
+    # dereferencing None below.
+    if actor_identity is None:
+        return False
+
     if getattr(actor_identity, 'is_superuser', False):
         return True
 
@@ -65,6 +71,10 @@ def can_write_patient(actor_identity, target_person_id: int) -> bool:
     Self-access and personal representatives can always write their own data.
     """
     from patient_portal.models import PatientUser
+
+    # No actor (e.g. a userless OAuth client_credentials token) may write.
+    if actor_identity is None:
+        return False
 
     if getattr(actor_identity, 'is_superuser', False):
         return True

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -455,7 +455,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -492,7 +492,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient, can_write_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -582,7 +582,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -620,7 +620,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -1454,7 +1454,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                             )
 
                     # Block analysts from updating existing patients via FHIR upload.
-                    if not person_is_new and not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+                    if not person_is_new and not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
                         request_org = get_request_org(request)
                         same_org_upload = (
                             request_org is not None

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -13848,3 +13848,67 @@ class VocabReleaseAPITest(_SmartBase):
         resp = self.read_client.get('/api/v1/concepts/search/?q=test')
         self.assertEqual(resp.status_code, 200)
         self.assertIn('ETag', resp)
+
+
+class UserlessOAuthTokenDetailTest(TestCase):
+    """An OAuth2 client_credentials token has no resource owner
+    (AccessToken.user is None), so request.user is None on the patient-record
+    detail/write handlers. They must fail *closed* (per-patient denial -> 404),
+    never 500. Regression for healthkey-ai/promop#330.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from oauth2_provider.models import Application, AccessToken
+        from django.utils import timezone as tz
+        import datetime as _dt
+        from omop_core.models import Organization
+
+        # Owner is a superuser on purpose: the crash is driven by the userless
+        # AccessToken, NOT by Application.user, so a superuser owner must not
+        # mask it.
+        owner = Identity.objects.create_superuser(
+            email='userless_owner@test.com', password='pw',
+        )
+        cls.app = Application.objects.create(
+            name='Userless Service',
+            client_id='userless-client-id',
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            user=owner,
+        )
+        # No ApplicationOrganization -> get_request_org() is None -> execution
+        # reaches the can_access_patient / can_write_patient branch with a None
+        # actor (previously an AttributeError -> 500).
+        cls.read_token = AccessToken.objects.create(
+            user=None, application=cls.app, token='userless-read-tok',
+            expires=tz.now() + _dt.timedelta(hours=1), scope='patient/*.read',
+        )
+        cls.write_token = AccessToken.objects.create(
+            user=None, application=cls.app, token='userless-write-tok',
+            expires=tz.now() + _dt.timedelta(hours=1),
+            scope='patient/*.read patient/*.write',
+        )
+        org = Organization.objects.create(name='Userless Org', slug='userless-org')
+        cls.person = Person.objects.create(person_id=41001)
+        PatientRecord.objects.create(person=cls.person, organization=org)
+
+    def _client(self, token_str):
+        c = APIClient()
+        c.credentials(HTTP_AUTHORIZATION=f'Bearer {token_str}')
+        return c
+
+    def test_userless_token_read_detail_404_not_500(self):
+        resp = self._client(self.read_token.token).get(
+            f'/api/patient-info/{self.person.person_id}/')
+        self.assertEqual(
+            resp.status_code, status.HTTP_404_NOT_FOUND,
+            f'read detail must fail closed (404), got {resp.status_code}')
+
+    def test_userless_token_write_404_not_500(self):
+        resp = self._client(self.write_token.token).patch(
+            f'/api/patient-info/{self.person.person_id}/',
+            {'disease': 'x'}, format='json')
+        self.assertEqual(
+            resp.status_code, status.HTTP_404_NOT_FOUND,
+            f'write must fail closed (404), got {resp.status_code}')

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -13905,6 +13905,15 @@ class UserlessOAuthTokenDetailTest(TestCase):
             resp.status_code, status.HTTP_404_NOT_FOUND,
             f'read detail must fail closed (404), got {resp.status_code}')
 
+    def test_userless_token_read_detail_v1_404_not_500(self):
+        # The v1 path (what external consumers actually hit) routes to the same
+        # viewset and must fail closed identically.
+        resp = self._client(self.read_token.token).get(
+            f'/api/v1/patient-records/{self.person.person_id}/')
+        self.assertEqual(
+            resp.status_code, status.HTTP_404_NOT_FOUND,
+            f'v1 read detail must fail closed (404), got {resp.status_code}')
+
     def test_userless_token_write_404_not_500(self):
         resp = self._client(self.write_token.token).patch(
             f'/api/patient-info/{self.person.person_id}/',
@@ -13912,3 +13921,14 @@ class UserlessOAuthTokenDetailTest(TestCase):
         self.assertEqual(
             resp.status_code, status.HTTP_404_NOT_FOUND,
             f'write must fail closed (404), got {resp.status_code}')
+
+    def test_authorization_helpers_none_actor_fail_closed(self):
+        # The three authorization helpers must all fail closed for a None actor
+        # rather than dereferencing it.
+        from omop_core.authorization import (
+            can_access_patient, can_write_patient, get_actor_role,
+        )
+        pid = self.person.person_id
+        self.assertFalse(can_access_patient(None, pid))
+        self.assertFalse(can_write_patient(None, pid))
+        self.assertIsNone(get_actor_role(None, pid))


### PR DESCRIPTION
Fixes the crash half of #330.

## Problem
An OAuth2 `client_credentials` access token has **no resource owner** — `AccessToken.user is None` — so DRF sets `request.user = None`. The patient detail/write handlers then 500:
1. First at `not request.user.is_superuser` (`retrieve`, `partial_update`, `provenance`, `revisions`, `upload_fhir`).
2. And even after that deref is guarded, again inside `can_access_patient` / `can_write_patient`, whose `actor_identity.patient_user` deref raises `AttributeError` — **not** the caught `PatientUser.DoesNotExist`.

This is the auth mode EXACT's service client uses (EXACT #237), so `/api/v1/patient-records/{id}/` currently 500s before returning anything.

**Empirically confirmed** (owner-superuser client): `application.user = admin (superuser)` but `AccessToken.user = None` → `request.user = None` → `AttributeError`. Owning the app with a superuser does **not** help — the crash is driven by the (userless) token, not `Application.user`.

## Fix — fail closed, not 500
- `views.py`: use the None-safe `getattr(request.user, 'is_superuser', False)` form already used elsewhere in this file, in all 5 sites.
- `omop_core/authorization.py`: `can_access_patient` / `can_write_patient` return `False` for a `None` actor before dereferencing it.

A userless token now degrades to the normal per-patient denial (**404**) instead of a 500. Behaviour is unchanged for any real (non-None) user (`Identity` always has `is_superuser`/`is_staff`).

> Note: this makes the endpoints robust; it does **not** by itself grant an OAuth service client patient access (it still 404s unless org-linked). Granting a trusted OAuth service full visibility is a separate decision — see #330.

## Review
Two independent reviews (fresh-context agent + codex). Both initially flagged that guarding only the `is_superuser` deref was insufficient (the 500 relocates into `can_access_patient`) — this PR fixes **both** layers. No privilege-escalation path; behaviour-preserving for real users.

## Recommended test coverage (not yet added — needs CI DB)
- Userless `client_credentials` token → **404** (not 500) on `retrieve` / `provenance` / `revisions` / `PATCH` / `upload_fhir` (existing patient).

Refs #330.