### PR TITLE
fix(deps): resolve 19 of 21 npm security advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -103,7 +103,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -627,6 +626,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -671,29 +671,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -957,22 +937,22 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "2.4.0",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.8.1.tgz",
+      "integrity": "sha512-JM8g76KzhhH44kHvM2JPJ5FIlQDwUNzw0vvq5EDSo/znNUmUEuSrfTssukCKg1nqnBGWLohjIV0LOOhLdCknoQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
-        "@module-federation/third-party-dts-extractor": "2.4.0",
-        "adm-zip": "0.5.10",
-        "ansi-colors": "4.1.3",
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/managers": "2.8.1",
+        "@module-federation/sdk": "2.8.1",
+        "@module-federation/third-party-dts-extractor": "2.8.1",
+        "adm-zip": "0.6.0",
         "isomorphic-ws": "5.0.0",
-        "node-schedule": "2.1.1",
-        "undici": "7.24.7",
-        "ws": "8.18.0"
+        "undici": "7.28.0",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
+        "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue-tsc": ">=1.0.24"
       },
       "peerDependenciesMeta": {
@@ -981,72 +961,66 @@
         }
       }
     },
-    "node_modules/@module-federation/dts-plugin/node_modules/undici": {
-      "version": "7.28.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.4.0",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.8.1.tgz",
+      "integrity": "sha512-0mQ+bWt1LRCZyURx3g2b8G+aAlvk8iXIgrp3Jit/75blrlVda/eVqnHz1L+YOxwkP3xSrdbUb4423AoWti31ZQ==",
       "license": "MIT"
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.4.0",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.8.1.tgz",
+      "integrity": "sha512-bHRooIgplIFNLH42eM3g21b2apM/a7lMG1EwifUxT4A4AobS42H08KGdYITdKJcrgowx3D7PhYndiwtHFI03zQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.4.0",
-        "find-pkg": "2.0.0"
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.4.0",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.8.1.tgz",
+      "integrity": "sha512-+xpq/r6Om4plbGJisZp6/rl7usEUlQszz34E+JUKgl9uW3QIRzVgxwOAzGiF7U+dqOKxMqmiq+nTJwK2wAwteA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/runtime-core": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/runtime-core": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.4.0",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.8.1.tgz",
+      "integrity": "sha512-Dif+3u7fvq6qBATFIv5qB7ay6Rgo2HNzhaNOt1yRfpVXjiJqQ3UPnHZ+TLP9znkXiZvg6Bg5W9EV2ZX4nH2S0w==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.4.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^2.7.0 || ^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.8.1.tgz",
+      "integrity": "sha512-3EVljiNilY2pFIG2RO4KNCC6gIPnYc9J+p5U6Nn8D5X3PtJeEcPyBvKGttxZnSLlXCi+YXQfgexBOfnkvEuzuQ==",
+      "license": "MIT"
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-pkg": "2.0.0",
-        "resolve": "1.22.8"
-      }
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.8.1.tgz",
+      "integrity": "sha512-6ulu7vqv5wyM5YWwxjUHzZ+8Sg6e+/vn+gskiUBs6EPqe/w3XMdRoUrFjAI3EW62xi0e0xbWLsjbQs9jCAj8ig==",
+      "license": "MIT"
     },
     "node_modules/@module-federation/vite": {
-      "version": "1.15.5",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.20.3.tgz",
+      "integrity": "sha512-+GwKDBr3muE/oXdAMLkh9B9BOrlV1zxG8JGQH4gKmIdMoIFPs5V74y1THN/p0rJ0r03cLOU7D0UnB0dq2TYwgQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/runtime": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
-        "es-module-lexer": "^2.0.0",
-        "estree-walker": "^3.0.3",
-        "pathe": "^2.0.3"
+        "@module-federation/dts-plugin": "2.8.1",
+        "@module-federation/runtime": "2.8.1",
+        "@module-federation/sdk": "2.8.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2459,8 +2433,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2528,6 +2501,7 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/gensync": {
@@ -2549,6 +2523,7 @@
       "version": "20.19.41",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2557,6 +2532,7 @@
       "version": "19.2.15",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2565,6 +2541,7 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2608,6 +2585,7 @@
       "version": "8.59.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -2904,6 +2882,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2920,10 +2899,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.10",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -2951,18 +2932,10 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2971,7 +2944,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3010,11 +2982,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -3047,14 +3021,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3075,6 +3051,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3172,16 +3149,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cron-parser": {
-      "version": "4.9.0",
-      "license": "MIT",
-      "dependencies": {
-        "luxon": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3386,8 +3353,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3461,6 +3427,7 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -3509,6 +3476,7 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3661,6 +3629,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -3677,16 +3646,6 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "license": "MIT"
-    },
-    "node_modules/expand-tilde": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "homedir-polyfill": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -3742,26 +3701,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/find-file-up": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-dir": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/find-pkg": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-file-up": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -3905,42 +3844,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/global-modules": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/globals": {
       "version": "17.6.0",
       "dev": true,
@@ -4013,16 +3916,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/homedir-polyfill": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "parse-passwd": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "dev": true,
@@ -4078,28 +3971,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "license": "ISC"
-    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -4126,19 +4002,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-ws": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
@@ -4160,6 +4032,7 @@
       "version": "29.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -4193,14 +4066,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "7.28.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/jsesc": {
@@ -4523,10 +4388,6 @@
       "version": "4.18.1",
       "license": "MIT"
     },
-    "node_modules/long-timeout": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
@@ -4552,18 +4413,10 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4632,7 +4485,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -4658,18 +4513,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/node-schedule": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "cron-parser": "^4.2.0",
-        "long-timeout": "0.1.1",
-        "sorted-array-functions": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/object-assign": {
@@ -4732,13 +4575,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-passwd": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "dev": true,
@@ -4766,12 +4602,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "license": "MIT"
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -4781,6 +4614,7 @@
     "node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4789,7 +4623,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4806,7 +4642,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4826,7 +4662,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4839,8 +4674,7 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4873,6 +4707,7 @@
     "node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4880,6 +4715,7 @@
     "node_modules/react-dom": {
       "version": "19.2.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4934,6 +4770,21 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/react-router-dom": {
       "version": "6.30.4",
       "license": "MIT",
@@ -4947,19 +4798,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.30.4",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
       }
     },
     "node_modules/react-smooth": {
@@ -5057,32 +4895,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-dir": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.1.4",
       "license": "MIT",
@@ -5164,10 +4976,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sorted-array-functions": {
-      "version": "1.3.0",
-      "license": "MIT"
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
@@ -5194,16 +5002,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {
@@ -5342,6 +5140,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5370,6 +5169,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -5476,6 +5284,7 @@
     "node_modules/vite": {
       "version": "8.1.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5714,8 +5523,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5759,6 +5571,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- Update axios 1.16.1 → 1.19.0 (clears 8 advisories)
- Update undici 7.28.0 → 7.29.0 (clears 4 advisories)
- Update postcss 8.5.16 → 8.5.25 (clears 1 advisory)
- Update brace-expansion 5.0.6 → 5.0.9 (clears 1 advisory)
- Update adm-zip 0.5.10 → 0.6.0 via @module-federation/dts-plugin (clears 1 advisory)
- Transitive dependency cleanup (~22 packages removed)

**Remaining:** 2 moderate react-router advisories (open redirect, SSR constructor injection) require major v6→v7 upgrade — deferred to separate PR.

## Test plan
- [x] Frontend: 158 tests pass (`npm test -- --run`)
- [x] Backend: 1,149 tests pass (local PostgreSQL)
- [x] `npm audit` shows only 2 moderate remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)