### PR TITLE
fix(api): trusted service token gets full access on patient-record detail reads

### DIFF
--- a/omop_core/authorization.py
+++ b/omop_core/authorization.py
@@ -117,6 +117,11 @@ def get_actor_role(actor_identity, target_person_id: int) -> str | None:
     """
     from patient_portal.models import PatientUser
 
+    # No actor (e.g. a userless OAuth client_credentials token) has no role —
+    # fail closed instead of dereferencing None below.
+    if actor_identity is None:
+        return None
+
     try:
         if actor_identity.patient_user.person_id == target_person_id:
             return 'self'

--- a/omop_core/authorization.py
+++ b/omop_core/authorization.py
@@ -20,6 +20,12 @@ def can_access_patient(actor_identity, target_person_id: int) -> bool:
     """Check if actor has access to target patient's data."""
     from patient_portal.models import PatientUser
 
+    # No actor (e.g. an OAuth client_credentials token, whose AccessToken has no
+    # resource owner) has no per-patient access — fail closed instead of
+    # dereferencing None below.
+    if actor_identity is None:
+        return False
+
     if getattr(actor_identity, 'is_superuser', False):
         return True
 
@@ -65,6 +71,10 @@ def can_write_patient(actor_identity, target_person_id: int) -> bool:
     Self-access and personal representatives can always write their own data.
     """
     from patient_portal.models import PatientUser
+
+    # No actor (e.g. a userless OAuth client_credentials token) may write.
+    if actor_identity is None:
+        return False
 
     if getattr(actor_identity, 'is_superuser', False):
         return True

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -455,7 +455,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -492,7 +492,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient, can_write_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -582,7 +582,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -620,7 +620,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if org is not None:
             if patient_info.organization != org:
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
             from omop_core.authorization import can_access_patient
             if not can_access_patient(request.user, person.person_id):
                 return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
@@ -1454,7 +1454,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                             )
 
                     # Block analysts from updating existing patients via FHIR upload.
-                    if not person_is_new and not request.user.is_superuser and not getattr(request.user, 'is_staff', False):
+                    if not person_is_new and not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
                         request_org = get_request_org(request)
                         same_org_upload = (
                             request_org is not None

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -451,14 +451,17 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             return Response({'error': 'Patient information not found'}, status=status.HTTP_404_NOT_FOUND)
 
         # AUTH-04: enforce per-patient row-level access
-        org = get_request_org(request)
-        if org is not None:
-            if patient_info.organization != org:
-                return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
-            from omop_core.authorization import can_access_patient
-            if not can_access_patient(request.user, person.person_id):
-                return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
+        # Trusted service tokens (HMAC) get full access, consistent with the
+        # list endpoint's get_queryset. See healthkey-ai/promop#330.
+        if not is_service_token(request):
+            org = get_request_org(request)
+            if org is not None:
+                if patient_info.organization != org:
+                    return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
+            elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
+                from omop_core.authorization import can_access_patient
+                if not can_access_patient(request.user, person.person_id):
+                    return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
 
         # Get the Identity associated with this person (not the logged-in user)
         from patient_portal.models import PatientUser
@@ -578,14 +581,17 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         except PatientRecord.DoesNotExist:
             return Response({'error': 'Patient information not found'}, status=status.HTTP_404_NOT_FOUND)
 
-        org = get_request_org(request)
-        if org is not None:
-            if patient_info.organization != org:
-                return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
-            from omop_core.authorization import can_access_patient
-            if not can_access_patient(request.user, person.person_id):
-                return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
+        # Trusted service tokens (HMAC) get full access, consistent with the
+        # list endpoint's get_queryset. See healthkey-ai/promop#330.
+        if not is_service_token(request):
+            org = get_request_org(request)
+            if org is not None:
+                if patient_info.organization != org:
+                    return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
+            elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
+                from omop_core.authorization import can_access_patient
+                if not can_access_patient(request.user, person.person_id):
+                    return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
 
         from django.db.models import Q
         # Build a single query for all provenance records across PatientRecord + OMOP tables
@@ -616,14 +622,17 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         except PatientRecord.DoesNotExist:
             return Response({'error': 'Patient information not found'}, status=status.HTTP_404_NOT_FOUND)
 
-        org = get_request_org(request)
-        if org is not None:
-            if patient_info.organization != org:
-                return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
-        elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
-            from omop_core.authorization import can_access_patient
-            if not can_access_patient(request.user, person.person_id):
-                return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
+        # Trusted service tokens (HMAC) get full access, consistent with the
+        # list endpoint's get_queryset. See healthkey-ai/promop#330.
+        if not is_service_token(request):
+            org = get_request_org(request)
+            if org is not None:
+                if patient_info.organization != org:
+                    return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
+            elif not getattr(request.user, 'is_superuser', False) and not getattr(request.user, 'is_staff', False):
+                from omop_core.authorization import can_access_patient
+                if not can_access_patient(request.user, person.person_id):
+                    return Response({'error': 'Patient not found'}, status=status.HTTP_404_NOT_FOUND)
 
         revisions = RecordRevision.objects.filter(
             patient_record=patient_info,

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -9839,6 +9839,23 @@ class ServiceTokenOmopAccessTest(TestCase):
         self.assertIn(self.person_a.person_id, returned_pids)
         self.assertIn(self.person_b.person_id, returned_pids)
 
+    def test_service_token_patient_record_detail_reads_cross_org(self):
+        """GET /api/patient-info/{id}/ (and /provenance/, /revisions/) is
+        readable by the service token for any org — detail now honors the
+        service token, consistent with the list endpoint (#330/#332)."""
+        for person in (self.person_a, self.person_b):
+            resp = self.client.get(f'/api/patient-info/{person.person_id}/')
+            self.assertEqual(
+                resp.status_code, status.HTTP_200_OK,
+                f'retrieve {person.person_id}: got {resp.status_code}')
+            self.assertIn('patient_info', resp.data)
+        for suffix in ('provenance', 'revisions'):
+            resp = self.client.get(
+                f'/api/patient-info/{self.person_a.person_id}/{suffix}/')
+            self.assertEqual(
+                resp.status_code, status.HTTP_200_OK,
+                f'{suffix}: got {resp.status_code}')
+
 
 class MeEndpointGuardTest(TestCase):
     """Tests for the /api/patient-info/me/ auto-provisioning guard (PR #190)."""

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -9856,6 +9856,25 @@ class ServiceTokenOmopAccessTest(TestCase):
                 resp.status_code, status.HTTP_200_OK,
                 f'{suffix}: got {resp.status_code}')
 
