### PR TITLE
Fix analyst-invite accept URL (redirect to analytics never fired)

### DIFF
--- a/patient_portal/api/org_views.py
+++ b/patient_portal/api/org_views.py
@@ -40,8 +40,12 @@ class InvitationEmailError(Exception):
 
 
 def _send_invitation_email(invitation) -> None:
-    slug = invitation.org.slug
-    accept_url = f"{settings.APP_BASE_URL}/org/{slug}/accept-invite?token={invitation.token}"
+    # Bare /accept-invite path — matches the SPA route (App.tsx) and the emailed-link
+    # convention used by /reset-password and /accept-patient-invite. An org-scoped
+    # /org/<slug>/accept-invite path has no route and gets swallowed by the catch-all,
+    # so the accept page (and its post-accept redirect) never runs. The token alone
+    # identifies the invitation and its org; the slug is not needed here.
+    accept_url = f"{settings.APP_BASE_URL}/accept-invite?token={invitation.token}"
     subject = f"You've been invited to join {invitation.org.name} on PROMOP"
     body = (
         f"Hi,\n\n"

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -9088,6 +9088,35 @@ class OrgInvitationFlowTest(TestCase):
         self.assertEqual(invitation.redirect_url, 'https://analytics.healthkey.ai')
         self.assertEqual(grant.redirect_url, 'https://analytics.healthkey.ai')
 
+    def test_invite_then_confirm_analyst_returns_default_redirect(self):
+        """End-to-end: invite analyst (no redirect_url given) → confirm → the
+        confirm response carries the default analytics redirect."""
+        resp = self.client.post('/api/orgs/invite-org/invite/', {
+            'email': 'repro-analyst@example.com',
+            'role': 'analyst',
+        })
+        self.assertEqual(resp.status_code, 201)
+        invitation = OrgInvitation.objects.get(org=self.org, email='repro-analyst@example.com')
+        confirm = APIClient().post('/api/orgs/confirm-invitation/', {'token': invitation.token})
+        self.assertEqual(confirm.status_code, 200, confirm.data)
+        self.assertEqual(confirm.data.get('redirect_url'), 'https://analytics.healthkey.ai')
+
+    def test_invitation_email_links_to_bare_accept_invite_route(self):
+        """The emailed link must point at the SPA's /accept-invite route (which
+        runs the accept + redirect), not an org-scoped path that no route matches."""
+        from django.conf import settings
+        from django.core import mail
+        resp = self.client.post('/api/orgs/invite-org/invite/', {
+            'email': 'link-check@example.com',
+            'role': 'analyst',
+        })
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(len(mail.outbox), 1)
+        invitation = OrgInvitation.objects.get(org=self.org, email='link-check@example.com')
+        body = mail.outbox[0].body
+        self.assertIn(f'{settings.APP_BASE_URL}/accept-invite?token={invitation.token}', body)
+        self.assertNotIn(f'/org/{self.org.slug}/accept-invite', body)
+
     def test_invite_analyst_allows_custom_redirect_url(self):
         resp = self.client.post('/api/orgs/invite-org/invite/', {
             'email': 'analyst-custom@example.com',
@@ -14092,14 +14121,18 @@ class PatientInviteViaOrgTest(TestCase):
         pu = PatientUser.objects.get(identity=identity)
         self.assertEqual(pu.person_id, person.pk)
 
-    def test_invitation_email_uses_org_scoped_url(self):
+    def test_invitation_email_uses_bare_accept_invite_url(self):
+        # The link must hit the SPA's /accept-invite route (which runs the accept +
+        # post-accept redirect). An /org/<slug>/accept-invite path matches no route
+        # and is swallowed by the catch-all, so the accept page never renders.
         from django.core import mail
         self.client.post('/api/orgs/pt-inv-org/invite/', {
             'email': 'email-check@test.com',
             'role': 'doctor',
         })
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn('/org/pt-inv-org/accept-invite?token=', mail.outbox[0].body)
+        self.assertIn('/accept-invite?token=', mail.outbox[0].body)
+        self.assertNotIn('/org/pt-inv-org/accept-invite', mail.outbox[0].body)
 
 
 @override_settings(


### PR DESCRIPTION
## Symptom
Accepting an analyst invitation didn't redirect to the analytics site (`analytics.healthkey.ai`).

## Root cause
The invitation email built `{APP_BASE_URL}/org/<slug>/accept-invite?token=…`, but the SPA has **no `/org/:slug/accept-invite` route** — only bare `/accept-invite` (`App.tsx`). React Router's catch-all (`path="*"` → `Navigate to "/"`) swallowed the link and dropped the `?token`, so the accept page — and its post-accept redirect to the analyst's `redirect_url` (default `analytics.healthkey.ai`) — never ran.

The backend confirm flow was already correct: I verified end-to-end that invite (analyst, default redirect) → confirm returns `redirect_url = https://analytics.healthkey.ai`, and the frontend `AcceptInvite` already `window.location.assign`s it. The **only** defect was the emailed URL.

## Fix
Point the email at the bare `/accept-invite?token=…` route — matching the SPA route and the emailed-link convention already used by `/reset-password` and `/accept-patient-invite`. The token alone identifies the invitation and its org, so the slug isn't needed. This also fixes any already-sent... (future invites; in-flight ones with the old URL can be re-sent).

## Tests
- New `OrgInvitationFlowTest.test_invite_then_confirm_analyst_returns_default_redirect` (end-to-end) and `…_links_to_bare_accept_invite_route` (link format).
- Fixed `PatientInviteViaOrgTest` which had asserted the old org-scoped URL.
- Backend **1126 passing**, frontend **153 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)