### PR TITLE
fix: stop 401 interceptor from redirecting public org pages to login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ db.sqlite3.backup
 
 # Generated Synthea export artifacts
 /synthea_bc_*.json
+/synthea-bc.json
 
 # Large synthea CLI jar (not tracked)
 synthea-with-dependencies.jar

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -71,8 +71,12 @@ api.interceptors.response.use(
       }
 
       clearTokens();
-      if (!window.location.pathname.includes('/login')) {
-        const orgMatch = window.location.pathname.match(/^\/org\/([^/]+)/);
+      const path = window.location.pathname;
+      const isPublicPage =
+        ['/login', '/signup', '/forgot-password', '/accept-invite', '/accept-patient-invite', '/reset-password', '/auth/callback']
+          .some(p => path.includes(p));
+      if (!isPublicPage) {
+        const orgMatch = path.match(/^\/org\/([^/]+)/);
         window.location.href = orgMatch ? `/org/${orgMatch[1]}/login` : '/login';
       }
     }


### PR DESCRIPTION
## Summary

- The axios 401 response interceptor in `frontend/src/api/axios.ts` only checked for `/login` in the pathname before redirecting unauthenticated users. Public pages like `/org/:slug/signup`, `/org/:slug/forgot-password`, `/accept-invite`, `/accept-patient-invite`, and `/reset-password` were incorrectly redirected to the login page when `useAuth`'s initial `GET /user/` call returned 401.
- Extended the guard to recognize all public page paths so the interceptor skips the redirect on those routes.

## Test plan

- [ ] Visit `/org/synthea-fl/signup` in an incognito window — should render signup form, not redirect to login
- [ ] Visit `/org/synthea-fl/forgot-password` in incognito — should render forgot-password form
- [ ] Visit `/org/synthea-fl/login` in incognito — should still render login (unchanged behavior)
- [ ] Visit `/accept-invite?token=...` — should render invite acceptance page
- [ ] Authenticated user on a protected page whose session expires — should still redirect to login
- [x] All 153 frontend tests pass

Fixes #353

Generated with [Claude Code](https://claude.com/claude-code)