+    def test_service_token_end_to_end_bearer_hmac_grants_cross_org_detail(self):
+        """The full ServiceTokenAuthentication path (real `Bearer <secret>`
+        header → HMAC compare), not just the injected sentinel, grants cross-org
+        detail read. The grant's entire security rests on this HMAC check, so a
+        wrong secret must NOT be treated as the service token."""
+        with self.settings(SERVICE_AUTH_TOKEN='test-service-secret'):
+            good = APIClient()
+            good.credentials(HTTP_AUTHORIZATION='Bearer test-service-secret')
+            resp = good.get(f'/api/patient-info/{self.person_b.person_id}/')
+            self.assertEqual(resp.status_code, status.HTTP_200_OK)
+            self.assertIn('patient_info', resp.data)
+
+            bad = APIClient()
+            bad.credentials(HTTP_AUTHORIZATION='Bearer wrong-secret')
+            resp = bad.get(f'/api/patient-info/{self.person_b.person_id}/')
+            self.assertNotEqual(
+                resp.status_code, status.HTTP_200_OK,
+                'a wrong secret must not authenticate as the service token')
+
 
 class MeEndpointGuardTest(TestCase):
     """Tests for the /api/patient-info/me/ auto-provisioning guard (PR #190)."""

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -13848,3 +13848,67 @@ class VocabReleaseAPITest(_SmartBase):
         resp = self.read_client.get('/api/v1/concepts/search/?q=test')
         self.assertEqual(resp.status_code, 200)
         self.assertIn('ETag', resp)
