### PR TITLE
Resolve legacy /org/<slug>/accept-invite links (pending invites → password prompt)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -93,6 +93,18 @@ describe("Org-scoped routes", () => {
     expect(screen.getByText("ORG_SIGNUP")).toBeInTheDocument();
   });
 
+  it("renders AcceptInvite at the bare /accept-invite route", () => {
+    mockUseAuth.mockReturnValue({ ...baseAuth, currentUser: null });
+    renderAt("/accept-invite?token=abc");
+    expect(screen.getByText("ACCEPT_INVITE")).toBeInTheDocument();
+  });
+
+  it("renders AcceptInvite at the legacy /org/:slug/accept-invite alias (older emails)", () => {
+    mockUseAuth.mockReturnValue({ ...baseAuth, currentUser: null });
+    renderAt("/org/acme/accept-invite?token=abc");
+    expect(screen.getByText("ACCEPT_INVITE")).toBeInTheDocument();
+  });
+
   it("renders PatientHome at /org/:slug for an authenticated patient with matching org", () => {
     mockUseAuth.mockReturnValue({
       ...baseAuth,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,7 +67,7 @@ function AppRoutes() {
 
   const publicPaths = ['/accept-invite', '/accept-patient-invite', '/reset-password', '/login', '/auth/callback'];
   const isPublicPath = (path: string) =>
-    publicPaths.includes(path) || /^\/org\/[^/]+\/(login|signup|forgot-password)$/.test(path);
+    publicPaths.includes(path) || /^\/org\/[^/]+\/(login|signup|forgot-password|accept-invite)$/.test(path);
   if (authLoading && !isPublicPath(location.pathname)) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -83,7 +83,7 @@ function AppRoutes() {
   // link, invite acceptance) are exempt so those flows can still complete.
   const forceChangeExemptPaths = ['/reset-password', '/accept-invite', '/accept-patient-invite'];
   const isForceChangeExempt = (path: string) =>
-    forceChangeExemptPaths.includes(path) || /^\/org\/[^/]+\/(login|signup|forgot-password)$/.test(path);
+    forceChangeExemptPaths.includes(path) || /^\/org\/[^/]+\/(login|signup|forgot-password|accept-invite)$/.test(path);
   if (
     currentUser?.must_change_password &&
     !isForceChangeExempt(location.pathname)
@@ -106,6 +106,9 @@ function AppRoutes() {
       <Route path="/login" element={<Login />} />
       <Route path="/auth/callback" element={<AuthCallback />} />
       <Route path="/accept-invite" element={<AcceptInvite />} />
+      {/* Alias for invitation emails sent before the link was un-nested — the
+          token in the query string carries everything; the slug is cosmetic. */}
+      <Route path="/org/:slug/accept-invite" element={<AcceptInvite />} />
       <Route path="/accept-patient-invite" element={<AcceptPatientInvite />} />
       <Route path="/reset-password" element={<ResetPassword />} />
 


### PR DESCRIPTION
## Symptom
An invitee clicks their invite email and is dropped on the login page (`analytics.healthkey.ai/login`) with **no accept page and no password prompt** — especially for invites that were **already pending**.

## Root cause
#363 un-nested the invitation email link to bare `/accept-invite`, but the SPA has **no `/org/:slug/accept-invite` route**. Every invite emailed *before* #363 — i.e. all currently-pending invites — still links to `/org/<slug>/accept-invite`, which matches no route, hits the catch-all (`path="*"` → `Navigate to "/"`), and bounces the invitee to login. The new password-prompt flow (#365) never runs because the accept page never loads.

## Fix
Add `/org/:slug/accept-invite` as an **alias** to the same `AcceptInvite` component. The token in the query string carries everything (the slug is cosmetic), so both the bare and legacy links now load the accept page — which looks up the invite and prompts for a password when needed. The path is added to the public / force-change-exempt patterns.

No re-sending of emails required: the links people already have now work.

## Tests
`App.test.tsx`: `AcceptInvite` renders at both `/accept-invite` and the legacy `/org/:slug/accept-invite`. Frontend **158 passing**.

## Deploy note
For the password prompt to appear, #363 + #365 + this must be deployed to the environment serving the invite links (`APP_BASE_URL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)