### PR TITLE
Always show the password field on the invite accept page

### DIFF
--- a/frontend/src/components/Auth/AcceptInvite.test.tsx
+++ b/frontend/src/components/Auth/AcceptInvite.test.tsx
@@ -23,16 +23,12 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-// Default lookup: an existing account (no password step) so the plain accept-flow
-// tests reach the Accept button directly.
-const lookup = (over = {}) =>
-  mockAxiosGet.mockResolvedValue({
-    data: { email: 'a@b.com', org_name: 'Acme Oncology', role: 'Analyst', needs_password: false, ...over },
-  });
-
 beforeEach(() => {
   vi.clearAllMocks();
-  lookup();
+  // Best-effort lookup for org/role display.
+  mockAxiosGet.mockResolvedValue({
+    data: { email: 'a@b.com', org_name: 'Acme Oncology', role: 'Analyst' },
+  });
 });
 
 const withToken = () =>
@@ -40,7 +36,11 @@ const withToken = () =>
 const withoutToken = () =>
   mockUseSearchParams.mockReturnValue([new URLSearchParams(''), vi.fn()]);
 
-const acceptButton = () => screen.findByRole('button', { name: /accept invitation/i });
+const acceptButton = () => screen.getByRole('button', { name: /accept & set password/i });
+const type = async (u: ReturnType<typeof userEvent.setup>, pw: string, confirm = pw) => {
+  await u.type(screen.getByLabelText('Password'), pw);
+  await u.type(screen.getByLabelText(/confirm password/i), confirm);
+};
 
 describe('AcceptInvite', () => {
   it('shows error message immediately when no token is in the URL', () => {
@@ -49,41 +49,31 @@ describe('AcceptInvite', () => {
     expect(screen.getByText(/No invitation token found/i)).toBeInTheDocument();
   });
 
-  it('shows the Accept button (with org/role) after the invitation loads', async () => {
+  it('always shows the password fields when a token is present', () => {
     withToken();
     render(<AcceptInviteModule.default />);
-    expect(await acceptButton()).toBeInTheDocument();
-    expect(screen.getByText(/Acme Oncology/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+    expect(acceptButton()).toBeInTheDocument();
   });
 
-  it('shows an error when the invitation lookup fails', async () => {
+  it('still shows the password fields when the org lookup fails', async () => {
     withToken();
-    mockAxiosGet.mockRejectedValueOnce({ response: { data: { error: 'Invitation has expired.' } } });
+    mockAxiosGet.mockRejectedValueOnce(new Error('endpoint missing'));
     render(<AcceptInviteModule.default />);
-    await waitFor(() => expect(screen.getByText('Invitation has expired.')).toBeInTheDocument());
+    // Field is present regardless of the lookup result.
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    await waitFor(() => expect(mockAxiosGet).toHaveBeenCalled());
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
   });
 
-  it('calls confirm-invitation with just the token when no password is needed', async () => {
+  it('submits the token and password to confirm-invitation on accept', async () => {
     withToken();
     mockAxiosPost.mockResolvedValueOnce({ data: { detail: 'Done.' } });
     render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
-    await user.click(await acceptButton());
-    await waitFor(() =>
-      expect(mockAxiosPost).toHaveBeenCalledWith('/orgs/confirm-invitation/', { token: 'abc123def456' })
-    );
-  });
-
-  it('collects and submits a password when the invite needs one', async () => {
-    withToken();
-    lookup({ needs_password: true });
-    mockAxiosPost.mockResolvedValueOnce({ data: { detail: 'Done.' } });
-    render(<AcceptInviteModule.default />);
-    const user = userEvent.setup();
-    await acceptButton();
-    await user.type(screen.getByLabelText('Password'), 'Str0ng-pass-42');
-    await user.type(screen.getByLabelText(/confirm password/i), 'Str0ng-pass-42');
-    await user.click(await acceptButton());
+    await type(user, 'Str0ng-pass-42');
+    await user.click(acceptButton());
     await waitFor(() =>
       expect(mockAxiosPost).toHaveBeenCalledWith('/orgs/confirm-invitation/', {
         token: 'abc123def456',
@@ -94,40 +84,22 @@ describe('AcceptInvite', () => {
 
   it('blocks submission when the password is too short and does not call the API', async () => {
     withToken();
-    lookup({ needs_password: true });
     render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
-    await acceptButton();
-    await user.type(screen.getByLabelText('Password'), 'short');
-    await user.type(screen.getByLabelText(/confirm password/i), 'short');
-    await user.click(await acceptButton());
+    await type(user, 'short');
+    await user.click(acceptButton());
     expect(await screen.findByText(/at least 8 characters/i)).toBeInTheDocument();
     expect(mockAxiosPost).not.toHaveBeenCalled();
   });
 
   it('blocks submission when the passwords do not match', async () => {
     withToken();
-    lookup({ needs_password: true });
     render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
-    await acceptButton();
-    await user.type(screen.getByLabelText('Password'), 'Str0ng-pass-42');
-    await user.type(screen.getByLabelText(/confirm password/i), 'Different-99');
-    await user.click(await acceptButton());
+    await type(user, 'Str0ng-pass-42', 'Different-99');
+    await user.click(acceptButton());
     expect(await screen.findByText(/do not match/i)).toBeInTheDocument();
     expect(mockAxiosPost).not.toHaveBeenCalled();
-  });
-
-  it('shows success message and Go to PROMOP button after a successful accept', async () => {
-    withToken();
-    mockAxiosPost.mockResolvedValueOnce({ data: { detail: 'Access granted to Acme Oncology.' } });
-    render(<AcceptInviteModule.default />);
-    const user = userEvent.setup();
-    await user.click(await acceptButton());
-    await waitFor(() =>
-      expect(screen.getByText('Access granted to Acme Oncology.')).toBeInTheDocument()
-    );
-    expect(screen.getByRole('button', { name: /go to promop/i })).toBeInTheDocument();
   });
 
   it('redirects to the supplied analyst site after a successful accept', async () => {
@@ -140,7 +112,8 @@ describe('AcceptInvite', () => {
     });
     render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
-    await user.click(await acceptButton());
+    await type(user, 'Str0ng-pass-42');
+    await user.click(acceptButton());
     await waitFor(() => screen.getByRole('link', { name: /continue/i }));
     expect(screen.getByRole('link', { name: /continue/i })).toHaveAttribute(
       'href',
@@ -148,12 +121,13 @@ describe('AcceptInvite', () => {
     );
   });
 
-  it('navigates to / when Go to PROMOP is clicked after success', async () => {
+  it('shows success + Go to PROMOP when there is no redirect', async () => {
     withToken();
     mockAxiosPost.mockResolvedValueOnce({ data: { detail: 'Done.' } });
     render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
-    await user.click(await acceptButton());
+    await type(user, 'Str0ng-pass-42');
+    await user.click(acceptButton());
     await waitFor(() => screen.getByRole('button', { name: /go to promop/i }));
     await user.click(screen.getByRole('button', { name: /go to promop/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/');
@@ -166,7 +140,8 @@ describe('AcceptInvite', () => {
     });
     render(<AcceptInviteModule.default />);
     const user = userEvent.setup();
-    await user.click(await acceptButton());
+    await type(user, 'Str0ng-pass-42');
+    await user.click(acceptButton());
     await waitFor(() =>
       expect(screen.getByText('Invitation has expired.')).toBeInTheDocument()
     );

--- a/frontend/src/components/Auth/AcceptInvite.tsx
+++ b/frontend/src/components/Auth/AcceptInvite.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { publicApi } from '@/api/publicAxios';
 
-type State = 'loading' | 'ready' | 'success' | 'error';
+type State = 'ready' | 'success' | 'error';
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -24,7 +24,6 @@ interface InviteInfo {
   email: string;
   org_name: string;
   role: string;
-  needs_password: boolean;
 }
 
 export default function AcceptInvite() {
@@ -32,57 +31,47 @@ export default function AcceptInvite() {
   const navigate = useNavigate();
   const token = params.get('token') ?? '';
 
-  const [state, setState] = useState<State>('loading');
-  const [message, setMessage] = useState('');
+  const [state, setState] = useState<State>(token ? 'ready' : 'error');
+  const [message, setMessage] = useState(token ? '' : 'No invitation token found in this link.');
   const [info, setInfo] = useState<InviteInfo | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [redirectUrl, setRedirectUrl] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
+  // Best-effort: fetch the org/role for display. The password field is shown
+  // regardless — the backend validates and sets it for a new invitee and
+  // ignores it for an account that already has one — so a lookup miss (older
+  // backend, transient error) never hides the field.
   useEffect(() => {
-    if (!token) {
-      setState('error');
-      setMessage('No invitation token found in this link.');
-      return;
-    }
+    if (!token) return;
     let cancelled = false;
-    (async () => {
-      try {
-        const res = await publicApi.get('/v1/orgs/invitation-lookup/', { params: { token } });
-        if (cancelled) return;
-        setInfo(res.data);
-        setState('ready');
-      } catch (err: unknown) {
-        if (cancelled) return;
-        setMessage(apiError(err, 'This invitation link is invalid or has expired.'));
-        setState('error');
-      }
-    })();
+    publicApi
+      .get('/v1/orgs/invitation-lookup/', { params: { token } })
+      .then((res) => {
+        if (!cancelled) setInfo(res.data);
+      })
+      .catch(() => {
+        /* non-fatal — still show the accept form */
+      });
     return () => {
       cancelled = true;
     };
   }, [token]);
 
-  const needsPassword = !!info?.needs_password;
-
   const handleAccept = async () => {
-    if (needsPassword) {
-      if (password.length < MIN_PASSWORD_LENGTH) {
-        setMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
-        return;
-      }
-      if (password !== confirmPassword) {
-        setMessage('Passwords do not match.');
-        return;
-      }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (password !== confirmPassword) {
+      setMessage('Passwords do not match.');
+      return;
     }
     setMessage('');
     setConfirming(true);
     try {
-      const payload: Record<string, string> = { token };
-      if (needsPassword) payload.password = password;
-      const res = await publicApi.post('/orgs/confirm-invitation/', payload);
+      const res = await publicApi.post('/orgs/confirm-invitation/', { token, password });
       setMessage(res.data.detail ?? 'Invitation accepted.');
       setRedirectUrl(res.data.redirect_url ?? '');
       setState('success');
@@ -102,45 +91,39 @@ export default function AcceptInvite() {
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-8 max-w-md w-full space-y-6">
         <h1 className="text-2xl font-semibold text-gray-900">Accept Invitation</h1>
 
-        {state === 'loading' && (
-          <p className="text-sm text-gray-600">Loading your invitation…</p>
-        )}
-
-        {state === 'ready' && info && (
+        {state === 'ready' && (
           <>
             <p className="text-sm text-gray-600">
-              You've been invited to join <span className="font-medium">{info.org_name}</span> as
-              a {info.role}.
+              {info
+                ? <>You've been invited to join <span className="font-medium">{info.org_name}</span> as a {info.role}. Set a password to finish setting up your account.</>
+                : 'Set a password to finish setting up your account.'}
             </p>
-            {needsPassword && (
-              <div className="space-y-4">
-                <p className="text-sm text-gray-600">Choose a password to finish setting up your account.</p>
-                <div>
-                  <label htmlFor="password" className="block text-sm font-medium text-gray-700">Password</label>
-                  <input
-                    id="password"
-                    type="password"
-                    autoComplete="new-password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    placeholder="At least 8 characters"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="confirm-password" className="block text-sm font-medium text-gray-700">Confirm password</label>
-                  <input
-                    id="confirm-password"
-                    type="password"
-                    autoComplete="new-password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    placeholder="Re-enter your password"
-                  />
-                </div>
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="password" className="block text-sm font-medium text-gray-700">Password</label>
+                <input
+                  id="password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  placeholder="At least 8 characters"
+                />
               </div>
-            )}
+              <div>
+                <label htmlFor="confirm-password" className="block text-sm font-medium text-gray-700">Confirm password</label>
+                <input
+                  id="confirm-password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  placeholder="Re-enter your password"
+                />
+              </div>
+            </div>
             {message && (
               <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-3">{message}</p>
             )}
@@ -149,7 +132,7 @@ export default function AcceptInvite() {
               disabled={confirming}
               className="w-full py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
             >
-              {confirming ? 'Accepting…' : 'Accept Invitation'}
+              {confirming ? 'Accepting…' : 'Accept & set password'}
             </button>
           </>
         )}


### PR DESCRIPTION
## Symptom
Accepting an org invite on promop-staging shows **no password field** — it just accepts and redirects to `analytics.healthkey.ai`, where the invitee has no credential to sign in with.

## Cause
#365 gated the password field behind the `invitation-lookup` endpoint's `needs_password` flag. If that lookup returns `false` or the call fails (e.g. the backend build serving the page predates the endpoint), the field is hidden and there's no way to set a password before the redirect.

## Fix
Show the password field **unconditionally** whenever a token is present. The lookup is now best-effort — used only to show the org/role name — and its failure no longer hides the field.

The **backend is unchanged** and already handles both cases safely: it validates and sets the password for a new/placeholder invitee, and ignores it for an account that already has one (never overwrites an existing credential).

## Result
Invite link → promop-staging accept page **with a password field** → set password → redirect to analytics and sign in with it.

## Tests
`AcceptInvite`: field present with a token and even when the lookup fails; token+password submitted to confirm; short/mismatch blocked; redirect on success. Frontend **156 passing**.

> Note: this must be deployed to promop-staging (which serves `APP_BASE_URL`) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)