### PR TITLE
feat(vocab): harden snapshot — reject non-latest release + emit X-Vocab-Release-Id (#371)

### DIFF
--- a/docs/adr/0001-vocabulary-source-of-truth.md
+++ b/docs/adr/0001-vocabulary-source-of-truth.md
@@ -127,6 +127,17 @@ API contract. To honour the decision, promop must provide:
   `concept_synonym`, `concept_relationship` (incl. edge validity), `concept_ancestor`,
   `drug_strength`, `source_to_concept_map`, and vocabulary metadata — with source-asserted
   identity preserved.
+- **Bulk table snapshots are latest-only** (amended 2026-08-05, promop#371). Because the
+  loader reloads the vocabulary tables wholesale per release (retention of prior *row-data*
+  is not yet built — see "Release construction & publication" above), the streaming
+  snapshot endpoint can only truthfully serve the **latest** published release: it returns
+  `409 Conflict` for a non-latest release and stamps every response with an
+  `X-Vocab-Release-Id` header. Historical *manifests* remain addressable via the manifest
+  API. **Open fork for a future revision:** **(A)** keep snapshots latest-only — current
+  decision, honest and cheap; or **(B)** make snapshots genuinely release-scoped by
+  retaining per-release row-data, restoring addressable historical snapshots at a storage +
+  loader cost. Consumers pin a release id from the latest manifest and stream immediately;
+  a mid-stream publish surfaces as a transient `409` to re-resolve, never silent skew.
 
 ### Corpus boundary
 - The loader currently scopes `concept` to selected vocabularies/classes,

--- a/docs/vocab-consumer-cache-protocol.md
+++ b/docs/vocab-consumer-cache-protocol.md
@@ -77,7 +77,7 @@ If-None-Match: "<your-cached-etag>"
 
 **Key fields for consumers:**
 
-- `id` — use to construct snapshot URLs for a pinned release
+- `id` — the release these snapshots reflect (snapshots are latest-only; see Step 2)
 - `row_counts` — expected row counts per table (for completeness verification)
 - `checksums` — per-table SHA-256 hashes (for integrity verification)
 - `published_at` — when this release was made available
@@ -98,11 +98,31 @@ JSON (NDJSON):
 GET /api/v1/vocab-releases/latest/snapshot/<table>/
 ```
 
-Or pin to a specific release:
+An explicit release id is also accepted, but **only if it is the latest
+published release** — the race-safe spelling of the line above:
 
 ```
 GET /api/v1/vocab-releases/<release_id>/snapshot/<table>/
 ```
+
+> **Snapshots serve the latest release only.** The vocabulary tables are reloaded
+> wholesale on each release (they are current-only; historical *row-data* is not
+> retained), so a snapshot can only truthfully represent the latest published
+> release. Requesting a **non-latest** release returns **`409 Conflict`** — the
+> body names the current latest and points back to `/latest/` — rather than
+> silently streaming current rows under a stale label. Historical *metadata*
+> (manifests, checksums, per-vocabulary versions) stays available via the manifest
+> API (`GET /api/v1/vocab-releases/<id>/`); only bulk row-level snapshots are
+> latest-only.
+>
+> Every snapshot response (both `200` and `304`) carries an **`X-Vocab-Release-Id`**
+> header naming the release the rows reflect — capture the release id from there
+> rather than parsing the `ETag` or the `Content-Disposition` filename.
+>
+> Consumers resolve the latest manifest and stream by its `id` immediately (see the
+> sync example below). If a new release publishes mid-sync, the in-flight id is no
+> longer latest and its snapshot returns `409` — treat that as "re-resolve `/latest`
+> and retry," never as a fatal error.
 
 ### Available tables
 
@@ -207,6 +227,8 @@ release = response.json()
 new_etag = response.headers["ETag"]
 
 for table in TABLES_I_NEED:
+    # release.id is the latest we just resolved; a 409 here means a newer release
+    # published mid-sync — restart from the /latest poll rather than failing.
     stream = GET /api/v1/vocab-releases/{release.id}/snapshot/{table}/
     write_to_local_db(stream)
     verify_sentinel(stream)
@@ -238,6 +260,8 @@ import requests
 def sync_table(base_url, token, release_id, table, local_cursor):
     url = f"{base_url}/api/v1/vocab-releases/{release_id}/snapshot/{table}/"
     resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, stream=True)
+    # 409 = release_id is no longer the latest (a newer release published);
+    # re-resolve /latest and restart the sync rather than treating it as fatal.
     resp.raise_for_status()
 
     local_cursor.execute(f"TRUNCATE {table}")  # or use a staging table

--- a/omop_core/services/vocab_release.py
+++ b/omop_core/services/vocab_release.py
@@ -17,7 +17,11 @@ def get_latest_release():
     return (
         VocabularyRelease.objects
         .filter(status='published')
-        .order_by('-published_at')
+        # `-pk` is a deterministic tiebreaker: two releases can share a
+        # published_at (bulk publish, or one captured timestamp), and without it
+        # "latest" would be arbitrary per query — which can make the snapshot
+        # view's single-latest guard 409 the /latest/ URL against itself.
+        .order_by('-published_at', '-pk')
         .first()
     )
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -5434,15 +5434,36 @@ class VocabSnapshotView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # 2. Resolve release
+        # 2. Resolve release. Resolve `latest` ONCE and reuse it for both the
+        # release_id=None branch and the non-latest guard below — two independent
+        # get_latest_release() reads could straddle a publish (or a published_at
+        # tie) and make the /latest/ URL 409 against itself.
+        latest = get_latest_release()
         if release_id is None:
-            release = get_latest_release()
+            release = latest
         else:
             release = VocabularyRelease.objects.filter(
                 pk=release_id, status='published',
             ).first()
         if release is None:
             return Response({'detail': 'Release not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+        # 2b. Refuse a non-latest published release. The vocab tables are reloaded
+        # wholesale per release (current-only), and the stream below filters only by
+        # `source`, not release_id — so serving an OLDER release's URL would stream
+        # the CURRENT rows under a stale label. Only the latest published release is
+        # truthful; the manifest API (vocab_release_detail) still serves historical
+        # metadata. See issue #371 / exact#286.
+        if latest is not None and release.pk != latest.pk:
+            return Response(
+                {'detail': (
+                    f'Snapshot for release {release.pk} is unavailable: vocabulary '
+                    f'tables are current-only, so only the latest published release '
+                    f'({latest.pk}) can be streamed. Use '
+                    f'/api/v1/vocab-releases/latest/snapshot/{table}/.'
+                )},
+                status=status.HTTP_409_CONFLICT,
+            )
 
         # 3. ETag / conditional request
         etag = get_release_etag(release)
@@ -5451,6 +5472,7 @@ class VocabSnapshotView(APIView):
             resp = HttpResponseNotModified()
             if etag:
                 resp['ETag'] = etag
+            resp['X-Vocab-Release-Id'] = str(release.pk)
             return resp
 
         # 4. Build WHERE clause (source filter for concept table only)
@@ -5479,6 +5501,10 @@ class VocabSnapshotView(APIView):
         response['Content-Disposition'] = (
             f'attachment; filename="{table}_{release.pk}.ndjson"'
         )
+        # Name the release these rows reflect, so consumers capture it robustly
+        # (not by parsing the ETag/filename). Always the latest published release —
+        # non-latest is refused above. See issue #371 / cancerbot#4646.
+        response['X-Vocab-Release-Id'] = str(release.pk)
         if etag:
             response['ETag'] = etag
             response['Cache-Control'] = 'private, max-age=86400'

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -14789,6 +14789,47 @@ class VocabSnapshotTest(_SmartBase):
             resp['Content-Disposition'],
         )
 
+    def test_x_vocab_release_id_header(self):
+        # Consumers capture the release_id from an explicit header, not the ETag.
+        resp = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['X-Vocab-Release-Id'], str(self.release.pk))
+        # /latest/ resolves to the same release and carries the header too.
+        latest = self.read_client.get(self._snapshot_url('vocabulary'))
+        self.assertEqual(latest['X-Vocab-Release-Id'], str(self.release.pk))
+        # Present on a source-filtered concept request too (header is set before the
+        # source/etag mutation).
+        filtered = self.read_client.get(
+            self._snapshot_url('concept', self.release.pk) + '?source=HealthKey')
+        self.assertEqual(filtered['X-Vocab-Release-Id'], str(self.release.pk))
+
+    def test_x_vocab_release_id_header_on_304(self):
+        # The conditional 304 response must also name the release.
+        resp1 = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        resp2 = self.read_client.get(
+            self._snapshot_url('vocabulary', self.release.pk),
+            HTTP_IF_NONE_MATCH=resp1['ETag'],
+        )
+        self.assertEqual(resp2.status_code, 304)
+        self.assertEqual(resp2['X-Vocab-Release-Id'], str(self.release.pk))
+
+    def test_409_on_non_latest_published_release(self):
+        # A newer published release makes self.release non-latest; the vocab tables
+        # are current-only, so the older release's snapshot is refused (not silently
+        # streamed under a stale label). The latest snapshot still works.
+        from datetime import timedelta
+        from omop_core.models import VocabularyRelease
+        from django.utils import timezone as tz
+        newer = VocabularyRelease.objects.create(
+            build_timestamp=tz.now(), status='published',
+            published_at=tz.now() + timedelta(hours=1),
+        )
+        resp = self.read_client.get(self._snapshot_url('vocabulary', self.release.pk))
+        self.assertEqual(resp.status_code, 409)
+        self.assertIn(str(newer.pk), resp.data['detail'])
+        ok = self.read_client.get(self._snapshot_url('vocabulary', newer.pk))
+        self.assertEqual(ok.status_code, 200)
+
     def test_unauthenticated_returns_401(self):
         from rest_framework.test import APIClient
         anon = APIClient()


### PR DESCRIPTION
Closes #371.

## Problem
The vocab tables are reloaded wholesale per release (`concept` &c. are **current-only**), and `VocabSnapshotView` filters only by `source`, **not** `release_id`. So `GET /api/v1/vocab-releases/<OLD_id>/snapshot/<table>/` silently streamed the **current** rows under a stale release label — a correctness hazard for consumers (EXACT `vocab_mirror` sync; CancerBot build-time crosswalk capture, cancerbot#4646). Surfaced during the OMOP therapy-types release-consistency work (exact#286).

## Change
1. **Refuse a non-latest published release → HTTP 409.** Only the latest published release is truthful for row-level snapshots; the manifest API (`vocab_release_detail`) still serves historical metadata. `latest` is resolved **once** per request and `get_latest_release()` gets a deterministic `-pk` tiebreaker, so a `published_at` tie or a mid-request publish can't make the `/latest/` URL 409 against itself.
2. **Emit `X-Vocab-Release-Id`** on the 200 stream and the 304 response, so consumers capture the release_id robustly (not by parsing the ETag/filename) — enables cancerbot#4646 auto-capture.

## Consumer impact
EXACT `vocab_mirror` sync resolves `/latest` then streams by that id. During a publish race it now sees a **transient 409** and retries on the next poll — previously it would silently build a mirror mislabeled `N` while holding `N+1`'s rows. A consumer that **persists** an old id and re-fetches later gets a **permanent 409 by design** (that id's rows are gone); the 409 body points to `/latest/`. Worth a heads-up to vocab_mirror owners: treat 409 as "re-resolve latest," not fatal.

## Review
- **codex review** (`--base origin/dev`): clean — "consistently reject stale release requests; header on streamed + conditional responses."
- **Fresh cold Claude review** (separate subagent): one Medium — `get_latest_release()` resolved twice → `/latest/` could 409 against itself on a `published_at` tie / TOCTOU — **fixed** (single-resolve + `-pk` tiebreaker). M2 (persisted-id permanent 409) is the intended contract; L3 (24h `Cache-Control`) is pre-existing and out of scope. Test gaps closed.

## Tests
409-on-non-latest-published; `X-Vocab-Release-Id` on 200, `/latest/`, source-filtered `concept`, and 304. Release service/API/publish suite (38) + full backend suite (`omop_core` + `patient_portal`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)