### PR TITLE
Require 12-char passwords to match the analytics (PRism) app

### DIFF
--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -212,6 +212,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        # 12 chars — matches the analytics (PRism) app, which shares this identity
+        # table, so a credential set in promop always satisfies the analytics bar.
+        'OPTIONS': {'min_length': 12},
     },
     {
         'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',

--- a/frontend/src/components/Auth/AcceptInvite.test.tsx
+++ b/frontend/src/components/Auth/AcceptInvite.test.tsx
@@ -88,7 +88,7 @@ describe('AcceptInvite', () => {
     const user = userEvent.setup();
     await type(user, 'short');
     await user.click(acceptButton());
-    expect(await screen.findByText(/at least 8 characters/i)).toBeInTheDocument();
+    expect(await screen.findByText(/at least 12 characters/i)).toBeInTheDocument();
     expect(mockAxiosPost).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/Auth/AcceptInvite.tsx
+++ b/frontend/src/components/Auth/AcceptInvite.tsx
@@ -4,7 +4,7 @@ import { publicApi } from '@/api/publicAxios';
 
 type State = 'ready' | 'success' | 'error';
 
-const MIN_PASSWORD_LENGTH = 8;
+const MIN_PASSWORD_LENGTH = 12;
 
 // Module-local (not exported): the file must export only the component so
 // react-refresh/only-export-components / Fast Refresh stays happy.
@@ -108,7 +108,7 @@ export default function AcceptInvite() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  placeholder="At least 8 characters"
+                  placeholder="At least 12 characters"
                 />
               </div>
               <div>

--- a/frontend/src/components/Auth/AcceptPatientInvite.test.tsx
+++ b/frontend/src/components/Auth/AcceptPatientInvite.test.tsx
@@ -54,8 +54,8 @@ describe('AcceptPatientInvite', () => {
     render(<AcceptPatientInvite />);
     await screen.findByDisplayValue('rae@example.com');
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText('Password'), 'sup3rsecret');
-    await user.type(screen.getByLabelText('Confirm password'), 'different1');
+    await user.type(screen.getByLabelText('Password'), 'sup3r-secret-pass');
+    await user.type(screen.getByLabelText('Confirm password'), 'different-pass-99');
     await user.click(screen.getByRole('button', { name: /create account/i }));
     expect(await screen.findByText(/passwords do not match/i)).toBeInTheDocument();
     expect(mockPost).not.toHaveBeenCalled();
@@ -68,13 +68,13 @@ describe('AcceptPatientInvite', () => {
     render(<AcceptPatientInvite />);
     await screen.findByDisplayValue('rae@example.com');
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText('Password'), 'sup3rsecret');
-    await user.type(screen.getByLabelText('Confirm password'), 'sup3rsecret');
+    await user.type(screen.getByLabelText('Password'), 'sup3r-secret-pass');
+    await user.type(screen.getByLabelText('Confirm password'), 'sup3r-secret-pass');
     await user.click(screen.getByRole('button', { name: /create account/i }));
     await waitFor(() =>
       expect(mockPost).toHaveBeenCalledWith('/v1/patient-invitations/accept/', {
         token: 'a'.repeat(64),
-        password: 'sup3rsecret',
+        password: 'sup3r-secret-pass',
       })
     );
     expect(await screen.findByText(/account created/i)).toBeInTheDocument();

--- a/frontend/src/components/Auth/AcceptPatientInvite.tsx
+++ b/frontend/src/components/Auth/AcceptPatientInvite.tsx
@@ -4,7 +4,7 @@ import { publicApi } from '@/api/publicAxios';
 
 type State = 'loading' | 'ready' | 'success' | 'error';
 
-const MIN_PASSWORD_LENGTH = 8;
+const MIN_PASSWORD_LENGTH = 12;
 
 function errorMessage(err: unknown, fallback: string): string {
   if (err && typeof err === 'object' && 'response' in err) {
@@ -118,7 +118,7 @@ export default function AcceptPatientInvite() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  placeholder="At least 8 characters"
+                  placeholder="At least 12 characters"
                 />
               </div>
               <div>

--- a/frontend/src/components/Auth/ChangePassword.tsx
+++ b/frontend/src/components/Auth/ChangePassword.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import api from '@/api/axios';
 
-const MIN_PASSWORD_LENGTH = 8;
+const MIN_PASSWORD_LENGTH = 12;
 
 function errorMessage(err: unknown, fallback: string): string {
   if (err && typeof err === 'object' && 'response' in err) {
@@ -84,7 +84,7 @@ export default function ChangePassword({ onChanged, onLogout }: Props) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-              placeholder="At least 8 characters"
+              placeholder="At least 12 characters"
             />
           </div>
           <div>

--- a/frontend/src/components/Auth/OrgSignup.test.tsx
+++ b/frontend/src/components/Auth/OrgSignup.test.tsx
@@ -77,7 +77,7 @@ describe("OrgSignup", () => {
     fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "short" } });
     fireEvent.click(screen.getByRole("button", { name: "Create account" }));
 
-    expect(screen.getByText("Password must be at least 8 characters.")).toBeInTheDocument();
+    expect(screen.getByText("Password must be at least 12 characters.")).toBeInTheDocument();
     expect(mockPost).not.toHaveBeenCalled();
   });
 
@@ -92,8 +92,8 @@ describe("OrgSignup", () => {
     });
 
     fireEvent.change(screen.getByLabelText("Email"), { target: { value: "test@test.com" } });
-    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "password123" } });
-    fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "password456" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "password-alpha-1" } });
+    fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "password-bravo-2" } });
     fireEvent.click(screen.getByRole("button", { name: "Create account" }));
 
     expect(screen.getByText("Passwords do not match.")).toBeInTheDocument();
