### PR TITLE
fix(vocab): make snapshot stream + release manifest work for a consumer (#342, #343)

### DIFF
--- a/API_SURFACE.md
+++ b/API_SURFACE.md
@@ -50,6 +50,7 @@ appropriate OMOP table write, then the signal chain re-derives PatientRecord.
    - [Document & trial endpoints](#document--trial-endpoints)
    - [Vocabulary & concept lookup endpoints](#vocabulary--concept-lookup-endpoints)
    - [Concept graph endpoints](#concept-graph-endpoints)
+   - [Vocabulary release & snapshot (consumer mirror)](#vocabulary-release--snapshot-consumer-mirror)
    - [OAuth2 endpoints](#oauth2-endpoints)
 5. [OMOP write internals](#omop-write-internals) — _upsert_omop_measurement, _LAB_FIELD_TO_LOINC, FHIR pipeline, signal chain
 6. [Provenance tagging](#provenance-tagging)
@@ -817,6 +818,42 @@ Returns every entry in a controlled vocabulary table.
 Available `model_name` slugs (37 total):
 
 `binet-stage` · `cancer-stage` · `disease` · `disease-activity` · `disease-progression` · `distant-metastasis-stage` · `ecog-status` · `estrogen-receptor-status` · `ethnicity` · `flipi-score` · `follicular-lymphoma-grade` · `gelf-criteria` · `her2-status` · `histologic-type` · `hr-status` · `hrd-status` · `infection-status` · `karnofsky-score` · `language` · `language-skill-level` · `measurable-disease` · `morphologic-variant` · `mutation-code` · `mutation-gene` · `mutation-interpretation` · `mutation-origin` · `nodes-stage` · `peripheral-neuropathy-grade` · `pre-existing-condition-category` · `protein-expression` · `richter-transformation` · `staging-modality` · `stem-cell-transplant` · `toxicity-grade` · `tumor-burden` · `tumor-stage`
+
+---
+
+## Vocabulary release & snapshot (consumer mirror)
+
+A consumer (e.g. EXACT) mirrors promop's vocabulary by pinning a **release** and
+cross-checking a streamed **snapshot** against the release **manifest**.
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/vocab-releases/` | List published releases |
+| GET | `/api/v1/vocab-releases/latest/` | Current release pointer |
+| GET | `/api/v1/vocab-releases/{id}/` | **Manifest** for a release: `id`, `vocab_versions`, `row_counts` (per table), `checksums`, `schema_version`, `scope`, `status`, `published_at` |
+| GET | `/api/v1/vocab-releases/{id}/snapshot/{table}/` | **Snapshot**: streaming NDJSON, one row per line, terminated by a `{"__done": true, "rows": N}` sentinel |
+| GET | `/api/v1/vocab-releases/latest/snapshot/{table}/` | Snapshot of the current release |
+
+**Snapshot response** is `Content-Type: application/x-ndjson`, `Content-Disposition:
+attachment`, carries an `ETag` (supports `If-None-Match` → **304**), and is streamed
+from a server-side cursor (constant memory for large tables).
+
+**Completeness gate (consumer side).** A consumer counts the streamed rows and
+compares against `row_counts[table]` in the manifest; a missing `__done` sentinel
+means the stream was truncated (fail closed). Note the following:
+
+- **Only unfiltered downloads are completeness-checkable.** The `concept` snapshot
+  accepts `?source=HealthKey` / `?source=external`, which streams a **subset**;
+  `row_counts` is the **full-table** count, so a filtered download will (correctly)
+  not match it. Use the unfiltered snapshot for the full-mirror completeness check.
+- **The snapshot reads the live table, not an isolated view of the pinned release.**
+  If a `load_athena_vocabularies` run mutates a table between a release's publish and
+  the consumer's download, the streamed rows can disagree with that release's
+  manifest. Loads are infrequent and each publishes a fresh release/ETag, so the
+  window is small; treat a mismatch as fail-closed and re-pin to `latest`.
+- **Auth is coarse today.** Any token with `patient/*.read` or `user/*.read` can read
+  the manifest and snapshot — there is no dedicated system scope for reference data.
+  Tightening this is tracked separately (**#344**).
 
 ---
 

--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -852,7 +852,7 @@ class Command(BaseCommand):
                     "vocabulary_release: COUNT(*)/ctid probe failed for %s (%s); "
                     "falling back to this run's load count — the manifest may "
                     "disagree with the streamed table for %s.",
-                    table_name, exc, table_name,
+                    table_name, exc, table_name, exc_info=True,
                 )
                 real_counts[table_name] = counts[table_name]
                 checksums[table_name] = {'count': counts[table_name]}

--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -823,7 +823,13 @@ class Command(BaseCommand):
             Vocabulary.objects.order_by('vocabulary_id')
             .values_list('vocabulary_id', 'vocabulary_version')
         )
+        # row_counts must reflect the ACTUAL table content the snapshot streams
+        # (SELECT COUNT(*)), not this run's load counts — the table can hold rows
+        # from prior loads / seed data / metadata vocabularies, so a consumer that
+        # cross-checks streamed rows against the manifest (EXACT's fail-closed
+        # completeness gate) would otherwise always mismatch.
         checksums = {}
+        real_counts = {}
         for table_name in counts:
             try:
                 with connection.cursor() as cur:
@@ -832,12 +838,14 @@ class Command(BaseCommand):
                         f'FROM {table_name}'
                     )
                     row = cur.fetchone()
+                    real_counts[table_name] = row[0]
                     checksums[table_name] = {
                         'count': row[0],
                         'min_ctid': row[1],
                         'max_ctid': row[2],
                     }
             except Exception:
+                real_counts[table_name] = counts[table_name]
                 checksums[table_name] = {'count': counts[table_name]}
 
         now = timezone.now()
@@ -848,7 +856,7 @@ class Command(BaseCommand):
             build_timestamp=build_ts,
             athena_version=getattr(self, '_cdm_vocab_version', None),
             vocab_versions=vocab_versions,
-            row_counts=counts,
+            row_counts=real_counts,
             checksums=checksums,
             status='published',
             published_at=now,

--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -844,7 +844,16 @@ class Command(BaseCommand):
                         'min_ctid': row[1],
                         'max_ctid': row[2],
                     }
-            except Exception:
+            except Exception as exc:
+                # Fall back to this run's load count, but never silently: a bare
+                # swallow here reintroduces the manifest↔stream mismatch (#343)
+                # with no server-side signal for the consumer's fail-closed gate.
+                logger.warning(
+                    "vocabulary_release: COUNT(*)/ctid probe failed for %s (%s); "
+                    "falling back to this run's load count — the manifest may "
+                    "disagree with the streamed table for %s.",
+                    table_name, exc, table_name,
+                )
                 real_counts[table_name] = counts[table_name]
                 checksums[table_name] = {'count': counts[table_name]}
 

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -1887,7 +1887,13 @@ class PublishReleaseTest(_OmopBase):
         self.assertEqual(release.status, 'published')
         self.assertIsNotNone(release.published_at)
         self.assertEqual(release.athena_version, 'v5.0 2024-07-01')
-        self.assertEqual(release.row_counts, {'concept': 100, 'vocabulary': 5})
+        # row_counts reflects the ACTUAL table COUNT(*) the snapshot streams, NOT
+        # the per-run load counts passed in — so a consumer cross-checking streamed
+        # rows against the manifest matches. It therefore equals the count captured
+        # in checksums for the same table.
+        self.assertEqual(set(release.row_counts), {'concept', 'vocabulary'})
+        self.assertEqual(release.row_counts['concept'], release.checksums['concept']['count'])
+        self.assertEqual(release.row_counts['vocabulary'], release.checksums['vocabulary']['count'])
         self.assertIn('concept', release.checksums)
         self.assertIn('vocabulary', release.checksums)
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -5360,15 +5360,21 @@ class VocabSnapshotView(APIView):
     @staticmethod
     def _stream_ndjson(sql, params=None):
         import json as _json
-        from django.db import connection
+        from django.db import connection, transaction
         count = 0
-        with connection.connection.cursor(name='vocab_snapshot') as cursor:
-            cursor.itersize = 1000
-            cursor.execute(sql, params or [])
-            for (row_json,) in cursor:
-                if isinstance(row_json, dict):
-                    yield _json.dumps(row_json) + '\n'
-                else:
-                    yield str(row_json) + '\n'
-                count += 1
+        # A server-side (named) cursor issues DECLARE CURSOR, which Postgres only
+        # allows inside a transaction block. The streaming generator runs after the
+        # view returns, in Django's default autocommit — so wrap it in an explicit
+        # transaction spanning the whole stream, or the first fetch raises
+        # NoActiveSqlTransaction.
+        with transaction.atomic():
+            with connection.connection.cursor(name='vocab_snapshot') as cursor:
+                cursor.itersize = 1000
+                cursor.execute(sql, params or [])
+                for (row_json,) in cursor:
+                    if isinstance(row_json, dict):
+                        yield _json.dumps(row_json) + '\n'
+                    else:
+                        yield str(row_json) + '\n'
+                    count += 1
         yield _json.dumps({'__done': True, 'rows': count}) + '\n'

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -16,7 +16,7 @@ import tempfile
 from datetime import date, timedelta
 
 from patient_portal.models import Identity
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -14273,6 +14273,68 @@ class UserlessOAuthTokenDetailTest(TestCase):
 # ---------------------------------------------------------------------------
 # Vocabulary Snapshot (streaming NDJSON) tests
 # ---------------------------------------------------------------------------
+
+class VocabSnapshotStreamTransactionTest(TransactionTestCase):
+    """Regression for #342 — the snapshot stream must not raise
+    NoActiveSqlTransaction.
+
+    Deliberately a TransactionTestCase, not TestCase: the server-side (named)
+    cursor's DECLARE CURSOR requires an open transaction, and the streaming
+    generator runs *after* the view returns, in Django's autocommit. A plain
+    TestCase wraps every test in an ambient transaction that masks a missing
+    `transaction.atomic()` wrap in the view — so the other snapshot tests pass
+    with or without the fix. This base has no ambient transaction, so consuming
+    the stream fails on Postgres if the fix is reverted.
+    """
+
+    def setUp(self):
+        from oauth2_provider.models import Application, AccessToken
+        from django.utils import timezone as tz
+        import datetime
+        from omop_core.models import VocabularyRelease
+        _make_vocab_fixtures()
+        user = Identity.objects.create_user(email='snap_svc@test.com', password='pw')
+        app = Application.objects.create(
+            name='Snap EHR', client_id='snap-client-id',
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            user=user,
+        )
+        AccessToken.objects.create(
+            user=user, application=app, token='snap-read-token',
+            expires=tz.now() + datetime.timedelta(hours=1),
+            scope='patient/*.read openid launch/patient',
+        )
+        self.release = VocabularyRelease.objects.create(
+            build_timestamp=tz.now(), status='published', published_at=tz.now(),
+            scope=['TEST'], vocab_versions={'TEST': '1.0'},
+            row_counts={'vocabulary': 1}, checksums={},
+        )
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer snap-read-token')
+
+    def tearDown(self):
+        from patient_portal.api.views import _vocab_version_cache
+        _vocab_version_cache['release_pk'] = None
+        _vocab_version_cache['map'] = None
+
+    def test_stream_consumes_without_ambient_transaction(self):
+        # No ambient transaction here: iterating the server-side cursor relies on
+        # the view's own transaction.atomic() wrap. Consuming to completion + the
+        # __done sentinel proves the fix; removing the wrap raises
+        # NoActiveSqlTransaction on Postgres and this fails.
+        import json
+        resp = self.client.get(
+            f'/api/v1/vocab-releases/{self.release.pk}/snapshot/vocabulary/')
+        self.assertEqual(resp.status_code, 200)
+        content = b''.join(resp.streaming_content).decode()
+        lines = [l for l in content.strip().split('\n') if l]
+        self.assertTrue(lines, 'stream produced no lines')
+        self.assertTrue(
+            json.loads(lines[-1]).get('__done'),
+            'stream must end with the __done sentinel',
+        )
+
 
 class VocabSnapshotTest(_SmartBase):
     """Test /api/v1/vocab-releases/.../snapshot/<table>/ endpoints."""

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -14287,6 +14287,14 @@ class VocabSnapshotStreamTransactionTest(TransactionTestCase):
     the stream fails on Postgres if the fix is reverted.
     """
 
+    # TransactionTestCase truncates all tables on teardown and does NOT restore
+    # migration-seeded reference data (concept-zero, vocab rows, lookups, ...).
+    # This is currently the only non-TestCase DB test, and Django runs all
+    # TestCase subclasses first, so nothing DB-touching runs after this truncation
+    # — but serialize+restore removes the reliance on that ordering luck so a
+    # future TransactionTestCase can't inherit emptied reference tables.
+    serialized_rollback = True
+
     def setUp(self):
         from oauth2_provider.models import Application, AccessToken
         from django.utils import timezone as tz


### PR DESCRIPTION
Closes #342, #343. Both bugs were found + verified by the **EXACT vocab-mirror consumer e2e** (EXACT #250 ↔ #333/#334) — the consumer's `sync_vocab_mirror` only completes with both fixes.

## #342 — snapshot stream 500s in production (`NoActiveSqlTransaction`)
`VocabSnapshotView._stream_ndjson` opens a **server-side (named) cursor** (`DECLARE CURSOR`), which Postgres allows only inside a transaction. The streaming generator runs *after* the view returns, in Django's default autocommit → the first fetch raises `NoActiveSqlTransaction`. **Every snapshot download 500s in prod.**

Why CI is green today: Django `TestCase` wraps each test in a transaction, which masks the bug — so the existing `VocabSnapshotTest` cases pass despite it. This is a **prod-only** failure the unit tests structurally can't catch.

Fix: wrap the stream in `transaction.atomic()` (restores autocommit on exit; rolls back cleanly on early client disconnect).

## #343 — manifest `row_counts` ≠ streamed rows
`_publish_release` stored `row_counts = ` this run's per-table load counts, but the snapshot streams the **whole table** (which can hold rows from prior loads / `seed_omop_concepts` / metadata vocabularies). A consumer that cross-checks streamed rows against the manifest (EXACT's fail-closed completeness gate) therefore always mismatched (`loaded 8 rows != manifest row_count 5`).

Fix: `row_counts` = actual table `COUNT(*)` (reusing the count already computed for `checksums`).

## Verification
- `omop_core.tests.PublishReleaseTest.test_publish_release_creates_row` updated for the new contract (row_counts == real table count == checksums count) — **passes**.
- All **12 `VocabSnapshotTest`** cases pass with the atomic change — no regression.
- End-to-end: EXACT `sync_vocab_mirror` completed against real HemOnc vocab (14.6k concepts / 290k relationships / 137k ancestors) → READY → activate, only after these two fixes.

Related consumer-side fix: EXACT PR #268 (client offers `*/*` so DRF negotiation can't 406 the ndjson stream). Contract item #344 (vocab endpoints require `patient/*.read`; reference data has no system scope) is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)