### PR TITLE
feat: streaming NDJSON bulk snapshot for vocabulary tables

### DIFF
--- a/patient_portal/api/v1_urls.py
+++ b/patient_portal/api/v1_urls.py
@@ -17,6 +17,7 @@ from .views import (
     concept_ancestors, concept_descendants, concept_graph_batch,
     concept_synonyms, concept_synonym_search, concept_replacement,
     vocab_release_list, vocab_release_detail, vocab_release_latest,
+    VocabSnapshotView,
     org_disease_stats,
     InterchangeAgreementViewSet,
 )
@@ -75,6 +76,8 @@ urlpatterns = [
     path('vocab-releases/', vocab_release_list, name='v1-vocab-release-list'),
     path('vocab-releases/latest/', vocab_release_latest, name='v1-vocab-release-latest'),
     path('vocab-releases/<int:release_id>/', vocab_release_detail, name='v1-vocab-release-detail'),
+    path('vocab-releases/<int:release_id>/snapshot/<str:table>/', VocabSnapshotView.as_view(), name='v1-vocab-snapshot'),
+    path('vocab-releases/latest/snapshot/<str:table>/', VocabSnapshotView.as_view(), {'release_id': None}, name='v1-vocab-snapshot-latest'),
     path('vocabularies/<str:model_name>/', vocabulary_list, name='v1-vocabulary-list'),
     path('concepts/lookup/', concept_lookup, name='v1-concept-lookup'),
     path('concepts/search/', concept_search, name='v1-concept-search'),

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from patient_portal.models import Identity
@@ -5267,3 +5268,94 @@ def _serialize_vocab_release(release, include_checksums=False):
     if include_checksums:
         data['checksums'] = release.checksums
     return data
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary Snapshot — streaming NDJSON bulk download
+# ---------------------------------------------------------------------------
+
+class VocabSnapshotView(APIView):
+    """Stream all rows from a vocabulary table as newline-delimited JSON.
+
+    Uses raw SQL ``row_to_json()`` to avoid ORM overhead on large tables.
+    The table name is validated against a whitelist before interpolation.
+    """
+    permission_classes = [ScopedTokenPermission]
+
+    ALLOWED_TABLES = {
+        'concept': 'concept',
+        'concept_relationship': 'concept_relationship',
+        'concept_ancestor': 'concept_ancestor',
+        'concept_synonym': 'concept_synonym',
+        'drug_strength': 'drug_strength',
+        'source_to_concept_map': 'source_to_concept_map',
+        'vocabulary': 'vocabulary',
+    }
+
+    def get(self, request, table, release_id=None):
+        from django.http import HttpResponseNotModified, StreamingHttpResponse
+        from omop_core.models import VocabularyRelease
+        from omop_core.services.vocab_release import get_latest_release, get_release_etag
+
+        # 1. Validate table name
+        if table not in self.ALLOWED_TABLES:
+            return Response(
+                {'detail': f'Unknown table. Valid tables: {", ".join(sorted(self.ALLOWED_TABLES))}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 2. Resolve release
+        if release_id is None:
+            release = get_latest_release()
+        else:
+            release = VocabularyRelease.objects.filter(
+                pk=release_id, status='published',
+            ).first()
+        if release is None:
+            return Response({'detail': 'Release not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+        # 3. ETag / conditional request
+        etag = get_release_etag(release)
+        if_none_match = request.META.get('HTTP_IF_NONE_MATCH', '')
+        if _etag_matches(if_none_match, etag):
+            return HttpResponseNotModified()
+
+        # 4. Build WHERE clause (source filter for concept table only)
+        db_table = self.ALLOWED_TABLES[table]
+        where = ''
+        if table == 'concept':
+            source_param = request.query_params.get('source')
+            if source_param == 'HealthKey':
+                where = "WHERE source = 'HealthKey'"
+            elif source_param == 'external':
+                where = 'WHERE source IS NULL'
+
+        # 5. Stream NDJSON
+        sql = f'SELECT row_to_json(t) FROM {db_table} t {where}'
+        response = StreamingHttpResponse(
+            self._stream_ndjson(sql),
+            content_type='application/x-ndjson',
+        )
+        response['Content-Disposition'] = (
+            f'attachment; filename="{table}_{release.pk}.ndjson"'
+        )
+        if etag:
+            response['ETag'] = etag
+            response['Cache-Control'] = 'public, max-age=86400'
+        return response
+
+    @staticmethod
+    def _stream_ndjson(sql):
+        import json as _json
+        from django.db import connection
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            while True:
+                rows = cursor.fetchmany(1000)
+                if not rows:
+                    break
+                for (row_json,) in rows:
+                    if isinstance(row_json, dict):
+                        yield _json.dumps(row_json) + '\n'
+                    else:
+                        yield str(row_json) + '\n'

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -5282,12 +5282,16 @@ class VocabSnapshotView(APIView):
     """
     permission_classes = [ScopedTokenPermission]
 
+    # SECURITY: db_table values are hardcoded; never interpolate user input.
     ALLOWED_TABLES = {
         'concept': 'concept',
-        'concept_relationship': 'concept_relationship',
         'concept_ancestor': 'concept_ancestor',
+        'concept_class': 'concept_class',
+        'concept_relationship': 'concept_relationship',
         'concept_synonym': 'concept_synonym',
+        'domain': 'domain',
         'drug_strength': 'drug_strength',
+        'relationship': 'relationship',
         'source_to_concept_map': 'source_to_concept_map',
         'vocabulary': 'vocabulary',
     }
@@ -5318,22 +5322,32 @@ class VocabSnapshotView(APIView):
         etag = get_release_etag(release)
         if_none_match = request.META.get('HTTP_IF_NONE_MATCH', '')
         if _etag_matches(if_none_match, etag):
-            return HttpResponseNotModified()
+            resp = HttpResponseNotModified()
+            if etag:
+                resp['ETag'] = etag
+            return resp
 
         # 4. Build WHERE clause (source filter for concept table only)
         db_table = self.ALLOWED_TABLES[table]
         where = ''
+        params = []
+        source_param = None
         if table == 'concept':
             source_param = request.query_params.get('source')
             if source_param == 'HealthKey':
-                where = "WHERE source = 'HealthKey'"
+                where = 'WHERE source = %s'
+                params = ['HealthKey']
             elif source_param == 'external':
                 where = 'WHERE source IS NULL'
+
+        # Vary ETag by source filter so different queries don't share ETags
+        if source_param and etag:
+            etag = etag.rstrip('"') + f'-{source_param}"'
 
         # 5. Stream NDJSON
         sql = f'SELECT row_to_json(t) FROM {db_table} t {where}'
         response = StreamingHttpResponse(
-            self._stream_ndjson(sql),
+            self._stream_ndjson(sql, params),
             content_type='application/x-ndjson',
         )
         response['Content-Disposition'] = (
@@ -5341,21 +5355,21 @@ class VocabSnapshotView(APIView):
         )
         if etag:
             response['ETag'] = etag
-            response['Cache-Control'] = 'public, max-age=86400'
+            response['Cache-Control'] = 'private, max-age=86400'
         return response
 
     @staticmethod
-    def _stream_ndjson(sql):
+    def _stream_ndjson(sql, params=None):
         import json as _json
         from django.db import connection
-        with connection.cursor() as cursor:
-            cursor.execute(sql)
-            while True:
-                rows = cursor.fetchmany(1000)
-                if not rows:
-                    break
-                for (row_json,) in rows:
-                    if isinstance(row_json, dict):
-                        yield _json.dumps(row_json) + '\n'
-                    else:
-                        yield str(row_json) + '\n'
+        count = 0
+        with connection.connection.cursor(name='vocab_snapshot') as cursor:
+            cursor.itersize = 1000
+            cursor.execute(sql, params or [])
+            for (row_json,) in cursor:
+                if isinstance(row_json, dict):
+                    yield _json.dumps(row_json) + '\n'
+                else:
+                    yield str(row_json) + '\n'
+                count += 1
+        yield _json.dumps({'__done': True, 'rows': count}) + '\n'

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -13928,6 +13928,8 @@ class VocabSnapshotTest(_SmartBase):
         for line in content.strip().split('\n'):
             if line:
                 row = json.loads(line)
+                if row.get('__done'):
+                    continue
                 self.assertIn('vocabulary_id', row)
 
     def test_404_on_staged_release(self):
@@ -13952,6 +13954,8 @@ class VocabSnapshotTest(_SmartBase):
             HTTP_IF_NONE_MATCH=etag,
         )
         self.assertEqual(resp2.status_code, 304)
+        # RFC 7232: 304 must include ETag
+        self.assertEqual(resp2['ETag'], etag)
 
     def test_400_on_unknown_table(self):
         resp = self.read_client.get(self._snapshot_url('bogus_table', self.release.pk))
@@ -13970,7 +13974,7 @@ class VocabSnapshotTest(_SmartBase):
         resp = self.read_client.get(url)
         self.assertEqual(resp.status_code, 200)
         content = b''.join(resp.streaming_content).decode()
-        rows = [json.loads(l) for l in content.strip().split('\n') if l]
+        rows = [json.loads(l) for l in content.strip().split('\n') if l and '__done' not in l]
         concept_ids = {r['concept_id'] for r in rows}
         self.assertIn(8880002, concept_ids)
         self.assertNotIn(8880001, concept_ids)
@@ -13981,7 +13985,7 @@ class VocabSnapshotTest(_SmartBase):
         resp = self.read_client.get(url)
         self.assertEqual(resp.status_code, 200)
         content = b''.join(resp.streaming_content).decode()
-        rows = [json.loads(l) for l in content.strip().split('\n') if l]
+        rows = [json.loads(l) for l in content.strip().split('\n') if l and '__done' not in l]
         concept_ids = {r['concept_id'] for r in rows}
         self.assertIn(8880001, concept_ids)
         self.assertNotIn(8880002, concept_ids)
@@ -13993,3 +13997,18 @@ class VocabSnapshotTest(_SmartBase):
             f'vocabulary_{self.release.pk}.ndjson',
             resp['Content-Disposition'],
         )
+
+    def test_unauthenticated_returns_401(self):
+        from rest_framework.test import APIClient
+        anon = APIClient()
+        resp = anon.get(self._snapshot_url('vocabulary', self.release.pk))
+        self.assertIn(resp.status_code, [401, 403])
+
+    def test_done_sentinel_in_stream(self):
+        import json
+        resp = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        content = b''.join(resp.streaming_content).decode()
+        lines = [l for l in content.strip().split('\n') if l]
+        last = json.loads(lines[-1])
+        self.assertTrue(last.get('__done'))
+        self.assertEqual(last['rows'], len(lines) - 1)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -13848,3 +13848,148 @@ class VocabReleaseAPITest(_SmartBase):
         resp = self.read_client.get('/api/v1/concepts/search/?q=test')
         self.assertEqual(resp.status_code, 200)
         self.assertIn('ETag', resp)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary Snapshot (streaming NDJSON) tests
+# ---------------------------------------------------------------------------
+
+class VocabSnapshotTest(_SmartBase):
+    """Test /api/v1/vocab-releases/.../snapshot/<table>/ endpoints."""
+
+    def setUp(self):
+        super().setUp()
+        from omop_core.models import VocabularyRelease
+        from django.utils import timezone as tz
+        self.release = VocabularyRelease.objects.create(
+            build_timestamp=tz.now(),
+            status='published',
+            published_at=tz.now(),
+            scope=['TEST'],
+            vocab_versions={'TEST': '1.0'},
+            row_counts={'concept': 2, 'vocabulary': 1},
+            checksums={},
+        )
+        # Seed a concept with source='HealthKey' and one without
+        from omop_core.models import Concept, ConceptClass
+        cc, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Clinical Finding',
+            defaults={'concept_class_name': 'Clinical Finding', 'concept_class_concept_id': 0},
+        )
+        vocab = Vocabulary.objects.get(vocabulary_id='TEST')
+        domain = Domain.objects.get(domain_id='Condition')
+        from datetime import date
+        self.concept_ext = Concept.objects.create(
+            concept_id=8880001,
+            concept_name='External Concept',
+            domain=domain,
+            vocabulary=vocab,
+            concept_class=cc,
+            concept_code='EXT001',
+            source=None,
+            valid_start_date=date(1970, 1, 1),
+            valid_end_date=date(2099, 12, 31),
+        )
+        self.concept_hk = Concept.objects.create(
+            concept_id=8880002,
+            concept_name='HealthKey Concept',
+            domain=domain,
+            vocabulary=vocab,
+            concept_class=cc,
+            concept_code='HK001',
+            source='HealthKey',
+            valid_start_date=date(1970, 1, 1),
+            valid_end_date=date(2099, 12, 31),
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        from patient_portal.api.views import _vocab_version_cache
+        _vocab_version_cache['release_pk'] = None
+        _vocab_version_cache['map'] = None
+
+    def _snapshot_url(self, table, release_id=None):
+        if release_id is None:
+            return f'/api/v1/vocab-releases/latest/snapshot/{table}/'
+        return f'/api/v1/vocab-releases/{release_id}/snapshot/{table}/'
+
+    def test_returns_ndjson(self):
+        resp = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['Content-Type'], 'application/x-ndjson')
+        content = b''.join(resp.streaming_content).decode()
+        lines = [l for l in content.strip().split('\n') if l]
+        self.assertGreater(len(lines), 0)
+
+    def test_each_line_valid_json(self):
+        import json
+        resp = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        content = b''.join(resp.streaming_content).decode()
+        for line in content.strip().split('\n'):
+            if line:
+                row = json.loads(line)
+                self.assertIn('vocabulary_id', row)
+
+    def test_404_on_staged_release(self):
+        from omop_core.models import VocabularyRelease
+        from django.utils import timezone as tz
+        staged = VocabularyRelease.objects.create(
+            build_timestamp=tz.now(), status='staged',
+        )
+        resp = self.read_client.get(self._snapshot_url('vocabulary', staged.pk))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_404_on_nonexistent_release(self):
+        resp = self.read_client.get(self._snapshot_url('vocabulary', 99999))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_304_on_etag_match(self):
+        resp1 = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        self.assertEqual(resp1.status_code, 200)
+        etag = resp1['ETag']
+        resp2 = self.read_client.get(
+            self._snapshot_url('vocabulary', self.release.pk),
+            HTTP_IF_NONE_MATCH=etag,
+        )
+        self.assertEqual(resp2.status_code, 304)
+
+    def test_400_on_unknown_table(self):
+        resp = self.read_client.get(self._snapshot_url('bogus_table', self.release.pk))
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('Unknown table', resp.data['detail'])
+
+    def test_latest_resolves_to_published(self):
+        resp = self.read_client.get(self._snapshot_url('vocabulary'))
+        self.assertEqual(resp.status_code, 200)
+        content = b''.join(resp.streaming_content).decode()
+        self.assertGreater(len(content.strip()), 0)
+
+    def test_source_filter_healthkey(self):
+        import json
+        url = self._snapshot_url('concept', self.release.pk) + '?source=HealthKey'
+        resp = self.read_client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        content = b''.join(resp.streaming_content).decode()
+        rows = [json.loads(l) for l in content.strip().split('\n') if l]
+        concept_ids = {r['concept_id'] for r in rows}
+        self.assertIn(8880002, concept_ids)
+        self.assertNotIn(8880001, concept_ids)
+
+    def test_source_filter_external(self):
+        import json
+        url = self._snapshot_url('concept', self.release.pk) + '?source=external'
+        resp = self.read_client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        content = b''.join(resp.streaming_content).decode()
+        rows = [json.loads(l) for l in content.strip().split('\n') if l]
+        concept_ids = {r['concept_id'] for r in rows}
+        self.assertIn(8880001, concept_ids)
+        self.assertNotIn(8880002, concept_ids)
+
+    def test_content_disposition_header(self):
+        resp = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(
+            f'vocabulary_{self.release.pk}.ndjson',
+            resp['Content-Disposition'],
+        )


### PR DESCRIPTION
## Summary
- Add `VocabSnapshotView` (class-based `APIView`) that streams vocabulary table rows as newline-delimited JSON
- Two URL patterns: `/api/v1/vocab-releases/<id>/snapshot/<table>/` and `/api/v1/vocab-releases/latest/snapshot/<table>/`
- Supports 7 OMOP tables: concept, concept_relationship, concept_ancestor, concept_synonym, drug_strength, source_to_concept_map, vocabulary
- Uses PostgreSQL `row_to_json()` for server-side JSON serialization (no ORM overhead)
- Optional `?source=HealthKey` / `?source=external` filter on the concept table
- ETag/If-None-Match support (304 on match), Content-Disposition for file download
- 10 new tests covering NDJSON format, source filtering, ETag, 404/400 error cases

## Test plan
- [x] 10 new tests in `VocabSnapshotTest` pass
- [x] Full suite: 1073 tests pass (omop_core + patient_portal)
- [ ] Manual smoke test with vocab data loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)