@@ -114,8 +114,8 @@ describe("OrgSignup", () => {
     });
 
     fireEvent.change(screen.getByLabelText("Email"), { target: { value: "exists@test.com" } });
-    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "password123" } });
-    fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "password123" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "password-alpha-1" } });
+    fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "password-alpha-1" } });
     fireEvent.click(screen.getByRole("button", { name: "Create account" }));
 
     await waitFor(() => {
@@ -137,8 +137,8 @@ describe("OrgSignup", () => {
     });
 
     fireEvent.change(screen.getByLabelText("Email"), { target: { value: "test@test.com" } });
-    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "12345678" } });
-    fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "12345678" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "123456789012" } });
+    fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "123456789012" } });
     fireEvent.click(screen.getByRole("button", { name: "Create account" }));
 
     await waitFor(() => {

--- a/frontend/src/components/Auth/OrgSignup.tsx
+++ b/frontend/src/components/Auth/OrgSignup.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { publicApi } from "@/api/publicAxios";
 
-const MIN_PASSWORD_LENGTH = 8;
+const MIN_PASSWORD_LENGTH = 12;
 
 export default function OrgSignup() {
   const { slug } = useParams<{ slug: string }>();
@@ -187,7 +187,7 @@ export default function OrgSignup() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   className="block w-full rounded-md border border-input px-3 py-2 pr-10 shadow-sm placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  placeholder="At least 8 characters"
+                  placeholder="At least 12 characters"
                 />
                 <button
                   type="button"
@@ -204,7 +204,7 @@ export default function OrgSignup() {
                 </button>
               </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                Must be at least 8 characters, not a common password, and not entirely numeric.
+                Must be at least 12 characters, not a common password, and not entirely numeric.
               </p>
             </div>
 

--- a/frontend/src/components/Auth/ResetPassword.tsx
+++ b/frontend/src/components/Auth/ResetPassword.tsx
@@ -4,7 +4,7 @@ import { publicApi } from '@/api/publicAxios';
 
 type State = 'ready' | 'success' | 'error';
 
-const MIN_PASSWORD_LENGTH = 8;
+const MIN_PASSWORD_LENGTH = 12;
 
 function errorMessage(err: unknown, fallback: string): string {
   if (err && typeof err === 'object' && 'response' in err) {
@@ -67,7 +67,7 @@ export default function ResetPassword() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                placeholder="At least 8 characters"
+                placeholder="At least 12 characters"
               />
             </div>
             <div>

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -11044,14 +11044,14 @@ class PatientInvitationTest(TestCase):
         inv = self._create_invite()
         resp = APIClient().post(
             '/api/v1/patient-invitations/accept/',
-            {'token': inv.token, 'password': 'sup3rsecret'}, format='json',
+            {'token': inv.token, 'password': 'sup3r-secret-pass'}, format='json',
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
         inv.refresh_from_db()
         self.assertEqual(inv.status, 'accepted')
         pu = PatientUser.objects.get(person=self.person)
         self.assertTrue(pu.identity.has_usable_password())
-        self.assertTrue(pu.identity.check_password('sup3rsecret'))
+        self.assertTrue(pu.identity.check_password('sup3r-secret-pass'))
         # The new account is a first-class patient.
         self.assertEqual(patient_person_for(pu.identity), self.person)
 
@@ -11066,7 +11066,7 @@ class PatientInvitationTest(TestCase):
     def test_accept_rejects_unknown_token(self):
         resp = APIClient().post(
             '/api/v1/patient-invitations/accept/',
-            {'token': 'a' * 64, 'password': 'sup3rsecret'}, format='json',
+            {'token': 'a' * 64, 'password': 'sup3r-secret-pass'}, format='json',
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -11076,13 +11076,13 @@ class PatientInvitationTest(TestCase):
         inv.save(update_fields=['expires_at'])
         resp = APIClient().post(
             '/api/v1/patient-invitations/accept/',
-            {'token': inv.token, 'password': 'sup3rsecret'}, format='json',
+            {'token': inv.token, 'password': 'sup3r-secret-pass'}, format='json',
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_accept_cannot_be_replayed(self):
         inv = self._create_invite()
-        body = {'token': inv.token, 'password': 'sup3rsecret'}
+        body = {'token': inv.token, 'password': 'sup3r-secret-pass'}
         APIClient().post('/api/v1/patient-invitations/accept/', body, format='json')
         resp = APIClient().post('/api/v1/patient-invitations/accept/', body, format='json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
@@ -11118,11 +11118,11 @@ class PatientInvitationTest(TestCase):
         inv = self._create_invite('rae@example.com')
         resp = APIClient().post(
             '/api/v1/patient-invitations/accept/',
-            {'token': inv.token, 'password': 'sup3rsecret'}, format='json',
+            {'token': inv.token, 'password': 'sup3r-secret-pass'}, format='json',
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
         placeholder.refresh_from_db()
-        self.assertTrue(placeholder.check_password('sup3rsecret'))
+        self.assertTrue(placeholder.check_password('sup3r-secret-pass'))
         self.assertEqual(PatientUser.objects.get(person=self.person).identity, placeholder)
 
     # --- Email editable (lock-in) ---
@@ -11166,7 +11166,7 @@ class PatientSignupTest(TestCase):
     def test_staff_signup_local_creates_account_in_org(self):
         from patient_portal.models import PatientUser
         resp = self._staff().post(self.SIGNUP_URL, {
-            'org': 'acme-onc', 'email': 'newpt@example.com', 'password': 'sup3rsecret',
+            'org': 'acme-onc', 'email': 'newpt@example.com', 'password': 'sup3r-secret-pass',
             'given_name': 'New', 'family_name': 'Patient',
         }, format='json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
@@ -11174,7 +11174,7 @@ class PatientSignupTest(TestCase):
         pid = resp.data['person_id']
         pu = PatientUser.objects.get(person__person_id=pid)
         self.assertTrue(pu.identity.has_usable_password())
-        self.assertTrue(pu.identity.check_password('sup3rsecret'))
+        self.assertTrue(pu.identity.check_password('sup3r-secret-pass'))
         record = PatientRecord.objects.get(person__person_id=pid)
         self.assertEqual(record.organization, self.org)
         self.assertEqual(record.email, 'newpt@example.com')
@@ -11216,7 +11216,7 @@ class PatientSignupTest(TestCase):
 
     def test_staff_signup_requires_org_when_none_bound(self):
         resp = self._staff().post(self.SIGNUP_URL, {
-            'email': 'noorg@example.com', 'password': 'sup3rsecret',
+            'email': 'noorg@example.com', 'password': 'sup3r-secret-pass',
         }, format='json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -11224,7 +11224,7 @@ class PatientSignupTest(TestCase):
         c = APIClient()
         c.force_authenticate(user=self.patient)
         resp = c.post(self.SIGNUP_URL, {
-            'org': 'acme-onc', 'email': 'x@example.com', 'password': 'sup3rsecret',
+            'org': 'acme-onc', 'email': 'x@example.com', 'password': 'sup3r-secret-pass',
         }, format='json')
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 


### PR DESCRIPTION
## Problem
The invite accept page let an invitee set an **8-char** password, but the analytics app (`analytics.healthkey.ai` / PRism) — which **shares this identity table** — enforces a **12-char minimum**. So a password that promop accepted could be too weak for the analytics bar, and the credential the invitee just set wouldn't clear analytics' own signup/validation path.

## Fix
Raise promop's `MinimumLengthValidator` to `min_length: 12`, matching PRism. promop already shares PRism's `CommonPassword` + `Numeric` validators (and additionally has `UserAttributeSimilarity`), so the two apps' password rules now agree — any credential created in promop satisfies the analytics standard.

**Frontend:** bump the client-side minimum + helper/placeholder text to 12 across every password-set form — accept-invite, accept-patient-invite, reset-password, change-password, org-signup — so the client no longer accepts a value the backend will reject.

## Scope / safety
- Global validator change, but it only affects **new password-sets**. Existing accounts are unaffected — login doesn't re-validate password rules, so no one is locked out.
- All password-set flows (invite accept, patient-invite accept, signup, reset, change-password) now enforce 12.

## Tests
Updated password fixtures to ≥12 chars (backend `PatientInvitationTest` / `PatientSignupTest`; frontend `AcceptInvite` / `AcceptPatientInvite` / `OrgSignup`). Full suites: **backend 1140**, **frontend 156**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)