### PR TITLE
docs: align README/CITATION with paper; fix column count

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,13 +25,13 @@ keywords:
 abstract: >
   PRomop is an open-source longitudinal patient health record built on OMOP CDM v5.4
   with FHIR R4 ingestion. Its central feature is PatientRecord, a denormalized
-  286-column projection derived automatically from OMOP tables that enables
+  300+ column projection derived automatically from OMOP tables that enables
   population analytics, clinical trial matching, and clinical decision support to
   operate from a single shared substrate without re-deriving patient state. Deployed
   across approximately 17,500 real patients in two oncology organizations.
 preferred-citation:
   type: article
-  title: "PRomop: Building a Comprehensive Longitudinal Decision-Ready Patient Health Record"
+  title: "PRomop: A Longitudinal Decision-Ready Patient Health Record Built on OMOP CDM and FHIR R4"
   authors:
     - family-names: Blum
       given-names: Adam

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![CI](https://github.com/healthkey-ai/promop/actions/workflows/ci.yml/badge.svg)](https://github.com/healthkey-ai/promop/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-**PRomop** is an open-source longitudinal patient health record built on the [OMOP CDM v5.4](https://ohdsi.github.io/CommonDataModel/) with FHIR R4 ingestion. Its central feature is `PatientRecord` — a denormalized, 286-column projection derived automatically from OMOP tables that gives analytics, trial matching, and clinical decision support a single shared substrate, eliminating the repeated re-derivation of patient state across applications.
+**PRomop** is an open-source longitudinal patient health record built on the [OMOP CDM v5.4](https://ohdsi.github.io/CommonDataModel/) with FHIR R4 ingestion. Its central feature is `PatientRecord` — a wide denormalized projection (300+ columns) derived automatically from OMOP tables that gives analytics, trial matching, and clinical decision support a single shared substrate, eliminating the repeated re-derivation of patient state across applications.
 
-Deployed across approximately 17,500 real oncology patients, with trial matching against 6,000 actively recruiting trials. A 20-criterion eligibility search over raw OMOP requires 27–39 joins; against `PatientRecord` it requires zero — an estimated 30–200× speedup.
+Deployed across approximately 17,500 real oncology patients, with trial matching against 6,000 actively recruiting trials. Benchmarks show a [~37× speedup](https://arxiv.org/abs/2607.13947) for eligibility screening compared to querying raw OMOP tables directly.
 
 See [paper.md](paper.md) for the full research description.
 
@@ -18,7 +18,7 @@ Not on a Mac? See the [Linux setup guide](docs/linux-setup.md). Prefer Docker? S
 ## Key Features
 
 - **FHIR R4 ingestion** — Bundle uploads mapped to OMOP tables (observations → `Measurement`, conditions → `ConditionOccurrence`, medications → `DrugExposure` + `Episode`)
-- **PatientRecord projection** — 286-column decision-ready view, auto-rebuilt via signal chain on every OMOP write
+- **PatientRecord projection** — 300+ column decision-ready view, auto-rebuilt via signal chain on every OMOP write
 - **Versioned REST API** — `/api/v1/` with [OpenAPI 3.0 schema](API_SURFACE.md) and Swagger UI at `/api/v1/docs/`
 - **Multi-tenant access control** — OAuth2 and SMART on FHIR authorization, org-scoped role-based access
 - **Synthetic FHIR generator** — reproducible patient bundles for multiple diseases (MM, FL, breast cancer)

--- a/paper.md
+++ b/paper.md
@@ -33,7 +33,7 @@ multiplying effort and inconsistency.
 PRomop is an open-source longitudinal patient health record built on the OMOP Common Data Model
 (CDM 5.4) [@OHDSI2021] with oncology extensions. Its keystone is `PatientRecord`, a flattened,
 denormalized projection that collapses each patient's complete longitudinal history into a single
-decision-ready row of 286 columns. While the transactional CDM tables preserve everything that
+decision-ready row of over 300 columns. While the transactional CDM tables preserve everything that
 ever happened, `PatientRecord` represents what is true *now* — computing patient-state derivations
 once rather than repeatedly per consumer. Population analytics, clinical trial matching, and
 standard-of-care evaluation all operate on one shared substrate rather than maintaining divergent
@@ -50,26 +50,14 @@ PRomop is designed for clinical informaticists, data scientists, and developers 
 or integrate with a longitudinal patient health record — whether to power a trial matching engine,
 construct feature sets for clinical ML models, or deploy patient-level clinical decision support.
 
-The foundational standards address complementary but distinct problems and together do not fill
-this need. OMOP CDM provides a normalized, vocabulary-mapped schema optimized for population-level
-observational research. OHDSI tools built on it — ATLAS, HADES, ACHILLES — excel at cohort
-definition and epidemiological analysis across large databases [@OHDSI2021; @Overhage2012], but
-operate at the population level and do not provide a queryable per-patient state. Answering "what
-is this patient's current disease status, most recent lab values, and prior therapy lines?"
-requires assembling and aggregating across multiple OMOP tables at query time; every application
-that needs this must re-implement the derivation independently.
-
-FHIR R4 is an exchange protocol: it defines how clinical data moves between systems, not how it
-is stored for analytical queries [@HL7FHIR; @Mandel2016]. A FHIR server preserves resources in
-their original form; determining a patient's current clinical state still requires traversing and
-reconciling multiple resource types. Neither standard, nor the tools built on them, produces a
-pre-computed, per-patient record ready for trial matching criteria evaluation, CDS rule firing, or
-use as an ML feature vector.
-
-The consequence is repeated, redundant derivation. Each downstream application independently
-reconstructs patient state — resolving lines of therapy, determining current disease status,
+Today, answering "what is this patient's current disease status, most recent lab values, and prior
+therapy lines?" requires assembling and aggregating across multiple tables at query time. Every
+downstream application — analytics dashboards, trial matchers, CDS engines — independently
+reconstructs patient state: resolving lines of therapy, determining current disease status,
 normalizing biomarkers, reconciling conflicting source values. This re-derivation is expensive,
 error-prone, and a frequent source of inconsistency between applications that should agree.
+Neither OMOP CDM's normalized tables nor FHIR's resource-oriented exchange protocol (see *State
+of the Field*) produces a pre-computed, per-patient record ready for these use cases.
 
 PRomop fills this gap by:
 
@@ -113,7 +101,7 @@ PRomop's central design trade-off is **normalization for writes versus denormali
 Clinical data arrives as FHIR R4 Bundles and is written into normalized OMOP CDM 5.4 tables
 (`Measurement`, `ConditionOccurrence`, `DrugExposure`, `Episode`), preserving full longitudinal
 history and OHDSI-ecosystem compatibility. A Django `post_save` signal chain then derives
-`PatientRecord` — a 286-column materialized projection, one row per patient — on every write.
+`PatientRecord` — a wide materialized projection (currently over 300 columns), one row per patient — on every write.
 
 ```
 FHIR R4 Bundle ingest
@@ -122,7 +110,7 @@ FHIR R4 Bundle ingest
 OMOP CDM tables  (Measurement, ConditionOccurrence, DrugExposure, Episode …)
         │  post_save signal chain
         ▼
-  PatientRecord  (286-column denormalized projection, one row per patient)
+  PatientRecord  (300+ column denormalized projection, one row per patient)
         │
         ├── Population analytics (PRism)
         ├── Clinical trial matching (EXACT)


### PR DESCRIPTION
## Summary
- Fix `CITATION.cff` preferred-citation title to match `paper.md`
- Update README speedup claim from estimated 30–200× to measured ~37×
- Deduplicate OHDSI/FHIR discussion between Statement of Need and State of the Field
- Replace hardcoded "286 columns" with "300+" across paper, README, and CITATION.cff

## Test plan
- [ ] Verify paper.md renders correctly
- [ ] Confirm no remaining "286" references in reviewer-facing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)