### PR TITLE
fix(vocab): accept system/*.read scope on vocab release/snapshot endpoints (#344)

### DIFF
--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -372,6 +372,7 @@ OAUTH2_PROVIDER = {
         'patient/*.write':  'Write all patient clinical data',
         'user/*.read':      'Read data on behalf of the current user',
         'user/*.write':     'Write data on behalf of the current user',
+        'system/*.read':    'Read reference/system data (vocabulary, concepts) — not patient-specific',
     },
     'DEFAULT_SCOPES': ['openid', 'patient/*.read'],
     'ACCESS_TOKEN_EXPIRE_SECONDS': 3600,

--- a/patient_portal/api/permissions.py
+++ b/patient_portal/api/permissions.py
@@ -41,6 +41,10 @@ def get_request_org(request):
 _SAFE_METHODS = frozenset(('GET', 'HEAD', 'OPTIONS'))
 _READ_SCOPES = frozenset(('patient/*.read', 'user/*.read'))
 _WRITE_SCOPES = frozenset(('patient/*.write', 'user/*.write'))
+# Vocabulary/concept data is reference (system) data, not patient data, so a
+# service consumer may read it with a system/reference scope in addition to the
+# patient/user read scopes. See healthkey-ai/promop#344.
+_VOCAB_READ_SCOPES = _READ_SCOPES | frozenset(('system/*.read',))
 
 
 class ScopedTokenPermission(BasePermission):
@@ -97,6 +101,30 @@ class ScopedTokenPermission(BasePermission):
         if request.method in _SAFE_METHODS:
             return bool(token_scopes & _READ_SCOPES)
         return bool(token_scopes & _WRITE_SCOPES)
+
+
+class VocabReadPermission(ScopedTokenPermission):
+    """Read permission for the vocabulary release + snapshot endpoints.
+
+    Vocabulary/concept data is reference (system) data, not patient data, so an
+    OAuth2 consumer may read it with a ``system/*.read`` scope in addition to the
+    patient/user read scopes the base class accepts (#344). All views using this
+    class are GET-only; service-token, staff, and partner/session auth are handled
+    by the base class exactly as before — only the OAuth2 safe-method read-scope
+    set is broadened here.
+    """
+
+    def has_permission(self, request, view):
+        token = request.auth
+        # OAuth2 bearer token on a safe method: accept the broadened read-scope
+        # set. Everything else (service token, staff, partner/session, expired
+        # tokens, non-safe methods) falls through to the base class unchanged.
+        if (token is not None and not isinstance(token, TokenClaims)
+                and hasattr(token, 'scope')
+                and request.method in _SAFE_METHODS
+                and timezone.now() < token.expires):
+            return bool(frozenset(token.scope.split()) & _VOCAB_READ_SCOPES)
+        return super().has_permission(request, view)
 
 
 class LabSyncPermission(ScopedTokenPermission):

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -60,7 +60,7 @@ import json
 import logging
 import re
 from io import StringIO
-from .permissions import ScopedTokenPermission, PatientCrudPermission, PatientSelfScopePermission, PatientDeletePermission, get_request_org, is_service_token
+from .permissions import ScopedTokenPermission, VocabReadPermission, PatientCrudPermission, PatientSelfScopePermission, PatientDeletePermission, get_request_org, is_service_token
 from .providers.base import TokenClaims
 from .serializers import (
     UserSerializer, PatientRecordSerializer, PatientListSerializer, ProvenanceRecordSerializer,
@@ -5221,7 +5221,7 @@ class InterchangeAgreementViewSet(viewsets.ReadOnlyModelViewSet):
 # ---------------------------------------------------------------------------
 
 @api_view(['GET'])
-@permission_classes([ScopedTokenPermission])
+@permission_classes([VocabReadPermission])
 def vocab_release_list(request):
     """Paginated list of published vocabulary releases (newest first)."""
     from omop_core.models import VocabularyRelease
@@ -5234,7 +5234,7 @@ def vocab_release_list(request):
 
 
 @api_view(['GET'])
-@permission_classes([ScopedTokenPermission])
+@permission_classes([VocabReadPermission])
 def vocab_release_detail(request, release_id):
     """Full manifest for a specific published vocabulary release, including checksums."""
     from omop_core.models import VocabularyRelease
@@ -5247,7 +5247,7 @@ def vocab_release_detail(request, release_id):
 
 
 @api_view(['GET'])
-@permission_classes([ScopedTokenPermission])
+@permission_classes([VocabReadPermission])
 def vocab_release_latest(request):
     """Latest published vocabulary release. Supports If-None-Match → 304."""
     from omop_core.services.vocab_release import get_latest_release
@@ -5288,7 +5288,7 @@ class VocabSnapshotView(APIView):
     Uses raw SQL ``row_to_json()`` to avoid ORM overhead on large tables.
     The table name is validated against a whitelist before interpolation.
     """
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [VocabReadPermission]
 
     # SECURITY: db_table values are hardcoded; never interpolate user input.
     ALLOWED_TABLES = {

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -14549,6 +14549,88 @@ class VocabSnapshotStreamTransactionTest(TransactionTestCase):
         )
 
 
+class VocabSystemScopeTest(_SmartBase):
+    """#344 — vocabulary release/snapshot endpoints are reference (system) data,
+    so they accept a `system/*.read` scope in addition to patient/user read
+    scopes, while still rejecting a token that carries no read scope."""
+
+    def setUp(self):
+        super().setUp()
+        from oauth2_provider.models import AccessToken
+        from omop_core.models import VocabularyRelease
+        from django.utils import timezone as tz
+        import datetime
+        self.release = VocabularyRelease.objects.create(
+            build_timestamp=tz.now(), status='published', published_at=tz.now(),
+            scope=['TEST'], vocab_versions={'TEST': '1.0'},
+            row_counts={'vocabulary': 1}, checksums={})
+
+        def _tok(token, scope):
+            return AccessToken.objects.create(
+                user=self.foundation_user, application=self.app, token=token,
+                expires=tz.now() + datetime.timedelta(hours=1), scope=scope)
+        _tok('sys-read-tok', 'system/*.read')
+        _tok('noread-tok', 'openid')
+        _tok('writeonly-tok', 'patient/*.write')
+
+    def tearDown(self):
+        super().tearDown()
+        from patient_portal.api.views import _vocab_version_cache
+        _vocab_version_cache['release_pk'] = None
+        _vocab_version_cache['map'] = None
+
+    def _client(self, token):
+        c = APIClient()
+        c.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
+        return c
+
+    def _urls(self):
+        rid = self.release.pk
+        return [
+            '/api/v1/vocab-releases/',
+            '/api/v1/vocab-releases/latest/',
+            f'/api/v1/vocab-releases/{rid}/',
+            f'/api/v1/vocab-releases/{rid}/snapshot/vocabulary/',
+        ]
+
+    def test_system_read_scope_allowed(self):
+        for url in self._urls():
+            resp = self._client('sys-read-tok').get(url)
+            self.assertEqual(resp.status_code, 200, f'{url}: {resp.status_code}')
+
+    def test_patient_read_scope_still_allowed(self):
+        for url in self._urls():
+            resp = self._client(self.read_token.token).get(url)
+            self.assertEqual(resp.status_code, 200, f'{url}: {resp.status_code}')
+
+    def test_token_without_read_scope_denied(self):
+        for url in self._urls():
+            resp = self._client('noread-tok').get(url)
+            self.assertEqual(resp.status_code, 403, f'{url}: {resp.status_code}')
+
+    def test_write_only_scope_denied_on_read(self):
+        for url in self._urls():
+            resp = self._client('writeonly-tok').get(url)
+            self.assertEqual(resp.status_code, 403, f'{url}: {resp.status_code}')
+
+    def test_expired_system_token_denied(self):
+        from oauth2_provider.models import AccessToken
+        from django.utils import timezone as tz
+        import datetime
+        AccessToken.objects.create(
+            user=self.foundation_user, application=self.app, token='sys-expired-tok',
+            expires=tz.now() - datetime.timedelta(seconds=1), scope='system/*.read')
+        resp = self._client('sys-expired-tok').get('/api/v1/vocab-releases/latest/')
+        self.assertIn(resp.status_code, (401, 403), resp.status_code)
+
+    def test_system_scope_denied_on_patient_data_endpoint(self):
+        # Isolation: system/*.read is a reference-data scope and must NOT grant
+        # access to patient data. Guards against a future refactor accidentally
+        # folding system/*.read into the base _READ_SCOPES.
+        resp = self._client('sys-read-tok').get('/api/v1/patient-records/')
+        self.assertEqual(resp.status_code, 403, resp.status_code)
+
+
 class VocabSnapshotTest(_SmartBase):
     """Test /api/v1/vocab-releases/.../snapshot/<table>/ endpoints."""
 


### PR DESCRIPTION
Closes #344 (promop-side / **Option 1**) — opening as **draft** for the cross-repo SoT direction call before staging cutover.

## Why
`vocab-releases/latest/`, `.../snapshot/{table}/` etc. required `patient/*.read` or `user/*.read`. But vocabulary/concept data is **reference (system) data, not patient data** — EXACT's vocab-mirror consumer uses `system/*.read` and currently gets **403**, forcing it to overload a *patient* scope for *non-patient* data. The #345 consumer e2e only passed via that workaround (forcing `patient/*.read` via env).

## What
- Register `system/*.read` in `OAUTH2_PROVIDER['SCOPES']` (grantable; **not** in `DEFAULT_SCOPES`).
- New `VocabReadPermission(ScopedTokenPermission)` — broadens **only** the OAuth2 safe-method read-scope set to include `system/*.read`, for the 4 GET-only vocab views. Service-token, staff, partner/session, expired-token, and all write paths are unchanged (deferred to the base class).
- Wire `vocab_release_list` / `_detail` / `_latest` + `VocabSnapshotView` to it.

## Scope isolation (verified)
`system/*.read` lives only in `_VOCAB_READ_SCOPES`, consumed only by `VocabReadPermission`. A token carrying only `system/*.read` is **denied** on any patient-data endpoint (base `_READ_SCOPES` unchanged). A regression test guards this.

## Tests — `VocabSystemScopeTest`
- `system/*.read` reads list/latest/detail/snapshot (was 403) ✓
- `patient/*.read` still works ✓
- no-read-scope (`openid`) → 403 ✓ · write-only → 403 ✓
- expired `system/*.read` → denied ✓
- `system/*.read` → **403 on `/api/v1/patient-records/`** (isolation) ✓

Full backend suite green (1116). Two independent reviews (fresh-context + codex) reconciled; no path found where a write succeeds, an expired token is accepted, or a no-read-scope token is accepted.

## Decision needed (cross-repo, cc @adamblum)
Confirm we take **Option 1 (promop accepts `system/*.read`)** vs Option 2 (EXACT switches its client to `patient/*.read`). This PR implements Option 1; happy to close if the call goes the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)