### PR TITLE
Fix patient detail name display and FL name suffix

### DIFF
--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -214,9 +214,9 @@ export default function PatientDetail({
         setEditedInfo(d);
 
         const user = res.data.user;
-        const name = user
-          ? (user.name || user.email || `Patient ${personId}`)
-          : `Patient ${personId}`;
+        const name = d.patient_name
+          || (user ? (user.name || user.email) : null)
+          || `Patient ${personId}`;
         setPatientName(name);
         setEditedName(name);
         setFetchError(null);

--- a/omop_core/management/commands/_fl_generator.py
+++ b/omop_core/management/commands/_fl_generator.py
@@ -159,17 +159,10 @@ def _pick_regimen(regimen_list, early_stage=False):
 
 
 class FLBundleGenerator:
-    """Generates a FHIR R4 Bundle for Follicular Lymphoma patients.
-
-    Each instantiation produces a unique run_id that is appended to every
-    patient's family name (e.g. "Smith-a3f7").  This guarantees that two
-    separate generate runs can never produce matching patients and therefore
-    can never overwrite each other's org assignment on re-import.
-    """
+    """Generates a FHIR R4 Bundle for Follicular Lymphoma patients."""
 
     def __init__(self, watch_wait_ratio=0.20):
         self.watch_wait_ratio = watch_wait_ratio
-        self.run_id = uuid.uuid4().hex[:4]   # e.g. "a3f7" — unique per generate run
         self._first_line_regimens, self._later_line_regimens = self._build_regimen_lists()
 
     def _build_regimen_lists(self):
@@ -348,7 +341,7 @@ class FLBundleGenerator:
         p['age']        = int(random.triangular(42, 82, 62))
         p['ethnicity']  = _wc(_ETHNICITIES, _ETHNICITY_WEIGHTS)
         p['first_name'] = random.choice(_FIRST_NAMES)
-        p['last_name']  = random.choice(_LAST_NAMES) + '-' + self.run_id
+        p['last_name']  = random.choice(_LAST_NAMES)
         p['city'], p['state'] = random.choice(_US_LOCATIONS)
 
         if p['gender'] == 'male':

--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -282,7 +282,7 @@ class PatientRecordSerializer(serializers.ModelSerializer):
         if obj.person:
             full_name = f"{obj.person.given_name or ''} {obj.person.family_name or ''}".strip()
             return full_name if full_name else f"Patient {obj.person.person_id}"
-        return f"Patient {obj.person.person_id}"
+        return f"Patient {obj.pk}"
 
     def get_name(self, obj):
         return self.get_patient_name(obj)


### PR DESCRIPTION
## Summary
- Fix detail view showing "Patient nnnn" instead of actual name — now uses `patient_name` from `patient_info` response
- Fix serializer crash when `obj.person` is None in `get_patient_name`
- Remove `-{run_id}` suffix from FL generator last names (was appending e.g. `-1657`)

Closes #340.

## Test plan
- [x] 153 frontend tests pass
- [x] 1096 backend tests pass
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)