### PR TITLE
Admin-initiated single-patient deletion (staff / org-scoped org_admin)

### DIFF
--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -830,6 +830,87 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
 
         return Response({'detail': 'Account and all associated data have been permanently deleted.'})
 
+    @action(detail=True, methods=['delete'], url_path='admin-delete',
+            permission_classes=[IsAuthenticated])
+    def admin_delete(self, request, pk=None):
+        """DELETE /api/v1/patient-records/{person_id}/admin-delete/ — administrator
+        deletion of a patient and all associated data (PHR-S FM TI.1.7, admin-initiated).
+
+        ``pk`` is the person_id (consistent with retrieve/export_fhir). Distinct from
+        the patient self-service ``me`` DELETE.
+
+        Authorization:
+          - staff / superuser: may delete any patient.
+          - org_admin: may delete only when EVERY org the patient has a record in is
+            one they administer (``get_admin_orgs``). This prevents cascade-deleting a
+            patient that is also owned by an org the caller does not administer.
+          - everyone else (doctors, analysts, patients): 403.
+
+        Requires body ``{"confirm": "DELETE"}``. The request is audited by
+        AuditLogMiddleware (record_delete); an explicit log line is also emitted.
+        """
+        from patient_portal.models import PatientUser
+        from omop_core.models import GroupAccess, Person
+
+        # Resolve by person_id directly — authorization here is the explicit
+        # staff/org-admin check below, which is stricter than mere view access
+        # (a viewer is not necessarily allowed to delete).
+        try:
+            person = Person.objects.get(person_id=pk)
+        except (Person.DoesNotExist, ValueError, TypeError):
+            return Response({'detail': 'Patient not found.'},
+                            status=status.HTTP_404_NOT_FOUND)
+
+        actor = request.user
+        is_staff_actor = bool(getattr(actor, 'is_staff', False))
+        if not is_staff_actor:
+            admin_org_ids = set(get_admin_orgs(actor).values_list('id', flat=True))
+            person_org_ids = set(
+                PatientRecord.objects.filter(person=person)
+                .values_list('organization_id', flat=True)
+            )
+            # Every org this patient belongs to must be one the caller administers;
+            # an org-less patient (empty set) is staff-only.
+            if not person_org_ids or not person_org_ids.issubset(admin_org_ids):
+                return Response(
+                    {'detail': 'You do not have permission to delete this patient.'},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+        if request.data.get('confirm') != 'DELETE':
+            return Response(
+                {'detail': 'Request body must include {"confirm": "DELETE"}.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        person_id = person.person_id
+        # Remove a purely-patient login alongside the record; keep an Identity that
+        # also holds provider access (GroupAccess) so we don't revoke a provider.
+        linked_identity = None
+        pu = PatientUser.objects.filter(person=person).select_related('identity').first()
+        if pu and not GroupAccess.objects.filter(identity=pu.identity).exists():
+            linked_identity = pu.identity
+
+        with transaction.atomic():
+            # EpisodeEvent has a bare integer FK not covered by CASCADE.
+            episode_ids = list(
+                Episode.objects.filter(person=person).values_list('episode_id', flat=True)
+            )
+            if episode_ids:
+                EpisodeEvent.objects.filter(episode_id__in=episode_ids).delete()
+            # Person delete cascades to OMOP rows, PatientRecord(s), PatientUser.
+            person.delete()
+            if linked_identity is not None:
+                linked_identity.delete()
+
+        logger.info(
+            'admin_patient_deleted person_id=%s by_identity_id=%s is_staff=%s',
+            person_id, actor.pk, is_staff_actor,
+        )
+        return Response(
+            {'detail': 'Patient and all associated data have been permanently deleted.'}
+        )
+
     @action(detail=True, methods=['get'], url_path='export-fhir',
             permission_classes=[ScopedTokenPermission, PatientSelfScopePermission])
     def export_fhir(self, request, pk=None):

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -14993,3 +14993,103 @@ class FieldProvenanceAPITest(TestCase):
             f'/api/v1/patient-records/{self.person.person_id}/field-provenance/hemoglobin_g_dl/',
         )
         self.assertIn(resp.status_code, [401, 403])
+
+
+class AdminDeletePatientTest(TestCase):
+    """Administrator single-patient deletion — staff (any org) or org_admin
+    (own org only), distinct from the patient self-service `me` DELETE."""
+
+    def setUp(self):
+        from omop_core.models import GroupAccess, PatientGroup
+        self.client = APIClient()
+        self.staff = _make_user('staff-del@test.com', is_staff=True)
+        self.org_a = _make_org('Org A Del', 'org-a-del')
+        self.org_b = _make_org('Org B Del', 'org-b-del')
+        self.admin_a = _make_user('admin-a-del@test.com')
+        GroupAccess.objects.create(identity=self.admin_a, org=self.org_a, role='org_admin')
+        self.doctor_a = _make_user('doctor-a-del@test.com')
+        self.group_a = PatientGroup.objects.create(
+            organization=self.org_a, name='Panel A', slug='panel-a')
+        # GroupAccess is org-XOR-group; a group panel grant sets group only.
+        GroupAccess.objects.create(identity=self.doctor_a, role='doctor', group=self.group_a)
+
+    def _make_patient(self, org, pid, in_group=None):
+        from omop_core.models import PatientGroupMembership
+        person = Person.objects.create(
+            person_id=pid, year_of_birth=1980, gender_source_value='unknown',
+            race_source_value='unknown', ethnicity_source_value='unknown',
+        )
+        PatientRecord.objects.create(person=person, organization=org)
+        if in_group is not None:
+            PatientGroupMembership.objects.create(group=in_group, person_id=person.person_id)
+        return person
+
+    def _url(self, person_id):
+        return f'/api/v1/patient-records/{person_id}/admin-delete/'
+
+    def _delete(self, user, person_id, body={'confirm': 'DELETE'}):
+        if user is not None:
+            self.client.force_authenticate(user=user)
+        return self.client.delete(self._url(person_id), body, format='json')
+
+    def test_staff_can_delete_any_patient(self):
+        p = self._make_patient(self.org_b, 700001)  # even another org
+        resp = self._delete(self.staff, 700001)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertFalse(Person.objects.filter(person_id=700001).exists())
+        self.assertFalse(PatientRecord.objects.filter(person_id=700001).exists())
+
+    def test_org_admin_can_delete_own_org_patient(self):
+        self._make_patient(self.org_a, 700002)
+        resp = self._delete(self.admin_a, 700002)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertFalse(Person.objects.filter(person_id=700002).exists())
+
+    def test_org_admin_cannot_delete_other_org_patient(self):
+        self._make_patient(self.org_b, 700003)
+        resp = self._delete(self.admin_a, 700003)
+        self.assertIn(resp.status_code, (403, 404))
+        self.assertTrue(Person.objects.filter(person_id=700003).exists())
+
+    def test_doctor_with_view_access_cannot_delete(self):
+        """A doctor who can *see* the patient (group panel) still can't delete —
+        view access is not delete authority."""
+        self._make_patient(self.org_a, 700004, in_group=self.group_a)
+        resp = self._delete(self.doctor_a, 700004)
+        self.assertEqual(resp.status_code, 403)
+        self.assertTrue(Person.objects.filter(person_id=700004).exists())
+
+    def test_requires_confirm(self):
+        self._make_patient(self.org_a, 700005)
+        resp = self._delete(self.staff, 700005, body={})
+        self.assertEqual(resp.status_code, 400)
+        self.assertTrue(Person.objects.filter(person_id=700005).exists())
+
+    def test_unauthenticated_denied(self):
+        self._make_patient(self.org_a, 700006)
+        resp = APIClient().delete(self._url(700006), {'confirm': 'DELETE'}, format='json')
+        self.assertIn(resp.status_code, (401, 403))
+        self.assertTrue(Person.objects.filter(person_id=700006).exists())
+
+    def test_deletes_patient_login_identity(self):
+        from patient_portal.models import PatientUser
+        p = self._make_patient(self.org_a, 700007)
+        pt_ident = Identity.objects.create_user(email='pt7-del@test.com', password=None)
+        PatientUser.objects.create(identity=pt_ident, person=p)
+        resp = self._delete(self.staff, 700007)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertFalse(Identity.objects.filter(pk=pt_ident.pk).exists())
+
+    def test_preserves_identity_that_also_has_provider_access(self):
+        """If the patient's linked identity is also a provider (holds GroupAccess),
+        delete the record but keep the identity so provider access isn't revoked."""
+        from omop_core.models import GroupAccess
+        from patient_portal.models import PatientUser
+        p = self._make_patient(self.org_a, 700008)
+        dual = _make_user('dual-del@test.com')
+        GroupAccess.objects.create(identity=dual, org=self.org_a, role='doctor')
+        PatientUser.objects.create(identity=dual, person=p)
+        resp = self._delete(self.staff, 700008)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertFalse(Person.objects.filter(person_id=700008).exists())
+        self.assertTrue(Identity.objects.filter(pk=dual.pk).exists())


### PR DESCRIPTION
Adds an administrator erasure path for a single patient, distinct from the patient self-service `me` DELETE.

## Endpoint
`DELETE /api/v1/patient-records/{person_id}/admin-delete/`, body `{"confirm": "DELETE"}`.

## Authorization (org-scoped, as agreed)
- **staff / superuser** — any patient.
- **org_admin** — only when **every** org the patient has a record in is one they administer (`get_admin_orgs`). This blocks an org_admin from cascade-deleting a patient co-owned by an org they don't administer.
- **doctors / analysts / patients** — 403. View access ≠ delete authority; patients delete themselves via `me`.

## Deletion semantics
Deletes the `Person` (cascading OMOP rows, `PatientRecord`, `PatientUser`) and the patient's login `Identity` — but **preserves** an Identity that also holds provider `GroupAccess`, so a dual patient+provider account keeps its provider access. Audited by `AuditLogMiddleware` (`record_delete`) plus an explicit log line.

## Tests — `AdminDeletePatientTest` (8)
staff any-org · org_admin own-org · org_admin other-org denied · doctor-with-view-access denied (403, not just 404) · confirm required · unauthenticated denied · patient login identity removed · dual patient+provider identity preserved. Full backend suite **1134 passing**.

## Note
Backend + permission model only (as requested). No frontend delete button yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)