+
+
+class UserlessOAuthTokenDetailTest(TestCase):
+    """An OAuth2 client_credentials token has no resource owner
+    (AccessToken.user is None), so request.user is None on the patient-record
+    detail/write handlers. They must fail *closed* (per-patient denial -> 404),
+    never 500. Regression for healthkey-ai/promop#330.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from oauth2_provider.models import Application, AccessToken
+        from django.utils import timezone as tz
+        import datetime as _dt
+        from omop_core.models import Organization
+
+        # Owner is a superuser on purpose: the crash is driven by the userless
+        # AccessToken, NOT by Application.user, so a superuser owner must not
+        # mask it.
+        owner = Identity.objects.create_superuser(
+            email='userless_owner@test.com', password='pw',
+        )
+        cls.app = Application.objects.create(
+            name='Userless Service',
+            client_id='userless-client-id',
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            user=owner,
+        )
+        # No ApplicationOrganization -> get_request_org() is None -> execution
+        # reaches the can_access_patient / can_write_patient branch with a None
+        # actor (previously an AttributeError -> 500).
+        cls.read_token = AccessToken.objects.create(
+            user=None, application=cls.app, token='userless-read-tok',
+            expires=tz.now() + _dt.timedelta(hours=1), scope='patient/*.read',
+        )
+        cls.write_token = AccessToken.objects.create(
+            user=None, application=cls.app, token='userless-write-tok',
+            expires=tz.now() + _dt.timedelta(hours=1),
+            scope='patient/*.read patient/*.write',
+        )
+        org = Organization.objects.create(name='Userless Org', slug='userless-org')
+        cls.person = Person.objects.create(person_id=41001)
+        PatientRecord.objects.create(person=cls.person, organization=org)
+
+    def _client(self, token_str):
+        c = APIClient()
+        c.credentials(HTTP_AUTHORIZATION=f'Bearer {token_str}')
+        return c
+
+    def test_userless_token_read_detail_404_not_500(self):
+        resp = self._client(self.read_token.token).get(
+            f'/api/patient-info/{self.person.person_id}/')
+        self.assertEqual(
+            resp.status_code, status.HTTP_404_NOT_FOUND,
+            f'read detail must fail closed (404), got {resp.status_code}')
+
+    def test_userless_token_write_404_not_500(self):
+        resp = self._client(self.write_token.token).patch(
+            f'/api/patient-info/{self.person.person_id}/',
+            {'disease': 'x'}, format='json')
+        self.assertEqual(
+            resp.status_code, status.HTTP_404_NOT_FOUND,
+            f'write must fail closed (404), got {resp.status_code}')

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -13905,6 +13905,15 @@ class UserlessOAuthTokenDetailTest(TestCase):
             resp.status_code, status.HTTP_404_NOT_FOUND,
             f'read detail must fail closed (404), got {resp.status_code}')
 
+    def test_userless_token_read_detail_v1_404_not_500(self):
+        # The v1 path (what external consumers actually hit) routes to the same
+        # viewset and must fail closed identically.
+        resp = self._client(self.read_token.token).get(
+            f'/api/v1/patient-records/{self.person.person_id}/')
+        self.assertEqual(
+            resp.status_code, status.HTTP_404_NOT_FOUND,
+            f'v1 read detail must fail closed (404), got {resp.status_code}')
+
     def test_userless_token_write_404_not_500(self):
         resp = self._client(self.write_token.token).patch(
             f'/api/patient-info/{self.person.person_id}/',
@@ -13912,3 +13921,14 @@ class UserlessOAuthTokenDetailTest(TestCase):
         self.assertEqual(
             resp.status_code, status.HTTP_404_NOT_FOUND,
             f'write must fail closed (404), got {resp.status_code}')
+
+    def test_authorization_helpers_none_actor_fail_closed(self):
+        # The three authorization helpers must all fail closed for a None actor
+        # rather than dereferencing it.
+        from omop_core.authorization import (
+            can_access_patient, can_write_patient, get_actor_role,
+        )
+        pid = self.person.person_id
+        self.assertFalse(can_access_patient(None, pid))
+        self.assertFalse(can_write_patient(None, pid))
+        self.assertIsNone(get_actor_role(None, pid))


### PR DESCRIPTION
Fixes the authorization-inconsistency half of #330. **Stacked on #331** (base `fix/patient-detail-guard-request-user`).

## Problem
The **list** endpoint (`get_queryset`) grants a trusted HMAC service token (`is_service_token`) full visibility across all patients — `PatientRecord.objects.all()`. But the read **detail** endpoints (`retrieve`, `provenance`, `revisions`) don't honor it: they fall through to the per-patient ACL (`get_request_org` / `can_access_patient`) and **404** a trusted backend that can already list every patient.

## Fix
Gate the per-patient ACL behind `if not is_service_token(request):` in the three read-detail methods, so a trusted service token reads an individual record exactly as it lists them.

### Scope / safety
- **READ only.** `partial_update` (write, guarded by `can_write_patient`) is intentionally left unchanged — this does not widen write access.
- `is_service_token()` is the **HMAC sentinel only** (`request.auth == "service-token"`, produced solely by `ServiceTokenAuthentication` after `hmac.compare_digest`). It never matches OAuth (`AccessToken` object), session (`None`), or partner (`TokenClaims`) — so this does **not** grant blanket patient access to OAuth `client_credentials` clients. Designating an OAuth client as a full-visibility internal service is a separate decision (see #330).
- ACL logic is byte-identical, only indented under the new guard — no dropped branch.

### Data-surface note (raised in review)
The service token could already enumerate every patient via list, so no new data is exposed at the row level. But detail uses `PatientRecordSerializer(fields="__all__")` vs the list's 9-field serializer, and `provenance`/`revisions` become reachable to this principal — an intentional widening consistent with the declared "trusted backend → full access" policy.

## Review
Two independent reviews (fresh-context agent + codex). Confirmed: no privilege escalation (HMAC sentinel unforgeable by OAuth/session), ACL preserved, write route unchanged, and no existing test expectation flips (`MultiTenantIsolationTest`, `PatientRecordIDORTest` still valid).

## Recommended test coverage (not yet added — needs CI DB)
- HMAC service token (`Bearer $SERVICE_AUTH_TOKEN`) → **200** cross-patient on `retrieve` / `provenance` / `revisions`.
- OAuth / session cross-org → still **denied** (unchanged).

Refs #330.