### PR TITLE
Reorganize patient portal: Allergies, Immunizations, Settings tabs

### DIFF
--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -415,7 +415,9 @@ export default function PatientDetail({
       const a = document.createElement("a");
       a.href = url;
       a.download = "my-health-record.fhir.json";
+      document.body.appendChild(a);
       a.click();
+      document.body.removeChild(a);
       URL.revokeObjectURL(url);
     } catch {
       setDownloadError("Failed to download your health record. Please try again.");
@@ -459,6 +461,7 @@ export default function PatientDetail({
   }
 
   const baseTabs = ["General", getDiseaseTabLabel(), "Treatment", "Blood", "Labs", "Behavior", "Wearable"];
+  const baseTabCount = baseTabs.length;
   const patientExtraTabs = patientMode ? ["Allergies", "Immunizations", "Settings"] : [];
   const tabLabels = [...baseTabs, ...patientExtraTabs];
   const baseDescriptions: Record<number, string> = {
@@ -471,9 +474,9 @@ export default function PatientDetail({
     6: "Apple wearable 30-day summaries derived from synced OMOP data.",
   };
   const patientExtraDescriptions: Record<number, string> = patientMode ? {
-    7: "Known allergies and intolerances from your health records.",
-    8: "Your vaccination history from linked health records.",
-    9: "Consent preferences and advance directive documents.",
+    [baseTabCount]: "Known allergies and intolerances from your health records.",
+    [baseTabCount + 1]: "Your vaccination history from linked health records.",
+    [baseTabCount + 2]: "Consent preferences and advance directive documents.",
   } : {};
   const tabDescriptions = { ...baseDescriptions, ...patientExtraDescriptions };
 
@@ -595,7 +598,7 @@ export default function PatientDetail({
           </nav>
         </div>
 
-        {activeTab <= 6 ? (
+        {activeTab < baseTabCount ? (
           <div className="rounded-2xl bg-background shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
             <div className="px-8 pb-6 pt-8">
               <h2 className="text-xl font-bold text-foreground">{tabLabels[activeTab]}</h2>
@@ -631,9 +634,9 @@ export default function PatientDetail({
           </div>
         ) : (
           <div key={activeTab} className="animate-tab-in">
-            {patientMode && activeTab === 7 && <AllergyList user={user ?? null} />}
-            {patientMode && activeTab === 8 && <ImmunizationList user={user ?? null} />}
-            {patientMode && activeTab === 9 && (
+            {patientMode && activeTab === baseTabCount && <AllergyList user={user ?? null} />}
+            {patientMode && activeTab === baseTabCount + 1 && <ImmunizationList user={user ?? null} />}
+            {patientMode && activeTab === baseTabCount + 2 && (
               <div className="space-y-6">
                 <PatientConsents user={user ?? null} />
                 <AdvanceDirectives user={user ?? null} />

--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -1,9 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, Check, AlertCircle, ChevronDown } from "lucide-react";
+import { ArrowLeft, Check, AlertCircle, ChevronDown, Download } from "lucide-react";
 import api from "@/api/axios";
 import { getActiveBranding } from "@/config/branding";
+import type { User } from "@/hooks/useAuth";
 import DeleteAccountDialog from "./DeleteAccountDialog";
+import AllergyList from "./AllergyList";
+import ImmunizationList from "./ImmunizationList";
+import PatientConsents from "./PatientConsents";
+import AdvanceDirectives from "./AdvanceDirectives";
 import GeneralTab from "@/components/PatientInfo/tabs/GeneralTab";
 import DiseaseTab from "@/components/PatientInfo/tabs/DiseaseTab";
 import TreatmentTab from "@/components/PatientInfo/tabs/TreatmentTab";
@@ -172,12 +177,15 @@ interface PatientDetailProps {
   patientMode?: boolean;
   /** Logout handler shown in the header when in patient mode. */
   onLogout?: () => void;
+  /** Authenticated user — needed for patient-mode tabs (Allergies, Immunizations, Settings). */
+  user?: User | null;
 }
 
 export default function PatientDetail({
   personIdOverride,
   patientMode = false,
   onLogout,
+  user,
 }: PatientDetailProps = {}) {
   const params = useParams<{ personId: string }>();
   const personId = personIdOverride ?? params.personId;
@@ -194,6 +202,9 @@ export default function PatientDetail({
   const [patientName, setPatientName] = useState("");
   const [editedName, setEditedName] = useState("");
   const [activeTab, setActiveTab] = useState(0);
+
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   type InviteState = "idle" | "sending" | "sent" | "error";
   const [inviteState, setInviteState] = useState<InviteState>("idle");
@@ -393,6 +404,26 @@ export default function PatientDetail({
     }
   }, [handleFieldChange]);
 
+  const handleDownloadFhir = useCallback(async () => {
+    if (!personId) return;
+    setDownloading(true);
+    setDownloadError(null);
+    try {
+      const response = await api.get(`/v1/patient-records/${personId}/export-fhir/`);
+      const blob = new Blob([JSON.stringify(response.data, null, 2)], { type: "application/fhir+json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "my-health-record.fhir.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setDownloadError("Failed to download your health record. Please try again.");
+    } finally {
+      setDownloading(false);
+    }
+  }, [personId]);
+
   const getDiseaseType = (): "breast" | "lymphoma" | "myeloma" | "cll" | "other" => {
     const d = (typeof editedInfo?.disease === "string" ? editedInfo.disease : "").toLowerCase();
     if (d.includes("breast")) return "breast";
@@ -427,8 +458,10 @@ export default function PatientDetail({
     );
   }
 
-  const tabLabels = ["General", getDiseaseTabLabel(), "Treatment", "Blood", "Labs", "Behavior", "Wearable"];
-  const tabDescriptions: Record<number, string> = {
+  const baseTabs = ["General", getDiseaseTabLabel(), "Treatment", "Blood", "Labs", "Behavior", "Wearable"];
+  const patientExtraTabs = patientMode ? ["Allergies", "Immunizations", "Settings"] : [];
+  const tabLabels = [...baseTabs, ...patientExtraTabs];
+  const baseDescriptions: Record<number, string> = {
     0: "Keep patient details up to date for accurate personalisation.",
     1: "Disease-specific clinical information and genetic details.",
     2: "Therapy history, treatment lines, and planned therapies.",
@@ -437,6 +470,12 @@ export default function PatientDetail({
     5: "Lifestyle, socioeconomic, and behavioural health factors.",
     6: "Apple wearable 30-day summaries derived from synced OMOP data.",
   };
+  const patientExtraDescriptions: Record<number, string> = patientMode ? {
+    7: "Known allergies and intolerances from your health records.",
+    8: "Your vaccination history from linked health records.",
+    9: "Consent preferences and advance directive documents.",
+  } : {};
+  const tabDescriptions = { ...baseDescriptions, ...patientExtraDescriptions };
 
   const initials = getInitials(patientName);
   const avatarBg = getAvatarBg(patientName);
@@ -469,7 +508,17 @@ export default function PatientDetail({
               </button>
             )}
             {patientMode && (
-              <span className="text-sm font-semibold text-foreground">My Health Record</span>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-semibold text-foreground">My Health Record</span>
+                <button
+                  onClick={handleDownloadFhir}
+                  disabled={downloading}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-[#eef0f4] hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  {downloading ? "Downloading..." : "Download"}
+                </button>
+              </div>
             )}
           </div>
 
@@ -546,43 +595,59 @@ export default function PatientDetail({
           </nav>
         </div>
 
-        <div className="rounded-2xl bg-background shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
-          <div className="px-8 pb-6 pt-8">
-            <h2 className="text-xl font-bold text-foreground">{tabLabels[activeTab]}</h2>
-            <p className="mt-1 text-sm text-muted-foreground">{tabDescriptions[activeTab]}</p>
-          </div>
+        {activeTab <= 6 ? (
+          <div className="rounded-2xl bg-background shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
+            <div className="px-8 pb-6 pt-8">
+              <h2 className="text-xl font-bold text-foreground">{tabLabels[activeTab]}</h2>
+              <p className="mt-1 text-sm text-muted-foreground">{tabDescriptions[activeTab]}</p>
+            </div>
 
-          <div key={activeTab} className="animate-tab-in px-8 pb-10">
-            {activeTab === 0 && (
-              <GeneralTab
-                formData={editedInfo}
-                onChange={handleFieldChange}
-                editedName={editedName}
-                onNameChange={handleNameChange}
-                onZipcodeChange={handleZipcodeChange}
-              />
-            )}
-            {activeTab === 1 && (
-              <DiseaseTab
-                formData={editedInfo}
-                onChange={handleFieldChange}
-                onMutationAdd={handleMutationAdd}
-                onMutationRemove={handleMutationRemove}
-                onMutationChange={handleMutationChange}
-                diseaseType={getDiseaseType()}
-              />
-            )}
-            {activeTab === 2 && <TreatmentTab formData={editedInfo} onChange={handleFieldChange} diseaseType={getDiseaseType()} />}
-            {activeTab === 3 && <BloodTab formData={editedInfo} onChange={handleFieldChange} />}
-            {activeTab === 4 && <LabsTab formData={editedInfo} onChange={handleFieldChange} />}
-            {activeTab === 5 && <BehaviorTab formData={editedInfo} onChange={handleFieldChange} />}
-            {activeTab === 6 && <WearableTab formData={editedInfo} onChange={handleFieldChange} />}
+            <div key={activeTab} className="animate-tab-in px-8 pb-10">
+              {activeTab === 0 && (
+                <GeneralTab
+                  formData={editedInfo}
+                  onChange={handleFieldChange}
+                  editedName={editedName}
+                  onNameChange={handleNameChange}
+                  onZipcodeChange={handleZipcodeChange}
+                />
+              )}
+              {activeTab === 1 && (
+                <DiseaseTab
+                  formData={editedInfo}
+                  onChange={handleFieldChange}
+                  onMutationAdd={handleMutationAdd}
+                  onMutationRemove={handleMutationRemove}
+                  onMutationChange={handleMutationChange}
+                  diseaseType={getDiseaseType()}
+                />
+              )}
+              {activeTab === 2 && <TreatmentTab formData={editedInfo} onChange={handleFieldChange} diseaseType={getDiseaseType()} />}
+              {activeTab === 3 && <BloodTab formData={editedInfo} onChange={handleFieldChange} />}
+              {activeTab === 4 && <LabsTab formData={editedInfo} onChange={handleFieldChange} />}
+              {activeTab === 5 && <BehaviorTab formData={editedInfo} onChange={handleFieldChange} />}
+              {activeTab === 6 && <WearableTab formData={editedInfo} onChange={handleFieldChange} />}
+            </div>
           </div>
-        </div>
+        ) : (
+          <div key={activeTab} className="animate-tab-in">
+            {patientMode && activeTab === 7 && <AllergyList user={user ?? null} />}
+            {patientMode && activeTab === 8 && <ImmunizationList user={user ?? null} />}
+            {patientMode && activeTab === 9 && (
+              <div className="space-y-6">
+                <PatientConsents user={user ?? null} />
+                <AdvanceDirectives user={user ?? null} />
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {saveErrorMsg && (
         <ErrorToast message={saveErrorMsg} onDismiss={() => setSaveErrorMsg(null)} />
+      )}
+      {downloadError && (
+        <ErrorToast message={downloadError} onDismiss={() => setDownloadError(null)} />
       )}
     </div>
   );

--- a/frontend/src/components/Patient/PatientHome.test.tsx
+++ b/frontend/src/components/Patient/PatientHome.test.tsx
@@ -5,8 +5,8 @@ import type { User } from "@/hooks/useAuth";
 
 // Capture the props PatientHome hands to PatientDetail.
 vi.mock("@/components/Patient/PatientDetail", () => ({
-  default: (props: { personIdOverride?: string; patientMode?: boolean }) => (
-    <div>{`PATIENT_DETAIL:${props.personIdOverride}:${String(props.patientMode)}`}</div>
+  default: (props: { personIdOverride?: string; patientMode?: boolean; user?: User | null }) => (
+    <div>{`PATIENT_DETAIL:${props.personIdOverride}:${String(props.patientMode)}:${props.user?.person_id ?? "none"}`}</div>
   ),
 }));
 
@@ -30,7 +30,7 @@ describe("PatientHome", () => {
         onLogout={vi.fn()}
       />
     );
-    expect(screen.getByText("PATIENT_DETAIL:7:true")).toBeInTheDocument();
+    expect(screen.getByText("PATIENT_DETAIL:7:true:7")).toBeInTheDocument();
   });
 
   it("shows a no-record message when no person is linked", () => {
@@ -44,20 +44,20 @@ describe("PatientHome", () => {
     expect(screen.getByText(/no health record is linked/i)).toBeInTheDocument();
   });
 
-  it("renders the download FHIR button when patient has a person_id", () => {
+  it("passes user prop to PatientDetail (download is now inside PatientDetail)", () => {
     render(
       <PatientHome
         user={makeUser({ is_patient: true, person_id: 7 })}
         onLogout={vi.fn()}
       />
     );
-    const downloadBtn = screen.getByRole("button", { name: /download my record \(fhir\)/i });
-    expect(downloadBtn).toBeInTheDocument();
-    expect(downloadBtn).toBeEnabled();
+    // Download button is now rendered by PatientDetail, which is mocked here.
+    // Verify PatientDetail receives the user prop so it can render the download button.
+    expect(screen.getByText(/PATIENT_DETAIL:7:true:7/)).toBeInTheDocument();
   });
 
-  it("does not render the download FHIR button when no person is linked", () => {
+  it("does not render PatientDetail when no person is linked", () => {
     render(<PatientHome user={makeUser({ is_patient: true, person_id: null })} onLogout={vi.fn()} />);
-    expect(screen.queryByRole("button", { name: /download my record \(fhir\)/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/PATIENT_DETAIL/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Patient/PatientHome.tsx
+++ b/frontend/src/components/Patient/PatientHome.tsx
@@ -1,14 +1,8 @@
-import { useState } from "react";
-import { AlertCircle, Download } from "lucide-react";
+import { AlertCircle } from "lucide-react";
 import type { User } from "@/hooks/useAuth";
 import PatientDetail from "@/components/Patient/PatientDetail";
-import PatientConsents from "@/components/Patient/PatientConsents";
 import PatientSurveys from "@/components/Patient/PatientSurveys";
 import PatientMessages from "@/components/Patient/PatientMessages";
-import AdvanceDirectives from "@/components/Patient/AdvanceDirectives";
-import ImmunizationList from "@/components/Patient/ImmunizationList";
-import AllergyList from "@/components/Patient/AllergyList";
-import api from "@/api/axios";
 
 /**
  * Patient (PHR Account Holder) landing view — PHR-S FM PH.1 / PH.2.
@@ -16,6 +10,12 @@ import api from "@/api/axios";
  * Renders the signed-in patient's OWN record in patient mode by reusing
  * PatientDetail with a fixed person_id. Providers never reach this component;
  * routing in App.tsx sends them to the provider console instead.
+ *
+ * Layout (top → bottom):
+ *   1. PatientDetail — "My Health Record" banner + clinical tabs
+ *      (includes Allergies, Immunizations, Settings tabs and Download button)
+ *   2. PatientSurveys
+ *   3. PatientMessages
  */
 export default function PatientHome({
   user,
@@ -24,9 +24,6 @@ export default function PatientHome({
   user: User | null;
   onLogout: () => void;
 }) {
-  const [downloading, setDownloading] = useState(false);
-  const [downloadError, setDownloadError] = useState<string | null>(null);
-
   if (!user || user.person_id == null) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#f5f7fa] p-6">
@@ -46,65 +43,20 @@ export default function PatientHome({
     );
   }
 
-  const handleDownloadFhir = async () => {
-    setDownloading(true);
-    setDownloadError(null);
-    try {
-      const response = await api.get(`/v1/patient-records/${user.person_id}/export-fhir/`);
-      const blob = new Blob([JSON.stringify(response.data, null, 2)], { type: "application/fhir+json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "my-health-record.fhir.json";
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch {
-      setDownloadError("Failed to download your health record. Please try again.");
-    } finally {
-      setDownloading(false);
-    }
-  };
-
   return (
     <div>
-      <div className="flex justify-end px-6 pt-4">
-        <button
-          onClick={handleDownloadFhir}
-          disabled={downloading}
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <Download className="h-4 w-4" />
-          {downloading ? "Downloading..." : "Download my record (FHIR)"}
-        </button>
-      </div>
-      {downloadError && (
-        <div className="px-6 pt-2">
-          <p className="text-sm text-red-600">{downloadError}</p>
-        </div>
-      )}
-      <div className="mx-auto max-w-5xl px-6 py-4">
-        <PatientConsents user={user} />
-      </div>
+      <PatientDetail
+        personIdOverride={String(user.person_id)}
+        patientMode
+        onLogout={onLogout}
+        user={user}
+      />
       <div className="mx-auto max-w-5xl px-6 py-4">
         <PatientSurveys user={user} />
       </div>
       <div className="mx-auto max-w-5xl px-6 py-4">
         <PatientMessages user={user} />
       </div>
-      <div className="mx-auto max-w-5xl px-6 py-4">
-        <AllergyList user={user} />
-      </div>
-      <div className="mx-auto max-w-5xl px-6 py-4">
-        <ImmunizationList user={user} />
-      </div>
-      <div className="mx-auto max-w-5xl px-6 py-4">
-        <AdvanceDirectives user={user} />
-      </div>
-      <PatientDetail
-        personIdOverride={String(user.person_id)}
-        patientMode
-        onLogout={onLogout}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Move **PatientDetail** ("My Health Record") to the top of the patient landing page
- Add **Download** button next to the "My Health Record" header text
- Add 3 new patient-mode tabs to PatientDetail:
  - **Allergies** — dedicated tab for allergy records (was inline card)
  - **Immunizations** — dedicated tab for vaccination history (was inline card)
  - **Settings** — combines Consent Preferences + Advance Directives (were separate inline cards)
- Surveys and Messages remain below as standalone sections

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 158 frontend tests pass (`npm test -- --run`)
- [x] All 1149 backend tests pass
- [x] PatientHome test updated for new structure

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)