### PR TITLE
Phase 3: Org admin UI for patient invitations

### DIFF
--- a/frontend/src/components/OrgAdmin/OrgDetail.test.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import OrgDetail from "./OrgDetail";
+
+// Mock api
+const mockGet = vi.fn();
+const mockPatch = vi.fn();
+const mockPost = vi.fn();
+const mockDelete = vi.fn();
+vi.mock("@/api/axios", () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}));
+
+const ORG_DATA = {
+  id: 1,
+  name: "Acme Clinic",
+  slug: "acme",
+  is_active: true,
+  allows_public_aggregated_data: false,
+  allows_patient_signup: false,
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+function setupMocks(overrides: Partial<typeof ORG_DATA> = {}) {
+  const orgData = { ...ORG_DATA, ...overrides };
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes("/orgs/acme/trusts/")) return Promise.resolve({ data: [] });
+    if (url.includes("/orgs/acme/invitations/")) return Promise.resolve({ data: [] });
+    if (url.includes("/orgs/acme/access/")) return Promise.resolve({ data: [] });
+    if (url.includes("/orgs/acme/")) return Promise.resolve({ data: orgData });
+    if (url.includes("/stats/org-disease/")) return Promise.resolve({ data: [] });
+    if (url.includes("/orgs/")) return Promise.resolve({ data: [] });
+    if (url.includes("/patient-records/"))
+      return Promise.resolve({
+        data: [
+          { person_id: 42, patient_name: "Jane Doe" },
+          { person_id: 99, patient_name: "John Smith" },
+        ],
+      });
+    return Promise.resolve({ data: {} });
+  });
+  mockPatch.mockResolvedValue({ data: orgData });
+  mockPost.mockResolvedValue({ data: { id: 10, email: "p@test.com", role: "patient", status: "pending" } });
+  return orgData;
+}
+
+function renderOrgDetail(props: Partial<React.ComponentProps<typeof OrgDetail>> = {}) {
+  return render(
+    <OrgDetail slug="acme" isStaff={true} onBack={vi.fn()} {...props} />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("OrgDetail — Settings", () => {
+  it("renders allows_patient_signup toggle", async () => {
+    setupMocks({ allows_patient_signup: true });
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    const toggle = screen.getByLabelText("Allow direct patient signup");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toBeChecked();
+  });
+
+  it("renders allows_patient_signup toggle unchecked when false", async () => {
+    setupMocks({ allows_patient_signup: false });
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    const toggle = screen.getByLabelText("Allow direct patient signup");
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("calls PATCH when allows_patient_signup toggle is clicked", async () => {
+    setupMocks({ allows_patient_signup: false });
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText("Allow direct patient signup"));
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/orgs/acme/", { allows_patient_signup: true });
+    });
+  });
+});
+
+describe("OrgDetail — Invite form", () => {
+  it("shows patient option in role dropdown", async () => {
+    setupMocks();
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    // Switch to Access Grants tab
+    fireEvent.click(screen.getByText("Access Grants"));
+    const select = screen.getByDisplayValue("Doctor");
+    const options = select.querySelectorAll("option");
+    const optionValues = Array.from(options).map((o) => o.getAttribute("value"));
+    expect(optionValues).toContain("patient");
+  });
+
+  it("shows patient search field when patient role is selected", async () => {
+    setupMocks();
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Access Grants"));
+    const roleSelect = screen.getByDisplayValue("Doctor");
+    fireEvent.change(roleSelect, { target: { value: "patient" } });
+    expect(screen.getByPlaceholderText("Search by name or ID...")).toBeInTheDocument();
+    expect(screen.getByText(/Link to patient record/)).toBeInTheDocument();
+  });
+
+  it("searches patients and shows results", async () => {
+    setupMocks();
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Access Grants"));
+    const roleSelect = screen.getByDisplayValue("Doctor");
+    fireEvent.change(roleSelect, { target: { value: "patient" } });
+
+    const searchInput = screen.getByPlaceholderText("Search by name or ID...");
+    fireEvent.change(searchInput, { target: { value: "Jane" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+    });
+  });
+
+  it("sends person_id when patient invite has linked record", async () => {
+    setupMocks();
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Access Grants"));
+    const roleSelect = screen.getByDisplayValue("Doctor");
+    fireEvent.change(roleSelect, { target: { value: "patient" } });
+
+    // Search and select a patient
+    const searchInput = screen.getByPlaceholderText("Search by name or ID...");
+    fireEvent.change(searchInput, { target: { value: "Jane" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+    });
+
+    // Click the result to select
+    fireEvent.click(screen.getByText(/Jane Doe/));
+
+    // Fill email and send
+    fireEvent.change(screen.getByPlaceholderText("Email address"), { target: { value: "jane@test.com" } });
+    fireEvent.click(screen.getByText("Send Invite"));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/orgs/acme/invite/", {
+        email: "jane@test.com",
+        role: "patient",
+        person_id: 42,
+      });
+    });
+  });
+
+  it("hides patient search when switching away from patient role", async () => {
+    setupMocks();
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Access Grants"));
+    const roleSelect = screen.getByDisplayValue("Doctor");
+    fireEvent.change(roleSelect, { target: { value: "patient" } });
+    expect(screen.getByPlaceholderText("Search by name or ID...")).toBeInTheDocument();
+
+    fireEvent.change(roleSelect, { target: { value: "doctor" } });
+    expect(screen.queryByPlaceholderText("Search by name or ID...")).not.toBeInTheDocument();
+  });
+});
+
+describe("OrgDetail — Invitations list", () => {
+  it("shows person_id for patient invitations", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes("/orgs/acme/invitations/"))
+        return Promise.resolve({
+          data: [
+            { id: 1, org_slug: "acme", email: "patient@test.com", role: "patient", person_id: 42, status: "pending", redirect_url: null, expires_at: "2099-01-01", created_at: "2024-01-01" },
+            { id: 2, org_slug: "acme", email: "doc@test.com", role: "doctor", person_id: null, status: "confirmed", redirect_url: null, expires_at: "2099-01-01", created_at: "2024-01-01" },
+          ],
+        });
+      if (url.includes("/orgs/acme/trusts/")) return Promise.resolve({ data: [] });
+      if (url.includes("/orgs/acme/access/")) return Promise.resolve({ data: [] });
+      if (url.includes("/orgs/acme/")) return Promise.resolve({ data: ORG_DATA });
+      if (url.includes("/stats/org-disease/")) return Promise.resolve({ data: [] });
+      if (url.includes("/orgs/")) return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: {} });
+    });
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Invitations"));
+    await waitFor(() => {
+      expect(screen.getByText("patient@test.com")).toBeInTheDocument();
+    });
+    // Patient invite shows linked person_id
+    expect(screen.getByText("#42")).toBeInTheDocument();
+    // Doctor invite does not show person_id
+    expect(screen.queryByText("#null")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/OrgAdmin/OrgDetail.test.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.test.tsx
@@ -35,7 +35,7 @@ function setupMocks(overrides: Partial<typeof ORG_DATA> = {}) {
     if (url.includes("/orgs/acme/")) return Promise.resolve({ data: orgData });
     if (url.includes("/stats/org-disease/")) return Promise.resolve({ data: [] });
     if (url.includes("/orgs/")) return Promise.resolve({ data: [] });
-    if (url.includes("/patient-records/"))
+    if (url.includes("/v1/patient-records/"))
       return Promise.resolve({
         data: [
           { person_id: 42, patient_name: "Jane Doe" },

--- a/frontend/src/components/OrgAdmin/OrgDetail.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.tsx
@@ -120,6 +120,14 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const [selectedPerson, setSelectedPerson] = useState<PatientSearchResult | null>(null);
   const [patientSearchLoading, setPatientSearchLoading] = useState(false);
   const patientSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const patientSearchSeq = useRef(0);
+
+  // Clean up debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (patientSearchTimer.current) clearTimeout(patientSearchTimer.current);
+    };
+  }, []);
 
   const base = `/orgs/${slug}`;
 
@@ -187,21 +195,24 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
     if (patientSearchTimer.current) clearTimeout(patientSearchTimer.current);
     if (query.length < 2) {
       setPatientSearchResults([]);
+      setPatientSearchLoading(false);
       return;
     }
-    setPatientSearchLoading(true);
+    const seq = ++patientSearchSeq.current;
     patientSearchTimer.current = setTimeout(async () => {
+      setPatientSearchLoading(true);
       try {
         const res = await api.get(
-          `/patient-records/?org=${encodeURIComponent(slug)}&search=${encodeURIComponent(query)}`
+          `/v1/patient-records/?org=${encodeURIComponent(slug)}&search=${encodeURIComponent(query)}`
         );
+        if (seq !== patientSearchSeq.current) return; // stale response
         const data = res.data;
         const results: PatientSearchResult[] = Array.isArray(data) ? data : (data.results ?? []);
         setPatientSearchResults(results);
       } catch {
-        setPatientSearchResults([]);
+        if (seq === patientSearchSeq.current) setPatientSearchResults([]);
       } finally {
-        setPatientSearchLoading(false);
+        if (seq === patientSearchSeq.current) setPatientSearchLoading(false);
       }
     }, 300);
   };
@@ -697,6 +708,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
                       placeholder="Search by name or ID..."
                       value={patientSearchQuery}
                       onChange={e => handlePatientSearch(e.target.value)}
+                      onBlur={() => setTimeout(() => setPatientSearchResults([]), 150)}
                       className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
                     />
                     {patientSearchLoading && (

--- a/frontend/src/components/OrgAdmin/OrgDetail.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { ArrowLeft, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowLeft, Trash2, X } from 'lucide-react';
 import api from '@/api/axios';
 
 const DEFAULT_ANALYST_REDIRECT_URL = 'https://analytics.healthkey.ai';
@@ -16,6 +16,7 @@ interface Org {
   slug: string;
   is_active: boolean;
   allows_public_aggregated_data: boolean;
+  allows_patient_signup: boolean;
   created_at: string;
 }
 
@@ -33,9 +34,15 @@ interface Invitation {
   email: string;
   role: string;
   redirect_url: string | null;
+  person_id: number | null;
   status: string;
   expires_at: string;
   created_at: string;
+}
+
+interface PatientSearchResult {
+  person_id: number;
+  patient_name: string;
 }
 
 interface InviteResponse extends Invitation {
@@ -87,6 +94,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const [orgName, setOrgName] = useState('');
   const [isActive, setIsActive] = useState(true);
   const [allowsPublicData, setAllowsPublicData] = useState(false);
+  const [allowsPatientSignup, setAllowsPatientSignup] = useState(false);
   const [settingsSaved, setSettingsSaved] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
 
@@ -106,6 +114,13 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteSuccess, setInviteSuccess] = useState<string | null>(null);
 
+  // Patient search state (for patient invites)
+  const [patientSearchQuery, setPatientSearchQuery] = useState('');
+  const [patientSearchResults, setPatientSearchResults] = useState<PatientSearchResult[]>([]);
+  const [selectedPerson, setSelectedPerson] = useState<PatientSearchResult | null>(null);
+  const [patientSearchLoading, setPatientSearchLoading] = useState(false);
+  const patientSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const base = `/orgs/${slug}`;
 
   const fetchAll = useCallback(async () => {
@@ -122,6 +137,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
       setOrgName(orgRes.data.name);
       setIsActive(orgRes.data.is_active);
       setAllowsPublicData(orgRes.data.allows_public_aggregated_data ?? false);
+      setAllowsPatientSignup(orgRes.data.allows_patient_signup ?? false);
       setTrusts(trustRes.data);
       setInvitations(invRes.data);
       setAccessGrants(accessRes.data);
@@ -155,6 +171,39 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
     } catch {
       setAllowsPublicData(!checked); // revert on error
     }
+  };
+
+  const handlePatientSignupToggle = async (checked: boolean) => {
+    setAllowsPatientSignup(checked);
+    try {
+      await api.patch(`${base}/`, { allows_patient_signup: checked });
+    } catch {
+      setAllowsPatientSignup(!checked);
+    }
+  };
+
+  const handlePatientSearch = (query: string) => {
+    setPatientSearchQuery(query);
+    if (patientSearchTimer.current) clearTimeout(patientSearchTimer.current);
+    if (query.length < 2) {
+      setPatientSearchResults([]);
+      return;
+    }
+    setPatientSearchLoading(true);
+    patientSearchTimer.current = setTimeout(async () => {
+      try {
+        const res = await api.get(
+          `/patient-records/?org=${encodeURIComponent(slug)}&search=${encodeURIComponent(query)}`
+        );
+        const data = res.data;
+        const results: PatientSearchResult[] = Array.isArray(data) ? data : (data.results ?? []);
+        setPatientSearchResults(results);
+      } catch {
+        setPatientSearchResults([]);
+      } finally {
+        setPatientSearchLoading(false);
+      }
+    }, 300);
   };
 
   const handleAddTrust = async () => {
@@ -198,9 +247,12 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
     try {
       setInviteError(null);
       setInviteSuccess(null);
-      const payload: Record<string, string> = { email: inviteEmail, role: inviteRole };
+      const payload: Record<string, unknown> = { email: inviteEmail, role: inviteRole };
       if (inviteRole === 'analyst') {
         payload.redirect_url = inviteRedirectUrl;
+      }
+      if (inviteRole === 'patient' && selectedPerson) {
+        payload.person_id = selectedPerson.person_id;
       }
       const res = await api.post<InviteResponse>(`${base}/invite/`, payload);
       if (res.data.email_warning) {
@@ -212,6 +264,9 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
       }
       setInviteEmail('');
       setInviteRedirectUrl(DEFAULT_ANALYST_REDIRECT_URL);
+      setSelectedPerson(null);
+      setPatientSearchQuery('');
+      setPatientSearchResults([]);
       fetchAll();
     } catch {
       setInviteError('Failed to send invitation.');
@@ -321,6 +376,15 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
               <label htmlFor="is_active" className="text-sm text-gray-700">Active</label>
             </div>
           )}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={allowsPatientSignup}
+              onChange={(e) => handlePatientSignupToggle(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-blue-600"
+            />
+            <span className="text-sm text-gray-700">Allow direct patient signup</span>
+          </label>
           <button
             onClick={handleSaveSettings}
             className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
@@ -571,12 +635,18 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
                   if (nextRole !== 'analyst') {
                     setInviteRedirectUrl(DEFAULT_ANALYST_REDIRECT_URL);
                   }
+                  if (nextRole !== 'patient') {
+                    setSelectedPerson(null);
+                    setPatientSearchQuery('');
+                    setPatientSearchResults([]);
+                  }
                 }}
                 className="border border-gray-300 rounded px-2 py-1.5 text-sm"
               >
                 <option value="org_admin">Org Admin</option>
                 <option value="doctor">Doctor</option>
                 <option value="analyst">Analyst</option>
+                <option value="patient">Patient</option>
               </select>
               <button
                 onClick={handleInvite}
@@ -597,6 +667,64 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
                 />
               </div>
             )}
+            {inviteRole === 'patient' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Link to patient record <span className="font-normal text-gray-400">(optional)</span>
+                </label>
+                {selectedPerson ? (
+                  <div className="flex items-center gap-2 border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50">
+                    <span className="flex-1 truncate">
+                      {selectedPerson.patient_name} <span className="text-gray-400">(#{selectedPerson.person_id})</span>
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSelectedPerson(null);
+                        setPatientSearchQuery('');
+                        setPatientSearchResults([]);
+                      }}
+                      className="text-gray-400 hover:text-gray-600"
+                      title="Clear selection"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                ) : (
+                  <div className="relative">
+                    <input
+                      type="text"
+                      placeholder="Search by name or ID..."
+                      value={patientSearchQuery}
+                      onChange={e => handlePatientSearch(e.target.value)}
+                      className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                    />
+                    {patientSearchLoading && (
+                      <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-400">...</span>
+                    )}
+                    {patientSearchResults.length > 0 && (
+                      <ul className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded shadow-lg max-h-40 overflow-y-auto">
+                        {patientSearchResults.map(p => (
+                          <li key={p.person_id}>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setSelectedPerson(p);
+                                setPatientSearchQuery('');
+                                setPatientSearchResults([]);
+                              }}
+                              className="w-full text-left px-3 py-1.5 text-sm hover:bg-blue-50"
+                            >
+                              {p.patient_name} <span className="text-gray-400">(#{p.person_id})</span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -615,6 +743,9 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
                   <span className="text-sm">
                     <span className="font-medium">{inv.email}</span>
                     <span className="text-gray-400 ml-2">({inv.role})</span>
+                    {inv.role === 'patient' && inv.person_id && (
+                      <span className="text-gray-400 ml-1">#{inv.person_id}</span>
+                    )}
                     <span className={`ml-2 text-xs px-1.5 py-0.5 rounded font-medium ${
                       inv.status === 'pending' ? 'bg-yellow-100 text-yellow-700'
                         : inv.status === 'confirmed' ? 'bg-green-100 text-green-700'


### PR DESCRIPTION
## Summary
- Add `allows_patient_signup` toggle to the org admin Settings tab (optimistic update with revert on error)
- Add `patient` role to the invite dropdown in the Access Grants tab
- When patient role is selected, show a searchable patient record field to optionally link the invite to an existing patient
- Show linked person ID in the Invitations tab for patient invitations
- 9 new frontend tests covering all new functionality

Closes #338. Part of the patient role roadmap (Phase 3). No backend changes — all endpoints already exist from Phase 1.

## Test plan
- [x] `allows_patient_signup` toggle renders and persists (PATCH call verified)
- [x] Patient option appears in invite role dropdown
- [x] Patient search field shows when patient role selected, hides otherwise
- [x] Search results display and selection works
- [x] Invite sends `person_id` when patient record is linked
- [x] Invitation list shows `#person_id` for patient invites
- [x] All 153 frontend tests pass
- [x] All 1096 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)