### PR TITLE
docs(adr): ADR 0002 — OMOP-native therapy TYPES (drug-class matching)

### DIFF
--- a/docs/adr/0002-omop-therapy-types.md
+++ b/docs/adr/0002-omop-therapy-types.md
@@ -1,0 +1,169 @@
+# ADR 0002 — OMOP-native therapy *types* (drug-class matching)
+
+**Status:** Draft / Proposed (for cross-repo discussion — do not implement past Phase 0 until accepted).
+**Extends:** [ADR 0001 — promop is the vocabulary source of truth](0001-vocabulary-source-of-truth.md).
+**Deciders:** promop, EXACT/CB, SoC maintainers.
+**Context repos:** promop (owner, vocab SoT + patient derivation), EXACT (`~/exact`, trial authoring/CB + matcher), SoC (`~/soc`).
+
+---
+
+## Context
+
+Trial therapy criteria match a patient along three levels: **regimen**, **drug component**, and
+**drug-class "type"** (e.g. proteasome inhibitor, IMiD, anti-CD38, BCL-2 inhibitor).
+
+- **Regimen + component** already went OMOP-native (EXACT epic #4447; matcher flip #228,
+  flag `EXACT_OMOP_THERAPY`): the patient's component **concept_ids** are pre-expanded by
+  promop (`therapy_component_ids`) and matched by direct concept_id overlap; EXACT does not
+  translate them.
+- **Types are still CB-only.** `TherapyComponentCategory` was **intentionally NOT OMOP-mapped**
+  (EXACT ADR 0001 decision A, #4502): the trial `omop_therapy_types_*` columns and their GIN
+  index were **removed** (EXACT migration 0017). EXACT maps the patient's component concept_ids
+  → CB category codes via a local flat table `ComponentCategoryOmopLookup`, built from CB's own
+  `TherapyComponentCategoryConnection`. This is the **"CB exception"** ADR 0001 §Decision.3
+  flags as scheduled for retirement.
+
+The recorded rationale for keeping types CB-only was: *"a patient never carries a class concept,
+so an `omop_therapy_types_*` column could never overlap."* That is a statement about the current
+**patient payload** (component ids, no derived class ids) — **not** about OMOP lacking class
+concepts. Two facts now change the calculus:
+
+1. **OMOP class concepts exist, at the right granularity.** A curated, SME-reviewed
+   category→class-concept crosswalk (the "CB therapy → OMOP concept_id" workbook) maps most CB
+   categories to fine-grained HemOnc / ATC **class concepts** — see *Coverage* below.
+2. **promop now stamps therapy-id provenance + release_id** ([#362](https://github.com/healthkey-ai/promop/pull/362)),
+   giving the release-consistency primitive any pre-expanded, release-derived projection needs.
+
+## Decision (proposed)
+
+Adopt **OMOP-native therapy-type matching** via **HemOnc/ATC class-concept-id overlap** — the
+same mechanism as components — for the subset of type criteria that map **losslessly** to a class
+concept. Keep the rest on the CB-category path (**hybrid**, not a big-bang cutover). Specifically:
+
+1. **Identifier space = HemOnc/ATC drug-class concept_ids** (e.g. Proteasome inhibitor `35807295`),
+   NOT the 5 coarse HemOnc `Has X tx` relationship ids (they encode regimen→component *roles*,
+   are far coarser than CB's ~30 category criteria, and would lose criterion meaning).
+2. **Matching semantics** follow the existing type matcher: **`required` = any-overlap (OR)**,
+   **`excluded` = any-hit** — *not* the regimen-level superset rule.
+3. **No locally-minted concepts** (ADR 0001 §Integrity). Class concepts are licensed HemOnc/ATC.
+4. **Gated by a vocabulary spike (Phase 0):** the *patient-side* `component-concept → class-concept`
+   derivation must be proven against a pinned promop release before any code cutover.
+5. **Fail-closed:** an unmapped/lossy `required` type criterion must **never** degrade to an empty
+   requirement (which would silently drop the eligibility gate) — it stays legacy or fails closed.
+
+## Coverage (from the SME-reviewed crosswalk)
+
+Of ~30 CB category/class criteria:
+
+- **~20 map to a fine-grained HemOnc/ATC class concept, SME-confirmed** — *lossless in
+  concept-id space, re-authorable:* proteasome inhibitor (`35807295`), IMiD (`35807403`),
+  anti-CD38 (`35807345`), anti-CD20 (`35807389`), anti-SLAMF7 (`35807363`), BCL-2 inhibitor
+  (`35807456`), XPO1 inhibitor (`35807438`), CAR-T (`35807448`), ADC (`35807221`), bispecific
+  antibody (`35807364`), mTOR (`35807369`), PI3K (`35807303`), HDAC (`947794`, ATC), anthracycline
+  (`35807214`), alkylating agent (`35807238`), immunotherapy (`35807189`), targeted therapy
+  (`912163`), monoclonal antibody (`21603754`, ATC), bisphosphonate (`35807233`), RANKL inhibitor
+  (`35807351`).
+- **~10 have no clean OMOP class concept — stay legacy/CB:** broad umbrellas (chemotherapy,
+  hormonal_therapy, supportive_therapy, corticosteroid) and non-drug modalities (radiotherapy,
+  surgery, stem_cell_transplant), plus non-therapeutic (diagnostic_tool, high-risk-smoldering).
+
+The crosswalk covers the **trial-authoring** side (category → class concept). The **patient**
+side (`component concept_id → class concept_id`) is a *different* mapping that must be derived
+from promop's graph and is the subject of Phase 0.
+
+---
+
+## Epic — phased, cross-repo, with gates
+
+Mirrors the component cutover (#4447 → #228). Each phase is a ticket set; **do not start a phase
+before its predecessor's gate passes.**
+
+### Phase 0 — Vocab spike (PROMOP, BLOCKING GATE, no prod change)
+- **P0.1** For each of the ~20 mapped class concepts, resolve its member drugs
+  (`class concept → component/ingredient concept_ids`) by traversing promop's `concept_relationship`
+  and/or `concept_ancestor` on a **pinned** release. Do **not** assume `concept_ancestor` carries
+  the non-hierarchical HemOnc class edges — verify.
+- **P0.2** Invert to the patient direction (`component concept_id → class concept_ids`) and
+  **audit precision/recall per active criterion** against EXACT's current
+  `component_concept_id → CB category` lookup (`ComponentCategoryOmopLookup`), **preserving
+  exclusions**.
+- **P0.3** Publish the definitive **lossless vs legacy** split (subset of the ~20 that pass).
+- **Gate:** no downstream phase until P0.2 meets an agreed precision/recall bar. *This is the one
+  unproven dependency; if the edges don't exist on the pinned release, the cutover stalls even
+  with a perfect CB mapping.*
+
+### Phase 1 — CB / EXACT authoring (trial + mapping)
+- **P1.1** Load the category→OMOP-class-concept crosswalk into the CB vocab model — add
+  `TherapyComponentCategory.omop_concept_id(s)` (analogue of `Therapy.omop_concept_id` /
+  `TherapyComponent.omop_concept_id`).
+- **P1.2** Mark the ~10 unmapped categories **`no_omop` explicitly**, so they never resolve to
+  `[]` (fail-closed guard starts here).
+- **P1.3** CB owns the upstream conversion (ADR 0001 §Governance).
+
+### Phase 2 — PROMOP (patient-side class projection + release-stamp)
+- **P2.1** At refresh, derive per-line **therapy-class concept_ids** for the patient from the
+  line's component concept_ids, using the P0-proven edges. Add a read-model field
+  (`*_component_class_ids` / `therapy_class_ids`), **release-stamped via the [#362]
+  provenance/release_id machinery** (origin + `release_id`).
+- **P2.2** Expose it read-only on the patient serializer (like `*_component_ids`); add to
+  `read_only_fields`.
+- **Alternative (lighter):** do not pre-expand — instead **guarantee the `component→class` edges
+  are in the vocab-snapshot corpus** so EXACT derives types by traversing its own release-pinned
+  mirror. Same ADR 0001 tension (pre-expand vs consumer-traverse); pre-expand is symmetric with
+  components and centralizes the graph walk in the SoT.
+
+### Phase 3 — EXACT (schema + mapper + consumer + matcher)
+- **P3.1 (schema, prerequisite):** restore `omop_therapy_types_required/excluded` + GIN index
+  (removed in EXACT migration 0017).
+- **P3.2 (mapper):** `therapy_concept_mapper.build_omop_columns` emits `omop_therapy_types_*` from
+  the CB category→class-concept mapping (today explicitly skipped).
+- **P3.3 (consumer):** `therapy_graph.derive_component_and_type_values` returns `type_values` as
+  **class concept_ids** in OMOP mode — from the promop field (P2.1) or the mirror-traversal
+  (P2.2 alternative). Legacy mode unchanged.
+- **P3.4 (matcher):** overlap patient class concept_ids vs `omop_therapy_types_*` —
+  `required` = any-overlap, `excluded` = any-hit — behind a **new flag `EXACT_OMOP_THERAPY_TYPES`**,
+  dependent on component-id availability, dual-mode like `EXACT_OMOP_THERAPY`. One shared patient
+  type-derivation used by **both** queryset and matcher.
+- **P3.5 (safety):** assert **equal `release_id`** patient↔trial (ADR 0001 cross-side skew rule;
+  #362 provides it). A `required` criterion mapping to `[]` must be treated fail-closed, never
+  dropped.
+
+### Phase 4 — Validation & flip
+- **P4.1** Shadow-compare OMOP-type matching alongside CB-category matching on real trials/patients;
+  compare **both `required` and `excluded`** outcomes; zero divergence on the covered subset.
+- **P4.2** Coverage validation under the fail-closed rule.
+- **P4.3** Hybrid flip per environment (like #228): OMOP types for the lossless subset, CB
+  categories retained for the ~10 legacy criteria.
+
+---
+
+## Consequences
+
+- **CB exception partially retired.** The type/category dimension moves to OMOP concept-id space
+  for the lossless subset; the ~10 non-mappable criteria (umbrellas + non-drug modalities) keep
+  the CB exception. Full retirement remains blocked "by HemOnc coverage alone" until those are
+  re-authored or dropped (ADR 0001 §CB exception).
+- **Hybrid matcher** (OMOP types + CB types) for the transition; a single derivation seam and one
+  new flag keep it mechanically small (the profile switch already exists for components).
+- **Release consistency becomes load-bearing for types too** — the patient class projection and
+  the trial class columns must pin the same release; #362 is the primitive.
+
+## Risks
+
+1. **Phase 0 is the real gate.** If `concept_relationship`/`concept_ancestor` do not cleanly give
+   `component → class` for the ~20 classes on the pinned release, the patient side can't be
+   derived and the cutover stalls regardless of the CB mapping.
+2. **Fail-open on partial coverage.** The current EXACT mapper drops unmapped values; for types a
+   dropped `required` criterion silently removes an eligibility gate. Must be fail-closed (P1.2,
+   P3.5).
+3. **Granularity/semantic drift.** A CB category may be finer/coarser than its nearest class
+   concept; only criteria that are provably lossless (P0.2) may flip — the rest stay legacy.
+
+## Links
+
+- ADR 0001 (vocab SoT), promop #362 (therapy_ids_provenance + release_id), promop #344/#359
+  (`system/*.read` scope for the vocab mirror).
+- EXACT: epic #4447 (component OMOP cutover), #228 (matcher flip), #4502 / EXACT-ADR-0001-decision-A
+  (types kept CB-only), migration 0017 (removed `omop_therapy_types_*`), `therapy_concept_mapper.py`,
+  `therapy_graph.py`, `component_category_lookup.py`, `therapy_match_profile.py`.
+- Source data: the SME-reviewed "CB therapy → OMOP concept_id" crosswalk workbook.

--- a/docs/adr/0002-omop-therapy-types.md
+++ b/docs/adr/0002-omop-therapy-types.md
@@ -1,6 +1,8 @@
 # ADR 0002 — OMOP-native therapy *types* (drug-class matching)
 
-**Status:** Draft / Proposed (for cross-repo discussion — do not implement past Phase 0 until accepted).
+**Status:** Draft / Proposed (for cross-repo discussion). Feasibility gate (Phase 0) is
+**preliminarily green** — the `component → class` derivation exists and is queryable; the
+remaining validation is a rollout-time shadow-compare, not a blocking upfront study.
 **Extends:** [ADR 0001 — promop is the vocabulary source of truth](0001-vocabulary-source-of-truth.md).
 **Deciders:** promop, EXACT/CB, SoC maintainers.
 **Context repos:** promop (owner, vocab SoT + patient derivation), EXACT (`~/exact`, trial authoring/CB + matcher), SoC (`~/soc`).
@@ -46,10 +48,20 @@ concept. Keep the rest on the CB-category path (**hybrid**, not a big-bang cutov
 2. **Matching semantics** follow the existing type matcher: **`required` = any-overlap (OR)**,
    **`excluded` = any-hit** — *not* the regimen-level superset rule.
 3. **No locally-minted concepts** (ADR 0001 §Integrity). Class concepts are licensed HemOnc/ATC.
-4. **Gated by a vocabulary spike (Phase 0):** the *patient-side* `component-concept → class-concept`
-   derivation must be proven against a pinned promop release before any code cutover.
-5. **Fail-closed:** an unmapped/lossy `required` type criterion must **never** degrade to an empty
-   requirement (which would silently drop the eligibility gate) — it stays legacy or fails closed.
+4. **promop pre-expands the patient's type values** and ships them to consumers, symmetric with
+   components. The patient's per-line **class concept_ids** are derived once in the SoT (the
+   `component concept → class concept` graph walk), release-stamped, and consumed as-is by EXACT —
+   EXACT does **not** traverse the vocabulary to derive types, and does **not** need the type edges
+   in its snapshot mirror. This is the ADR 0001 pre-expand stance, applied to types.
+5. **Fail-closed is the one hard invariant.** An unmapped/lossy `required` type criterion must
+   **never** degrade to an empty requirement (which would silently drop the eligibility gate) — it
+   stays legacy or fails closed. This is enforced by engineering (explicit `no_omop` marking +
+   matcher guard), not by an upfront comparison study.
+6. **Feasibility, not agreement, was the open question — and it is answered.** The spike proved the
+   derivation exists (Phase 0, green). We do **not** gate on the new OMOP mapping matching the old
+   CB lookup: the SME-curated OMOP crosswalk is the intended *replacement* for the legacy CB
+   taxonomy, so divergence is not by itself a defect. Any new-vs-old comparison is a rollout-time
+   **shadow-compare** (Phase 4), informational, not a blocking gate.
 
 ## Coverage (from the SME-reviewed crosswalk)
 
@@ -78,19 +90,20 @@ from promop's graph and is the subject of Phase 0.
 Mirrors the component cutover (#4447 → #228). Each phase is a ticket set; **do not start a phase
 before its predecessor's gate passes.**
 
-### Phase 0 — Vocab spike (PROMOP, BLOCKING GATE, no prod change)
-- **P0.1** For each of the ~20 mapped class concepts, resolve its member drugs
+### Phase 0 — Vocab feasibility spike (PROMOP, no prod change) — **DONE, green**
+- **P0.1** For each mapped class concept, resolve its member drugs
   (`class concept → component/ingredient concept_ids`) by traversing promop's `concept_relationship`
-  and/or `concept_ancestor` on a **pinned** release. Do **not** assume `concept_ancestor` carries
-  the non-hierarchical HemOnc class edges — verify.
-- **P0.2** Invert to the patient direction (`component concept_id → class concept_ids`) and
-  **audit precision/recall per active criterion** against EXACT's current
-  `component_concept_id → CB category` lookup (`ComponentCategoryOmopLookup`), **preserving
-  exclusions**.
-- **P0.3** Publish the definitive **lossless vs legacy** split (subset of the ~20 that pass).
-- **Gate:** no downstream phase until P0.2 meets an agreed precision/recall bar. *This is the one
-  unproven dependency; if the edges don't exist on the pinned release, the cutover stalls even
-  with a perfect CB mapping.*
+  on a **pinned** release. Do **not** assume `concept_ancestor` carries the non-hierarchical HemOnc
+  class edges — verify. *(Result: the edge is `Component --[Is a]--> Component Class`; see below.)*
+- **P0.2** Confirm the **corpus scope** on the pinned release includes what the patient payload
+  actually contains (promop emits HemOnc Component ids → single `Is a` hop; no RxNorm bridge needed
+  for those). Decide the ~2 ATC classes with no HemOnc `Is a` graph.
+- **P0.3** Publish the definitive **lossless vs legacy** split (the subset that resolves).
+- **What Phase 0 is NOT:** it is *not* a precision/recall study against the legacy
+  `ComponentCategoryOmopLookup`. The legacy CB lookup is the thing being *replaced*; requiring the
+  new mapping to reproduce it is backwards. New-vs-old comparison lives in Phase 4 (shadow-compare,
+  informational). The only Phase-0 gate is **"does the derivation exist and cover the intended
+  classes?"** — and it does.
 
 #### Phase 0 — preliminary spike results (run against a local Athena/HemOnc export)
 
@@ -137,8 +150,9 @@ queryable. Key findings:
   must confirm the corpus scope on the *pinned release* includes what the patient payload actually
   contains.
 
-Still to close before the gate is fully green: transitive-closure precision/recall **per active CB
-criterion** vs the current `ComponentCategoryOmopLookup`, and a decision on the 2 ATC classes.
+Still to close (housekeeping, not gates): confirm corpus scope on the *pinned* production release
+(this run used a local Athena/HemOnc export), and decide the 2 ATC classes (keep legacy, or find a
+HemOnc equivalent). Neither blocks starting the engineering.
 
 ### Phase 1 — CB / EXACT authoring (trial + mapping)
 - **P1.1** Load the category→OMOP-class-concept crosswalk into the CB vocab model — add
@@ -148,17 +162,25 @@ criterion** vs the current `ComponentCategoryOmopLookup`, and a decision on the 
   `[]` (fail-closed guard starts here).
 - **P1.3** CB owns the upstream conversion (ADR 0001 §Governance).
 
-### Phase 2 — PROMOP (patient-side class projection + release-stamp)
-- **P2.1** At refresh, derive per-line **therapy-class concept_ids** for the patient from the
-  line's component concept_ids, using the P0-proven edges. Add a read-model field
-  (`*_component_class_ids` / `therapy_class_ids`), **release-stamped via the [#362]
-  provenance/release_id machinery** (origin + `release_id`).
-- **P2.2** Expose it read-only on the patient serializer (like `*_component_ids`); add to
-  `read_only_fields`.
-- **Alternative (lighter):** do not pre-expand — instead **guarantee the `component→class` edges
-  are in the vocab-snapshot corpus** so EXACT derives types by traversing its own release-pinned
-  mirror. Same ADR 0001 tension (pre-expand vs consumer-traverse); pre-expand is symmetric with
-  components and centralizes the graph walk in the SoT.
+### Phase 2 — PROMOP (patient-side class projection + release-stamp) — **the substantive promop work**
+
+This is where the patient's type values come from. **Decided: promop pre-expands and ships them**
+(not EXACT-side mirror traversal) — symmetric with `*_component_ids`, centralizes the graph walk
+in the SoT, and removes any need for EXACT to carry the type edges in its mirror. Directly
+continues the #362 (provenance) / #270 (component expansion) patterns and is **self-contained**
+(no CB/EXACT dependency) — buildable now.
+
+- **P2.1** At refresh, derive per-line **therapy-class concept_ids** for the patient from the line's
+  component concept_ids via the P0-proven `Component --[Is a]--> Component Class` closure. Add a
+  read-model field (`*_component_class_ids` + aggregate `therapy_class_ids`), mirroring the
+  `*_component_ids` shape. Reuse `_expand_component_ids`' output as the input set (it already carries
+  the HemOnc Component ids → single `Is a` hop).
+- **P2.2** **Release-stamp** the derivation via the [#362] provenance/release_id machinery so a
+  consumer can assert patient↔trial release equality.
+- **P2.3** Expose read-only on the patient serializer (like `*_component_ids`); add to
+  `read_only_fields`. Cover both derivation paths (Episodes `_get_treatment_data` and inferred-LOT
+  `_apply_inferred_lots`), matching the component-id test structure in
+  `tests/test_therapy_component_ids.py`.
 
 ### Phase 3 — EXACT (schema + mapper + consumer + matcher)
 - **P3.1 (schema, prerequisite):** restore `omop_therapy_types_required/excluded` + GIN index
@@ -166,8 +188,8 @@ criterion** vs the current `ComponentCategoryOmopLookup`, and a decision on the 
 - **P3.2 (mapper):** `therapy_concept_mapper.build_omop_columns` emits `omop_therapy_types_*` from
   the CB category→class-concept mapping (today explicitly skipped).
 - **P3.3 (consumer):** `therapy_graph.derive_component_and_type_values` returns `type_values` as
-  **class concept_ids** in OMOP mode — from the promop field (P2.1) or the mirror-traversal
-  (P2.2 alternative). Legacy mode unchanged.
+  **class concept_ids** in OMOP mode — read **as-is from the promop patient field (P2.1)**, no local
+  traversal, no mirror dependency for types. Legacy mode unchanged.
 - **P3.4 (matcher):** overlap patient class concept_ids vs `omop_therapy_types_*` —
   `required` = any-overlap, `excluded` = any-hit — behind a **new flag `EXACT_OMOP_THERAPY_TYPES`**,
   dependent on component-id availability, dual-mode like `EXACT_OMOP_THERAPY`. One shared patient
@@ -176,10 +198,14 @@ criterion** vs the current `ComponentCategoryOmopLookup`, and a decision on the 
   #362 provides it). A `required` criterion mapping to `[]` must be treated fail-closed, never
   dropped.
 
-### Phase 4 — Validation & flip
+### Phase 4 — Shadow-compare & flip
 - **P4.1** Shadow-compare OMOP-type matching alongside CB-category matching on real trials/patients;
-  compare **both `required` and `excluded`** outcomes; zero divergence on the covered subset.
-- **P4.2** Coverage validation under the fail-closed rule.
+  log **both `required` and `excluded`** divergences. This is the *only* place new-vs-old is
+  compared — and it is **informational**: divergence surfaces cases for SME review (the OMOP mapping
+  may be the more-correct one), it does not by itself block the flip. **Exclusion divergences are
+  the exception** — any case where OMOP matching would *weaken* an exclusion (fail-open) is a hard
+  stop until resolved.
+- **P4.2** Coverage validation under the fail-closed rule (no `required` criterion resolves to `[]`).
 - **P4.3** Hybrid flip per environment (like #228): OMOP types for the lossless subset, CB
   categories retained for the ~10 legacy criteria.
 
@@ -198,14 +224,16 @@ criterion** vs the current `ComponentCategoryOmopLookup`, and a decision on the 
 
 ## Risks
 
-1. **Phase 0 is the real gate.** If `concept_relationship`/`concept_ancestor` do not cleanly give
-   `component → class` for the ~20 classes on the pinned release, the patient side can't be
-   derived and the cutover stalls regardless of the CB mapping.
-2. **Fail-open on partial coverage.** The current EXACT mapper drops unmapped values; for types a
-   dropped `required` criterion silently removes an eligibility gate. Must be fail-closed (P1.2,
-   P3.5).
+1. **Fail-open on partial coverage — the primary risk.** The current EXACT mapper drops unmapped
+   values; for types a dropped `required` criterion silently removes an eligibility gate, and a
+   dropped `excluded` value silently weakens an exclusion. Must be fail-closed (P1.2, P3.5) and is
+   the one hard stop in the Phase 4 shadow-compare.
+2. **Corpus-scope drift on the pinned release.** Feasibility is proven on a local export; the
+   pinned production release must actually carry the `Component --Is a--> Component Class` edges for
+   the classes patients present. Confirmed as P0.2 housekeeping before the promop derivation ships.
 3. **Granularity/semantic drift.** A CB category may be finer/coarser than its nearest class
-   concept; only criteria that are provably lossless (P0.2) may flip — the rest stay legacy.
+   concept; only the lossless subset flips — the rest stay legacy. Divergence here is surfaced (not
+   gated) by the Phase 4 shadow-compare for SME adjudication.
 
 ## Links
 

--- a/docs/adr/0002-omop-therapy-types.md
+++ b/docs/adr/0002-omop-therapy-types.md
@@ -3,10 +3,16 @@
 **Status:** **Accepted 2026-08-03** (cross-repo: promop / CancerBot / EXACT). Supersedes the
 "types are not OMOP-mapped" decision (**EXACT ADR 0001 decision A / CB #4502**): its premise —
 *"a patient never carries a class concept"* — no longer holds now that promop pre-expands the
-patient's class concept_ids (`*_component_class_ids`, [#370]). Feasibility gate (Phase 0) is
+patient's class concept_ids (`*_therapy_type_ids`, [#370]). Feasibility gate (Phase 0) is
 **green** — the `component → class` derivation exists and is queryable; remaining validation is a
-rollout-time shadow-compare, not a blocking upfront study. Implementation tracked in the epic
-[healthkey-ai/exact#283]: CB-side cancerbot#4631–4634, EXACT-side exact#284–288.
+rollout-time shadow-compare, not a blocking upfront study.
+
+**Implementation status** (epic [healthkey-ai/exact#283]): Phase 2 (promop patient projection)
+**merged** — [#370]. Phase 1 (CancerBot: cancerbot#4631–4634 → PRs #4635–#4638) and Phase 3 (EXACT:
+exact#284/#285 → PRs #289/#290) **in review**. Phase 4 pending: release-assert (exact#286),
+shadow-compare (exact#287), hybrid flip (exact#288). The patient field was named `*_therapy_type_ids`
+(not `*_component_class_ids`) to match the trial `omop_therapy_types_*` columns and the matcher's
+"TYPE" wording.
 **Extends:** [ADR 0001 — promop is the vocabulary source of truth](0001-vocabulary-source-of-truth.md).
 **Deciders:** promop, EXACT/CB, SoC maintainers.
 **Context repos:** promop (owner, vocab SoT + patient derivation), EXACT (`~/exact`, trial authoring/CB + matcher), SoC (`~/soc`).
@@ -174,11 +180,13 @@ in the SoT, and removes any need for EXACT to carry the type edges in its mirror
 continues the #362 (provenance) / #270 (component expansion) patterns and is **self-contained**
 (no CB/EXACT dependency) — buildable now.
 
-- **P2.1** At refresh, derive per-line **therapy-class concept_ids** for the patient from the line's
-  component concept_ids via the P0-proven `Component --[Is a]--> Component Class` closure. Add a
-  read-model field (`*_component_class_ids` + aggregate `therapy_class_ids`), mirroring the
-  `*_component_ids` shape. Reuse `_expand_component_ids`' output as the input set (it already carries
-  the HemOnc Component ids → single `Is a` hop).
+- **P2.1** At refresh, derive per-line **therapy-type (drug-class) concept_ids** for the patient from
+  the line's component concept_ids via the P0-proven `Component --[Is a]--> Component Class` closure.
+  Add a read-model field (`first/second/later_therapy_type_ids` + aggregate `therapy_type_ids`),
+  mirroring the `*_component_ids` shape. Reuse `_expand_component_ids`' output as the input set (it
+  already carries the HemOnc Component ids → single `Is a` hop). *(Internal derivation helper stays
+  `_expand_class_ids` — "class" is the OMOP Component Class concept level; "type" is the field/match
+  level.)*
 - **P2.2** **Release-stamp** the derivation via the [#362] provenance/release_id machinery so a
   consumer can assert patient↔trial release equality.
 - **P2.3** Expose read-only on the patient serializer (like `*_component_ids`); add to

--- a/docs/adr/0002-omop-therapy-types.md
+++ b/docs/adr/0002-omop-therapy-types.md
@@ -1,8 +1,12 @@
 # ADR 0002 — OMOP-native therapy *types* (drug-class matching)
 
-**Status:** Draft / Proposed (for cross-repo discussion). Feasibility gate (Phase 0) is
-**preliminarily green** — the `component → class` derivation exists and is queryable; the
-remaining validation is a rollout-time shadow-compare, not a blocking upfront study.
+**Status:** **Accepted 2026-08-03** (cross-repo: promop / CancerBot / EXACT). Supersedes the
+"types are not OMOP-mapped" decision (**EXACT ADR 0001 decision A / CB #4502**): its premise —
+*"a patient never carries a class concept"* — no longer holds now that promop pre-expands the
+patient's class concept_ids (`*_component_class_ids`, [#370]). Feasibility gate (Phase 0) is
+**green** — the `component → class` derivation exists and is queryable; remaining validation is a
+rollout-time shadow-compare, not a blocking upfront study. Implementation tracked in the epic
+[healthkey-ai/exact#283]: CB-side cancerbot#4631–4634, EXACT-side exact#284–288.
 **Extends:** [ADR 0001 — promop is the vocabulary source of truth](0001-vocabulary-source-of-truth.md).
 **Deciders:** promop, EXACT/CB, SoC maintainers.
 **Context repos:** promop (owner, vocab SoT + patient derivation), EXACT (`~/exact`, trial authoring/CB + matcher), SoC (`~/soc`).

--- a/docs/adr/0002-omop-therapy-types.md
+++ b/docs/adr/0002-omop-therapy-types.md
@@ -92,6 +92,54 @@ before its predecessor's gate passes.**
   unproven dependency; if the edges don't exist on the pinned release, the cutover stalls even
   with a perfect CB mapping.*
 
+#### Phase 0 — preliminary spike results (run against a local Athena/HemOnc export)
+
+**Gate is preliminarily GREEN for the HemOnc subset.** The `component → class` edge exists and is
+queryable. Key findings:
+
+- **Mechanism = `HemOnc Component --[Is a]--> HemOnc Component Class` (transitive), NOT
+  `concept_ancestor`.** The drug-class concepts are `concept_class_id='Component Class'`. A
+  concept's class membership is the `Is a` edge (e.g. `Bortezomib (35802928) —Is a→ Proteasome
+  inhibitor (35807295)`; multiple memberships are normal). `concept_ancestor` is the *wrong* tool
+  here: a class's descendants are the ~170 **regimens** that *use* the class, not its member drugs.
+- **18/18 HemOnc target classes resolve to drug members** via the transitive `Is a` closure
+  (member concepts are HemOnc Component / sub-Component-Class). Drug-member counts:
+
+  | class | concept_id | drug members (transitive) |
+  |---|---|---|
+  | Targeted therapy | 912163 | 277 |
+  | Immunotherapy | 35807189 | 83 |
+  | Alkylating agent | 35807238 | 39 |
+  | Anti-CD20 | 35807389 | 16 |
+  | ADC | 35807221 | 15 |
+  | Bispecific antibody | 35807364 | 15 |
+  | Anthracycline | 35807214 | 12 |
+  | CAR-T | 35807448 | 8 |
+  | PI3K inhibitor | 35807303 | 8 |
+  | Anti-CD38 | 35807345 | 6 |
+  | Bisphosphonate | 35807233 | 6 |
+  | Proteasome inhibitor | 35807295 | 4 |
+  | mTOR inhibitor | 35807369 | 4 |
+  | IMiD | 35807403 | 3 |
+  | Anti-SLAMF7 / BCL-2 / XPO1 / RANKL | 35807363/…456/…438/…351 | 1 each |
+
+- **Cleaner than expected:** promop's existing `_expand_component_ids` already carries **HemOnc
+  Component** concept_ids in the patient component set, so the class derivation is a **single `Is a`
+  hop** from data promop already emits (no extra RxNorm bridge needed for those).
+- **Two known gaps → stay legacy (or need a HemOnc equivalent):** the **2 ATC** target classes
+  (`HDAC inhibitor 947794`, `Monoclonal antibody 21603754`) have **0 usable descendants** in this
+  export's `concept_ancestor`; they don't participate in the HemOnc `Is a` graph. (`monoclonal
+  antibody` has HemOnc sub-classes — anti-CD38/CD20 etc. — that DO resolve, so only the broad ATC
+  umbrella is unmapped.)
+- **Scope caveat (RxNorm bridge):** this export carries **no `HemOnc Component → Maps to → RxNorm
+  Ingredient`** edges, so a patient carrying *only* RxNorm-ingredient component ids could not be
+  bridged from that export alone. Not a blocker (promop emits the HemOnc Component id), but P0.2
+  must confirm the corpus scope on the *pinned release* includes what the patient payload actually
+  contains.
+
+Still to close before the gate is fully green: transitive-closure precision/recall **per active CB
+criterion** vs the current `ComponentCategoryOmopLookup`, and a decision on the 2 ATC classes.
+
 ### Phase 1 — CB / EXACT authoring (trial + mapping)
 - **P1.1** Load the category→OMOP-class-concept crosswalk into the CB vocab model — add
   `TherapyComponentCategory.omop_concept_id(s)` (analogue of `Therapy.omop_concept_id` /

--- a/docs/adr/0002-phase0-coverage.txt
+++ b/docs/adr/0002-phase0-coverage.txt
@@ -1,0 +1,31 @@
+# ADR 0002 — Phase 0 spike: component→class coverage
+# Source: local Athena/HemOnc export (CONCEPT/CONCEPT_RELATIONSHIP/CONCEPT_ANCESTOR).
+# Mechanism: transitive 'Is a' closure to HemOnc 'Component Class' (NOT concept_ancestor).
+# Columns: class | concept_id | vocab | derivation path | members(transitive) | drug_members | rxn_ingredient_mapped
+
+class                     concept_id  vocab   path          members  drug_members  rxn_mapped 
+----------------------------------------------------------------------------------------------
+Targeted therapy          912163      HemOnc  HemOnc/Is-a   441      277           0          
+Immunotherapy             35807189    HemOnc  HemOnc/Is-a   133      83            0          
+Alkylating agent          35807238    HemOnc  HemOnc/Is-a   43       39            0          
+Anti-CD20                 35807389    HemOnc  HemOnc/Is-a   17       16            0          
+ADC                       35807221    HemOnc  HemOnc/Is-a   26       15            0          
+Bispecific antibody       35807364    HemOnc  HemOnc/Is-a   30       15            0          
+Anthracycline             35807214    HemOnc  HemOnc/Is-a   12       12            0          
+CAR-T                     35807448    HemOnc  HemOnc/Is-a   11       8             0          
+PI3K inhibitor            35807303    HemOnc  HemOnc/Is-a   11       8             0          
+Anti-CD38                 35807345    HemOnc  HemOnc/Is-a   6        6             0          
+Bisphosphonate            35807233    HemOnc  HemOnc/Is-a   6        6             0          
+Proteasome inhibitor      35807295    HemOnc  HemOnc/Is-a   4        4             0          
+mTOR inhibitor            35807369    HemOnc  HemOnc/Is-a   4        4             0          
+IMiD                      35807403    HemOnc  HemOnc/Is-a   3        3             0          
+Anti-SLAMF7               35807363    HemOnc  HemOnc/Is-a   1        1             0          
+BCL-2 inhibitor           35807456    HemOnc  HemOnc/Is-a   1        1             0          
+XPO1 inhibitor            35807438    HemOnc  HemOnc/Is-a   1        1             0          
+RANKL inhibitor           35807351    HemOnc  HemOnc/Is-a   1        1             0          
+HDAC inhibitor (ATC)      947794              ATC/ancestor  0        0             0          
+Monoclonal antibody (ATC) 21603754            ATC/ancestor  0        0             0          
+
+SUMMARY: 18/18 HemOnc target classes resolve to >=1 drug member via transitive 'Is a'.
+         2/2 ATC classes (HDAC 947794, Monoclonal antibody 21603754) have 0 usable descendants -> legacy / need HemOnc equivalent.
+         rxn_ingredient_mapped=0 across the board: this export lacks HemOnc Component -> Maps to -> RxNorm Ingredient edges (scope caveat; promop emits the HemOnc Component id directly).


### PR DESCRIPTION
**Draft for cross-repo discussion — cc @adamblum.** Do not implement past Phase 0 until accepted.

Formalizes the plan we scoped for making therapy **types** (drug-class) OMOP-native across CB / PROMOP / EXACT — the deferred second half of the component OMOP cutover (#4447 → matcher flip #228).

## The key correction (vs an earlier take)
Types are NOT a fundamental OMOP limitation. Fine-grained HemOnc/ATC **class concepts exist** and are SME-mapped in the "CB therapy → OMOP concept_id" crosswalk. So the type layer can be **concept-id overlap** like components — the identifier space is those class concepts (NOT the coarse 5 `Has X tx` relationships). The real blocker is the **patient payload** (component ids, no derived class ids) → a vocab spike.

## Coverage (SME-reviewed crosswalk)
- **~20/30 categories → fine-grained HemOnc/ATC class concepts** (PI, IMiD, anti-CD38/CD20, BCL-2, XPO1, CAR-T, ADC, bispecific, mTOR, PI3K, HDAC, anthracycline, alkylating, immunotherapy, targeted, mAb, bisphosphonate, RANKL): **lossless, re-authorable**.
- **~10 (umbrellas + non-drug: chemotherapy, hormonal, supportive, corticosteroid, radiotherapy, surgery, SCT, diagnostic_tool):** no clean class concept → **stay legacy/CB** (fail-closed).

## Phased epic (gates)
- **Phase 0 — PROMOP vocab spike (BLOCKING):** prove `component concept → class concept` on a pinned release (concept_relationship/concept_ancestor), audited precision/recall vs the current CB lookup, preserving exclusions. The one unproven dependency.
- **Phase 1 — CB:** load category→class-concept mapping; mark unmapped `no_omop` explicitly.
- **Phase 2 — PROMOP:** patient-side per-line class-concept projection, **release-stamped via #362**.
- **Phase 3 — EXACT:** restore removed `omop_therapy_types_*` schema (migration 0017) + GIN, emit them in `build_omop_columns`, consumer returns class concept_ids, matcher overlap (required=any-overlap / excluded=any-hit) behind a new `EXACT_OMOP_THERAPY_TYPES` flag (dual-mode like `EXACT_OMOP_THERAPY`), assert equal release_id, fail-closed on `[]`.
- **Phase 4 — validation/flip:** shadow-compare required AND excluded; hybrid flip (OMOP for the ~20, CB legacy for the ~10).

Full doc: `docs/adr/0002-omop-therapy-types.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)