### PR TITLE
feat: wearable upload (Garmin FIT + Apple Health)

### DIFF
--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -7,6 +7,7 @@ import type { User } from "@/hooks/useAuth";
 import DeleteAccountDialog from "./DeleteAccountDialog";
 import AllergyList from "./AllergyList";
 import ImmunizationList from "./ImmunizationList";
+import PatientSurveys from "./PatientSurveys";
 import PatientConsents from "./PatientConsents";
 import AdvanceDirectives from "./AdvanceDirectives";
 import PatientMessages from "./PatientMessages";
@@ -495,24 +496,31 @@ export default function PatientDetail({
     );
   }
 
-  const baseTabs = ["General", getDiseaseTabLabel(), "Treatment", "Blood", "Labs", "Behavior", "Wearables"];
-  const baseTabCount = baseTabs.length;
-  const patientExtraTabs = patientMode ? ["Allergies", "Immunizations"] : [];
-  const tabLabels = [...baseTabs, ...patientExtraTabs];
-  const baseDescriptions: Record<number, string> = {
+  // Build tab list dynamically — patient mode adds Allergies (after Labs) and Surveys (last).
+  // Immunizations are shown inside the Treatment tab, not as a separate tab.
+  const coreTabs = ["General", getDiseaseTabLabel(), "Treatment", "Blood", "Labs"];
+  const afterLabsTabs = patientMode ? ["Allergies"] : [];
+  const trailingTabs = ["Behavior", "Wearables"];
+  const surveyTabs = patientMode ? ["Surveys"] : [];
+  const tabLabels = [...coreTabs, ...afterLabsTabs, ...trailingTabs, ...surveyTabs];
+
+  // Compute dynamic indices
+  const allergiesIdx = patientMode ? coreTabs.length : -1;
+  const behaviorIdx = coreTabs.length + afterLabsTabs.length;
+  const wearablesIdx = behaviorIdx + 1;
+  const surveysIdx = patientMode ? wearablesIdx + 1 : -1;
+
+  const tabDescriptions: Record<number, string> = {
     0: "Keep patient details up to date for accurate personalisation.",
     1: "Disease-specific clinical information and genetic details.",
     2: "Therapy history, treatment lines, and planned therapies.",
     3: "Blood counts, electrolytes, coagulation, and cardiac markers.",
     4: "Chemistry panel, liver function tests, and other lab markers.",
-    5: "Lifestyle, socioeconomic, and behavioural health factors.",
-    6: "30 day summaries derived from synced OMOP data.",
+    ...(allergiesIdx >= 0 ? { [allergiesIdx]: "Known allergies and intolerances from your health records." } : {}),
+    [behaviorIdx]: "Lifestyle, socioeconomic, and behavioural health factors.",
+    [wearablesIdx]: "30 day summaries derived from synced OMOP data.",
+    ...(surveysIdx >= 0 ? { [surveysIdx]: "Surveys assigned to you by your care team." } : {}),
   };
-  const patientExtraDescriptions: Record<number, string> = patientMode ? {
-    [baseTabCount]: "Known allergies and intolerances from your health records.",
-    [baseTabCount + 1]: "Your vaccination history from linked health records.",
-  } : {};
-  const tabDescriptions = { ...baseDescriptions, ...patientExtraDescriptions };
 
   const initials = getInitials(patientName);
   const avatarBg = getAvatarBg(patientName);
@@ -642,46 +650,50 @@ export default function PatientDetail({
               </nav>
             </div>
 
-            {activeTab < baseTabCount ? (
-              <div className="rounded-2xl bg-background shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
-                <div className="px-8 pb-6 pt-8">
-                  <h2 className="text-xl font-bold text-foreground">{tabLabels[activeTab]}</h2>
-                  <p className="mt-1 text-sm text-muted-foreground">{tabDescriptions[activeTab]}</p>
-                </div>
+            <div className="rounded-2xl bg-background shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_24px_rgba(0,0,0,0.06)]">
+              <div className="px-8 pb-6 pt-8">
+                <h2 className="text-xl font-bold text-foreground">{tabLabels[activeTab]}</h2>
+                <p className="mt-1 text-sm text-muted-foreground">{tabDescriptions[activeTab]}</p>
+              </div>
 
-                <div key={activeTab} className="animate-tab-in px-8 pb-10">
-                  {activeTab === 0 && (
-                    <GeneralTab
-                      formData={editedInfo}
-                      onChange={handleFieldChange}
-                      editedName={editedName}
-                      onNameChange={handleNameChange}
-                      onZipcodeChange={handleZipcodeChange}
-                    />
-                  )}
-                  {activeTab === 1 && (
-                    <DiseaseTab
-                      formData={editedInfo}
-                      onChange={handleFieldChange}
-                      onMutationAdd={handleMutationAdd}
-                      onMutationRemove={handleMutationRemove}
-                      onMutationChange={handleMutationChange}
-                      diseaseType={getDiseaseType()}
-                    />
-                  )}
-                  {activeTab === 2 && <TreatmentTab formData={editedInfo} onChange={handleFieldChange} diseaseType={getDiseaseType()} />}
-                  {activeTab === 3 && <BloodTab formData={editedInfo} onChange={handleFieldChange} />}
-                  {activeTab === 4 && <LabsTab formData={editedInfo} onChange={handleFieldChange} />}
-                  {activeTab === 5 && <BehaviorTab formData={editedInfo} onChange={handleFieldChange} />}
-                  {activeTab === 6 && <WearableTab formData={editedInfo} onChange={handleFieldChange} />}
-                </div>
+              <div key={activeTab} className="animate-tab-in px-8 pb-10">
+                {activeTab === 0 && (
+                  <GeneralTab
+                    formData={editedInfo}
+                    onChange={handleFieldChange}
+                    editedName={editedName}
+                    onNameChange={handleNameChange}
+                    onZipcodeChange={handleZipcodeChange}
+                  />
+                )}
+                {activeTab === 1 && (
+                  <DiseaseTab
+                    formData={editedInfo}
+                    onChange={handleFieldChange}
+                    onMutationAdd={handleMutationAdd}
+                    onMutationRemove={handleMutationRemove}
+                    onMutationChange={handleMutationChange}
+                    diseaseType={getDiseaseType()}
+                  />
+                )}
+                {activeTab === 2 && (
+                  <>
+                    <TreatmentTab formData={editedInfo} onChange={handleFieldChange} diseaseType={getDiseaseType()} />
+                    {patientMode && (
+                      <div className="mt-8 border-t border-gray-200 pt-6">
+                        <ImmunizationList user={user ?? null} />
+                      </div>
+                    )}
+                  </>
+                )}
+                {activeTab === 3 && <BloodTab formData={editedInfo} onChange={handleFieldChange} />}
+                {activeTab === 4 && <LabsTab formData={editedInfo} onChange={handleFieldChange} />}
+                {allergiesIdx >= 0 && activeTab === allergiesIdx && <AllergyList user={user ?? null} />}
+                {activeTab === behaviorIdx && <BehaviorTab formData={editedInfo} onChange={handleFieldChange} />}
+                {activeTab === wearablesIdx && <WearableTab formData={editedInfo} onChange={handleFieldChange} onRefresh={() => { if (personId) { api.get(`/patient-info/${personId}/`).then(res => { const d = res.data.patient_info; setPatientInfo(d); setEditedInfo(d); }); } }} />}
+                {surveysIdx >= 0 && activeTab === surveysIdx && <PatientSurveys user={user ?? null} />}
               </div>
-            ) : (
-              <div key={activeTab} className="animate-tab-in">
-                {patientMode && activeTab === baseTabCount && <AllergyList user={user ?? null} />}
-                {patientMode && activeTab === baseTabCount + 1 && <ImmunizationList user={user ?? null} />}
-              </div>
-            )}
+            </div>
           </>
         )}
 

--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -690,7 +690,7 @@ export default function PatientDetail({
                 {activeTab === 4 && <LabsTab formData={editedInfo} onChange={handleFieldChange} />}
                 {allergiesIdx >= 0 && activeTab === allergiesIdx && <AllergyList user={user ?? null} />}
                 {activeTab === behaviorIdx && <BehaviorTab formData={editedInfo} onChange={handleFieldChange} />}
-                {activeTab === wearablesIdx && <WearableTab formData={editedInfo} onChange={handleFieldChange} onRefresh={() => { if (personId) { api.get(`/patient-info/${personId}/`).then(res => { const d = res.data.patient_info; setPatientInfo(d); setEditedInfo(d); }); } }} />}
+                {activeTab === wearablesIdx && <WearableTab formData={editedInfo} onChange={handleFieldChange} onRefresh={() => { if (personId) { api.get(`/patient-info/${personId}/`).then(res => { const d = res.data.patient_info; setPatientInfo(d); setEditedInfo(d); }).catch(() => {}); } }} />}
                 {surveysIdx >= 0 && activeTab === surveysIdx && <PatientSurveys user={user ?? null} />}
               </div>
             </div>

--- a/frontend/src/components/PatientInfo/tabs/WearableTab.tsx
+++ b/frontend/src/components/PatientInfo/tabs/WearableTab.tsx
@@ -1,5 +1,7 @@
+import { useRef, useState } from 'react';
 import Field from '../Field';
 import Section from '../Section';
+import api from '@/api/axios';
 
 const ACTIVITY_TREND_OPTIONS = ['improving', 'stable', 'declining', 'insufficient_data'];
 
@@ -8,7 +10,15 @@ interface Props {
   // onChange is accepted for API consistency with other tabs but not invoked —
   // all wearable fields are read-only (derived from OMOP, not user-editable).
   onChange?: (field: string, value: unknown) => void;
+  onRefresh?: () => void;
 }
+
+const SOURCES = [
+  { key: 'garmin', label: 'Garmin', accept: '.fit', enabled: true, multiple: true },
+  { key: 'apple', label: 'Apple Health', accept: '.zip', enabled: true, multiple: false },
+  { key: 'oura', label: 'Oura', accept: '', enabled: false, multiple: false },
+  { key: 'fitbit', label: 'Fitbit', accept: '', enabled: false, multiple: false },
+] as const;
 
 function formatSyncDate(raw: unknown): string {
   if (!raw) return '';
@@ -19,11 +29,145 @@ function formatSyncDate(raw: unknown): string {
   }
 }
 
-export default function WearableTab({ formData }: Props) {
+export default function WearableTab({ formData, onRefresh }: Props) {
   const noData = !formData?.wearable_last_sync_at;
+  const [showPicker, setShowPicker] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [selectedSource, setSelectedSource] = useState<string | null>(null);
+
+  const handleSourceSelect = (sourceKey: string) => {
+    const source = SOURCES.find(s => s.key === sourceKey);
+    if (!source || !source.enabled) return;
+    setSelectedSource(sourceKey);
+    setShowPicker(false);
+    // Trigger file picker
+    if (fileInputRef.current) {
+      fileInputRef.current.accept = source.accept;
+      fileInputRef.current.multiple = source.multiple;
+      fileInputRef.current.click();
+    }
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0 || !selectedSource) return;
+
+    setUploading(true);
+    setUploadResult(null);
+    setUploadError(null);
+
+    let totalCreated = 0;
+    let totalDuplicates = 0;
+
+    try {
+      for (let i = 0; i < files.length; i++) {
+        const formData = new FormData();
+        formData.append('file', files[i]);
+        formData.append('device_type', selectedSource);
+
+        const res = await api.post('/v1/patient-records/upload-wearable/', formData, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        });
+
+        totalCreated += res.data.samples_created || 0;
+        totalDuplicates += res.data.duplicates_skipped || 0;
+      }
+
+      setUploadResult(
+        `Uploaded ${totalCreated} sample${totalCreated !== 1 ? 's' : ''}` +
+        (totalDuplicates > 0 ? ` (${totalDuplicates} duplicate${totalDuplicates !== 1 ? 's' : ''} skipped)` : '')
+      );
+
+      // Trigger parent refresh to update displayed summaries
+      if (totalCreated > 0 && onRefresh) {
+        onRefresh();
+      }
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+        || 'Upload failed. Please try again.';
+      setUploadError(msg);
+    } finally {
+      setUploading(false);
+      setSelectedSource(null);
+      // Reset file input so the same file can be re-selected
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
 
   return (
     <div>
+      {/* Upload controls */}
+      <div className="mb-4 flex items-center gap-3">
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setShowPicker(!showPicker)}
+            disabled={uploading}
+            className="inline-flex items-center gap-2 rounded-md bg-portal-brand px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-portal-brand/90 disabled:opacity-50"
+          >
+            {uploading ? (
+              <>
+                <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Uploading...
+              </>
+            ) : (
+              <>
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5-5m0 0l5 5m-5-5v12" />
+                </svg>
+                Upload
+              </>
+            )}
+          </button>
+
+          {showPicker && (
+            <div className="absolute left-0 top-full z-10 mt-1 w-56 rounded-md border border-gray-200 bg-white py-1 shadow-lg">
+              {SOURCES.map(source => (
+                <button
+                  key={source.key}
+                  type="button"
+                  onClick={() => handleSourceSelect(source.key)}
+                  disabled={!source.enabled}
+                  className={`flex w-full items-center justify-between px-4 py-2 text-left text-sm ${
+                    source.enabled
+                      ? 'text-gray-700 hover:bg-gray-50'
+                      : 'cursor-not-allowed text-gray-400'
+                  }`}
+                >
+                  <span>{source.label}</span>
+                  {!source.enabled && (
+                    <span className="text-xs text-gray-400">Coming soon</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {uploadResult && (
+          <span className="text-sm text-green-600">{uploadResult}</span>
+        )}
+        {uploadError && (
+          <span className="text-sm text-red-600">{uploadError}</span>
+        )}
+      </div>
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
       {noData && (
         <p className="mb-4 text-sm text-gray-500 italic">
           No wearable data synced yet. Click Upload to contribute wearable data to your record.
@@ -35,7 +179,7 @@ export default function WearableTab({ formData }: Props) {
           <div className="space-y-1.5">
             <label className="text-sm font-medium text-portal-text-primary">Last Sync</label>
             <p className="text-sm text-gray-700 py-1.5">
-              {formatSyncDate(formData?.wearable_last_sync_at) || '—'}
+              {formatSyncDate(formData?.wearable_last_sync_at) || '\u2014'}
             </p>
           </div>
           <div className="space-y-1.5">
@@ -45,7 +189,7 @@ export default function WearableTab({ formData }: Props) {
             <p className="text-sm text-gray-700 py-1.5">
               {formData?.wearable_coverage_ratio_30d != null
                 ? `${(Number(formData.wearable_coverage_ratio_30d) * 100).toFixed(0)}%`
-                : '—'}
+                : '\u2014'}
             </p>
           </div>
         </div>
@@ -105,7 +249,7 @@ export default function WearableTab({ formData }: Props) {
       <Section title="Respiratory (30-Day)">
         <div className="grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
           <Field
-            label="Min SpO₂ (%)"
+            label="Min SpO\u2082 (%)"
             name="oxygen_saturation_min_30d"
             type="number"
             value={formData?.oxygen_saturation_min_30d}

--- a/frontend/src/components/PatientInfo/tabs/WearableTab.tsx
+++ b/frontend/src/components/PatientInfo/tabs/WearableTab.tsx
@@ -64,11 +64,11 @@ export default function WearableTab({ formData, onRefresh }: Props) {
 
     try {
       for (let i = 0; i < files.length; i++) {
-        const formData = new FormData();
-        formData.append('file', files[i]);
-        formData.append('device_type', selectedSource);
+        const payload = new FormData();
+        payload.append('file', files[i]);
+        payload.append('device_type', selectedSource);
 
-        const res = await api.post('/v1/patient-records/upload-wearable/', formData, {
+        const res = await api.post('/v1/patient-records/upload-wearable/', payload, {
           headers: { 'Content-Type': 'multipart/form-data' },
         });
 

--- a/omop_core/services/wearable_parsers.py
+++ b/omop_core/services/wearable_parsers.py
@@ -1,0 +1,278 @@
+"""Parsers for wearable device data files.
+
+Supported formats:
+- Garmin FIT files (.fit) — exported from Garmin Connect or USB-mounted watch
+- Apple Health export.zip — exported from Apple Health app on iPhone
+"""
+import io
+import logging
+import zipfile
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from typing import NamedTuple
+
+logger = logging.getLogger(__name__)
+
+
+class WearableSample(NamedTuple):
+    """A single daily metric extracted from a wearable data file."""
+    metric_key: str   # one of WEARABLE_LOINC keys
+    date: date
+    value: float
+
+
+# ── Garmin FIT ──────────────────────────────────────────────────────────────
+
+def parse_garmin_fit(file_bytes: bytes) -> list[WearableSample]:
+    """Parse a Garmin .fit file and return daily wearable samples.
+
+    Uses the ``fitparse`` library to iterate over FIT messages.  Extracts:
+    - steps (from ``monitoring`` or ``session`` messages)
+    - resting heart rate, HRV, SpO2, respiratory rate (from ``session``/``record``)
+    - active minutes (from ``session`` duration)
+    - sleep duration (from ``sleep_level`` messages)
+    """
+    try:
+        from fitparse import FitFile
+    except ImportError:
+        raise RuntimeError("python-fitparse is required for Garmin FIT uploads: pip install python-fitparse")
+
+    fitfile = FitFile(io.BytesIO(file_bytes))
+    fitfile.parse()
+
+    # Accumulators: metric_key → date → list of values (aggregated per day)
+    daily: dict[str, dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+
+    for record in fitfile.get_messages():
+        msg_type = record.name
+        fields = {f.name: f.value for f in record.fields}
+
+        ts = fields.get('timestamp')
+        if ts is None:
+            continue
+        if isinstance(ts, datetime):
+            d = ts.date()
+        else:
+            continue
+
+        if msg_type == 'monitoring':
+            # Steps from monitoring messages
+            steps = fields.get('cycles')
+            if steps is not None:
+                try:
+                    # Garmin stores steps as cycles*2 in some files
+                    daily['steps'][d].append(float(steps))
+                except (TypeError, ValueError):
+                    pass
+
+            hr = fields.get('heart_rate')
+            if hr is not None:
+                try:
+                    daily['resting_hr'][d].append(float(hr))
+                except (TypeError, ValueError):
+                    pass
+
+        elif msg_type == 'session':
+            # Active minutes from session duration (total_timer_time in seconds)
+            timer_time = fields.get('total_timer_time')
+            if timer_time is not None:
+                try:
+                    daily['active_minutes'][d].append(float(timer_time) / 60.0)
+                except (TypeError, ValueError):
+                    pass
+
+            # Steps from session if available
+            total_steps = fields.get('total_steps') or fields.get('total_cycles')
+            if total_steps is not None:
+                try:
+                    daily['steps'][d].append(float(total_steps))
+                except (TypeError, ValueError):
+                    pass
+
+            # SpO2
+            spo2 = fields.get('saturated_hemoglobin_percent') or fields.get('avg_saturated_hemoglobin_percent')
+            if spo2 is not None:
+                try:
+                    val = float(spo2)
+                    if val <= 1.0:
+                        val *= 100.0
+                    daily['spo2'][d].append(val)
+                except (TypeError, ValueError):
+                    pass
+
+            # Respiratory rate
+            rr = fields.get('avg_respiration_rate') or fields.get('respiration_rate')
+            if rr is not None:
+                try:
+                    daily['respiratory_rate'][d].append(float(rr))
+                except (TypeError, ValueError):
+                    pass
+
+        elif msg_type == 'record':
+            hr = fields.get('heart_rate')
+            if hr is not None:
+                try:
+                    daily['resting_hr'][d].append(float(hr))
+                except (TypeError, ValueError):
+                    pass
+
+        elif msg_type in ('sleep_level', 'sleep_data'):
+            # Sleep duration: compute from timestamp span if we see start/end
+            duration_sec = fields.get('total_timer_time')
+            if duration_sec is not None:
+                try:
+                    daily['sleep_duration'][d].append(float(duration_sec) / 3600.0)
+                except (TypeError, ValueError):
+                    pass
+
+        elif msg_type == 'stress':
+            # HRV SDNN sometimes in stress messages
+            hrv = fields.get('heart_rate_variability')
+            if hrv is not None:
+                try:
+                    daily['hrv_sdnn'][d].append(float(hrv))
+                except (TypeError, ValueError):
+                    pass
+
+        elif msg_type == 'hrv':
+            # Dedicated HRV message type
+            sdnn = fields.get('weekly_average') or fields.get('sdnn')
+            if sdnn is not None:
+                try:
+                    daily['hrv_sdnn'][d].append(float(sdnn))
+                except (TypeError, ValueError):
+                    pass
+
+    # Collapse daily lists to single values
+    samples: list[WearableSample] = []
+    for metric_key, date_map in daily.items():
+        for d, values in date_map.items():
+            if metric_key == 'steps':
+                # Sum steps across the day
+                agg = sum(values)
+            elif metric_key in ('active_minutes', 'sleep_duration'):
+                # Sum durations
+                agg = sum(values)
+            else:
+                # Average for rates/percentages
+                agg = sum(values) / len(values)
+            samples.append(WearableSample(metric_key=metric_key, date=d, value=round(agg, 2)))
+
+    logger.info('garmin_fit_parsed samples=%d metrics=%s', len(samples), sorted(daily.keys()))
+    return samples
+
+
+# ── Apple Health ────────────────────────────────────────────────────────────
+
+# HKQuantityType → our metric key
+_APPLE_TYPE_MAP = {
+    'HKQuantityTypeIdentifierStepCount': 'steps',
+    'HKQuantityTypeIdentifierAppleExerciseTime': 'active_minutes',
+    'HKQuantityTypeIdentifierRestingHeartRate': 'resting_hr',
+    'HKQuantityTypeIdentifierHeartRateVariabilitySDNN': 'hrv_sdnn',
+    'HKQuantityTypeIdentifierOxygenSaturation': 'spo2',
+    'HKQuantityTypeIdentifierRespiratoryRate': 'respiratory_rate',
+}
+
+_APPLE_SLEEP_TYPE = 'HKCategoryTypeIdentifierSleepAnalysis'
+
+
+def parse_apple_health_export(zip_bytes: bytes) -> list[WearableSample]:
+    """Parse an Apple Health export.zip and return daily wearable samples.
+
+    Streams ``apple_health_export/export.xml`` using ``iterparse`` to keep
+    memory usage low on large exports.
+    """
+    import xml.etree.ElementTree as ET
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile:
+        raise ValueError("Uploaded file is not a valid ZIP archive.")
+
+    # Find the export.xml inside the zip
+    xml_name = None
+    for name in zf.namelist():
+        if name.endswith('export.xml'):
+            xml_name = name
+            break
+    if xml_name is None:
+        raise ValueError("ZIP does not contain export.xml. Please upload the Apple Health export.zip.")
+
+    daily: dict[str, dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+
+    with zf.open(xml_name) as xml_file:
+        for event, elem in ET.iterparse(xml_file, events=('end',)):
+            if elem.tag != 'Record':
+                elem.clear()
+                continue
+
+            record_type = elem.get('type', '')
+            metric_key = _APPLE_TYPE_MAP.get(record_type)
+
+            if metric_key is not None:
+                # Quantity record
+                value_str = elem.get('value')
+                start_str = elem.get('startDate', '')
+                if value_str and start_str:
+                    try:
+                        val = float(value_str)
+                        # SpO2 is stored as fraction (0-1) in Apple Health
+                        if metric_key == 'spo2' and val <= 1.0:
+                            val *= 100.0
+                        d = _parse_apple_date(start_str)
+                        if d is not None:
+                            daily[metric_key][d].append(val)
+                    except (TypeError, ValueError):
+                        pass
+
+            elif record_type == _APPLE_SLEEP_TYPE:
+                # Sleep: compute duration from start/end
+                start_str = elem.get('startDate', '')
+                end_str = elem.get('endDate', '')
+                # Only count "asleep" categories (skip InBed)
+                sleep_value = elem.get('value', '')
+                if 'Asleep' in sleep_value or 'asleep' in sleep_value.lower() if sleep_value else False:
+                    if start_str and end_str:
+                        try:
+                            start_dt = _parse_apple_datetime(start_str)
+                            end_dt = _parse_apple_datetime(end_str)
+                            if start_dt and end_dt and end_dt > start_dt:
+                                hours = (end_dt - start_dt).total_seconds() / 3600.0
+                                d = start_dt.date()
+                                daily['sleep_duration'][d].append(hours)
+                        except (TypeError, ValueError):
+                            pass
+
+            elem.clear()
+
+    # Collapse daily lists to single values
+    samples: list[WearableSample] = []
+    for metric_key, date_map in daily.items():
+        for d, values in date_map.items():
+            if metric_key in ('steps', 'active_minutes', 'sleep_duration'):
+                agg = sum(values)
+            else:
+                agg = sum(values) / len(values)
+            samples.append(WearableSample(metric_key=metric_key, date=d, value=round(agg, 2)))
+
+    logger.info('apple_health_parsed samples=%d metrics=%s', len(samples), sorted(daily.keys()))
+    return samples
+
+
+def _parse_apple_date(s: str) -> date | None:
+    """Parse Apple Health date string like '2024-01-15 08:30:00 -0700' to date."""
+    try:
+        # Format: "2024-01-15 08:30:00 -0700"
+        return datetime.strptime(s[:10], '%Y-%m-%d').date()
+    except (ValueError, IndexError):
+        return None
+
+
+def _parse_apple_datetime(s: str) -> datetime | None:
+    """Parse Apple Health datetime string to datetime."""
+    try:
+        # "2024-01-15 08:30:00 -0700" — strip timezone for simplicity
+        return datetime.strptime(s[:19], '%Y-%m-%d %H:%M:%S')
+    except (ValueError, IndexError):
+        return None

--- a/omop_core/services/wearable_parsers.py
+++ b/omop_core/services/wearable_parsers.py
@@ -43,6 +43,17 @@ def parse_garmin_fit(file_bytes: bytes) -> list[WearableSample]:
     # Accumulators: metric_key → date → list of values (aggregated per day)
     daily: dict[str, dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
 
+    # Separate step sources to avoid double-counting:
+    # monitoring_steps has incremental cycle counts; session_steps has activity totals.
+    # We prefer monitoring (full-day) over session (activity subset) when both exist.
+    monitoring_steps: dict[date, list[float]] = defaultdict(list)
+    session_steps: dict[date, list[float]] = defaultdict(list)
+
+    # Separate HR sources: monitoring HR includes active periods and overestimates
+    # resting HR. We collect monitoring HR separately and use the 10th percentile
+    # as a resting HR proxy (closest to true resting without dedicated resting HR data).
+    monitoring_hr: dict[date, list[float]] = defaultdict(list)
+
     for record in fitfile.get_messages():
         msg_type = record.name
         fields = {f.name: f.value for f in record.fields}
@@ -56,19 +67,19 @@ def parse_garmin_fit(file_bytes: bytes) -> list[WearableSample]:
             continue
 
         if msg_type == 'monitoring':
-            # Steps from monitoring messages
+            # Incremental step cycles throughout the day
             steps = fields.get('cycles')
             if steps is not None:
                 try:
-                    # Garmin stores steps as cycles*2 in some files
-                    daily['steps'][d].append(float(steps))
+                    monitoring_steps[d].append(float(steps))
                 except (TypeError, ValueError):
                     pass
 
+            # All-day HR samples — NOT resting HR; collected separately
             hr = fields.get('heart_rate')
             if hr is not None:
                 try:
-                    daily['resting_hr'][d].append(float(hr))
+                    monitoring_hr[d].append(float(hr))
                 except (TypeError, ValueError):
                     pass
 
@@ -81,11 +92,11 @@ def parse_garmin_fit(file_bytes: bytes) -> list[WearableSample]:
                 except (TypeError, ValueError):
                     pass
 
-            # Steps from session if available
+            # Session step totals (activity subset, used as fallback only)
             total_steps = fields.get('total_steps') or fields.get('total_cycles')
             if total_steps is not None:
                 try:
-                    daily['steps'][d].append(float(total_steps))
+                    session_steps[d].append(float(total_steps))
                 except (TypeError, ValueError):
                     pass
 
@@ -105,14 +116,6 @@ def parse_garmin_fit(file_bytes: bytes) -> list[WearableSample]:
             if rr is not None:
                 try:
                     daily['respiratory_rate'][d].append(float(rr))
-                except (TypeError, ValueError):
-                    pass
-
-        elif msg_type == 'record':
-            hr = fields.get('heart_rate')
-            if hr is not None:
-                try:
-                    daily['resting_hr'][d].append(float(hr))
                 except (TypeError, ValueError):
                     pass
 
@@ -142,6 +145,25 @@ def parse_garmin_fit(file_bytes: bytes) -> list[WearableSample]:
                     daily['hrv_sdnn'][d].append(float(sdnn))
                 except (TypeError, ValueError):
                     pass
+
+    # Merge step sources: prefer monitoring (full-day) over session (activity subset)
+    all_step_dates = set(monitoring_steps.keys()) | set(session_steps.keys())
+    for d in all_step_dates:
+        if monitoring_steps.get(d):
+            daily['steps'][d] = monitoring_steps[d]
+        elif session_steps.get(d):
+            daily['steps'][d] = session_steps[d]
+
+    # Approximate resting HR from monitoring data using the 10th percentile.
+    # All-day monitoring includes active HR which inflates the average. The
+    # 10th percentile captures the lower range (rest/sleep) without being
+    # as noisy as the absolute minimum.
+    for d, hr_values in monitoring_hr.items():
+        if hr_values:
+            sorted_hr = sorted(hr_values)
+            p10_idx = max(0, len(sorted_hr) // 10)
+            resting_estimate = sorted_hr[p10_idx]
+            daily['resting_hr'][d].append(resting_estimate)
 
     # Collapse daily lists to single values
     samples: list[WearableSample] = []
@@ -183,7 +205,7 @@ def parse_apple_health_export(zip_bytes: bytes) -> list[WearableSample]:
     Streams ``apple_health_export/export.xml`` using ``iterparse`` to keep
     memory usage low on large exports.
     """
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     try:
         zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
@@ -232,7 +254,7 @@ def parse_apple_health_export(zip_bytes: bytes) -> list[WearableSample]:
                 end_str = elem.get('endDate', '')
                 # Only count "asleep" categories (skip InBed)
                 sleep_value = elem.get('value', '')
-                if 'Asleep' in sleep_value or 'asleep' in sleep_value.lower() if sleep_value else False:
+                if sleep_value and 'asleep' in sleep_value.lower():
                     if start_str and end_str:
                         try:
                             start_dt = _parse_apple_datetime(start_str)

--- a/omop_core/services/wearable_parsers.py
+++ b/omop_core/services/wearable_parsers.py
@@ -6,6 +6,7 @@ Supported formats:
 """
 import io
 import logging
+import xml.etree.ElementTree as ET
 import zipfile
 from collections import defaultdict
 from datetime import date, datetime, timedelta
@@ -146,11 +147,12 @@ def parse_garmin_fit(file_bytes: bytes) -> list[WearableSample]:
                 except (TypeError, ValueError):
                     pass
 
-    # Merge step sources: prefer monitoring (full-day) over session (activity subset)
+    # Merge step sources: prefer monitoring (full-day) over session (activity subset).
+    # monitoring.cycles is a cumulative counter, so take the max (= total) not the sum.
     all_step_dates = set(monitoring_steps.keys()) | set(session_steps.keys())
     for d in all_step_dates:
         if monitoring_steps.get(d):
-            daily['steps'][d] = monitoring_steps[d]
+            daily['steps'][d] = [max(monitoring_steps[d])]
         elif session_steps.get(d):
             daily['steps'][d] = session_steps[d]
 
@@ -199,14 +201,17 @@ _APPLE_TYPE_MAP = {
 _APPLE_SLEEP_TYPE = 'HKCategoryTypeIdentifierSleepAnalysis'
 
 
+_MAX_XML_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB zip bomb limit
+
+
 def parse_apple_health_export(zip_bytes: bytes) -> list[WearableSample]:
     """Parse an Apple Health export.zip and return daily wearable samples.
 
     Streams ``apple_health_export/export.xml`` using ``iterparse`` to keep
-    memory usage low on large exports.
+    memory usage low on large exports.  Uses stdlib ``xml.etree.ElementTree``
+    (defusedxml does not expose ``iterparse``).  The root element is cleared
+    after each record to prevent memory accumulation.
     """
-    import defusedxml.ElementTree as ET
-
     try:
         zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
     except zipfile.BadZipFile:
@@ -214,9 +219,15 @@ def parse_apple_health_export(zip_bytes: bytes) -> list[WearableSample]:
 
     # Find the export.xml inside the zip
     xml_name = None
-    for name in zf.namelist():
-        if name.endswith('export.xml'):
-            xml_name = name
+    for info in zf.infolist():
+        if info.filename.endswith('export.xml'):
+            # Zip bomb protection: reject implausibly large uncompressed XML
+            if info.file_size > _MAX_XML_UNCOMPRESSED_BYTES:
+                raise ValueError(
+                    f"export.xml uncompressed size ({info.file_size / (1024**3):.1f} GB) "
+                    f"exceeds the {_MAX_XML_UNCOMPRESSED_BYTES // (1024**3)} GB limit."
+                )
+            xml_name = info.filename
             break
     if xml_name is None:
         raise ValueError("ZIP does not contain export.xml. Please upload the Apple Health export.zip.")
@@ -224,7 +235,13 @@ def parse_apple_health_export(zip_bytes: bytes) -> list[WearableSample]:
     daily: dict[str, dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
 
     with zf.open(xml_name) as xml_file:
-        for event, elem in ET.iterparse(xml_file, events=('end',)):
+        context = ET.iterparse(xml_file, events=('start', 'end'))
+        root = None
+        for event, elem in context:
+            if root is None:
+                root = elem
+            if event != 'end':
+                continue
             if elem.tag != 'Record':
                 elem.clear()
                 continue
@@ -267,6 +284,8 @@ def parse_apple_health_export(zip_bytes: bytes) -> list[WearableSample]:
                             pass
 
             elem.clear()
+            if root is not None:
+                root.clear()
 
     # Collapse daily lists to single values
     samples: list[WearableSample] = []

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -3541,6 +3541,188 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         except Exception as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
+    @action(detail=False, methods=['post'], url_path='upload-wearable',
+            permission_classes=[IsAuthenticated])
+    def upload_wearable(self, request):
+        """POST /api/v1/patient-records/upload-wearable/
+
+        Accept a wearable data file (Garmin .fit or Apple Health .zip) and
+        write parsed samples into OMOP Measurement/Observation rows, then
+        refresh the PatientRecord 30-day summaries.
+
+        Form fields:
+          - file: the uploaded file
+          - device_type: 'garmin' | 'apple'
+        """
+        from omop_core.services.wearable_parsers import parse_garmin_fit, parse_apple_health_export
+        from omop_core.services.pk import next_pk_batch as _next_pk_batch
+        from omop_core.services.mappings import WEARABLE_LOINC, WEARABLE_ARTIFACT_BOUNDS
+        from omop_core.services.concept_cache import concept_by_loinc as _cc_by_loinc
+
+        if 'file' not in request.FILES:
+            return Response({'error': 'No file provided'}, status=status.HTTP_400_BAD_REQUEST)
+
+        device_type = request.data.get('device_type', '').strip().lower()
+        if device_type not in ('garmin', 'apple'):
+            return Response(
+                {'error': "device_type must be 'garmin' or 'apple'"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        uploaded = request.FILES['file']
+        file_bytes = uploaded.read()
+
+        # Validate file extension
+        name = (uploaded.name or '').lower()
+        if device_type == 'garmin' and not name.endswith('.fit'):
+            return Response({'error': 'Garmin uploads must be .fit files'}, status=status.HTTP_400_BAD_REQUEST)
+        if device_type == 'apple' and not name.endswith('.zip'):
+            return Response({'error': 'Apple Health uploads must be .zip files'}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Resolve the Person for the current user
+        from patient_portal.models import PatientUser
+        try:
+            patient_user = PatientUser.objects.get(identity=request.user)
+            person = patient_user.person
+        except PatientUser.DoesNotExist:
+            return Response(
+                {'error': 'No patient record linked to your account'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # Parse the file
+        try:
+            if device_type == 'garmin':
+                samples = parse_garmin_fit(file_bytes)
+            else:
+                samples = parse_apple_health_export(file_bytes)
+        except Exception as e:
+            logger.exception('wearable_parse_error device=%s', device_type)
+            return Response({'error': f'Failed to parse file: {e}'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not samples:
+            return Response({'samples_created': 0, 'duplicates_skipped': 0})
+
+        # Look up LOINC concepts for each metric
+        loinc_concepts: dict[str, Concept | None] = {}
+        for metric_key, loinc_code in WEARABLE_LOINC.items():
+            loinc_concepts[metric_key] = _cc_by_loinc(loinc_code)
+
+        # Measurement type concept (wearable device = 32883 / Patient self-report)
+        type_concept = None
+        try:
+            type_concept = Concept.objects.get(concept_id=32883)
+        except Concept.DoesNotExist:
+            try:
+                type_concept = Concept.objects.get(concept_id=32856)  # Lab fallback
+            except Concept.DoesNotExist:
+                pass
+
+        # Filter out artifact values and deduplicate
+        from django.db.models import Q
+
+        existing_keys = set()
+        # Build set of (metric_key, date, value) that already exist
+        for metric_key in set(s.metric_key for s in samples):
+            concept = loinc_concepts.get(metric_key)
+            if concept is None:
+                continue
+            existing_measurements = Measurement.objects.filter(
+                person=person,
+                measurement_concept=concept,
+            ).values_list('measurement_date', 'value_as_number')
+            for m_date, m_val in existing_measurements:
+                if m_val is not None:
+                    existing_keys.add((metric_key, m_date, float(m_val)))
+
+        pending_measurements = []
+        pending_observations = []
+        duplicates_skipped = 0
+
+        for sample in samples:
+            concept = loinc_concepts.get(sample.metric_key)
+            if concept is None:
+                continue
+
+            # Artifact filter
+            bounds = WEARABLE_ARTIFACT_BOUNDS.get(sample.metric_key)
+            if bounds and not (bounds[0] <= sample.value <= bounds[1]):
+                continue
+
+            # Dedup check
+            dedup_key = (sample.metric_key, sample.date, round(sample.value, 2))
+            if dedup_key in existing_keys:
+                duplicates_skipped += 1
+                continue
+            existing_keys.add(dedup_key)
+
+            if sample.metric_key == 'sleep_duration':
+                # Sleep goes into Observation table
+                obs = Observation(
+                    observation_id=0,  # allocated below
+                    person=person,
+                    observation_concept=concept,
+                    observation_date=sample.date,
+                    observation_type_concept=type_concept,
+                    value_as_number=sample.value,
+                    observation_source_value=WEARABLE_LOINC[sample.metric_key],
+                    unit_source_value='h',
+                )
+                pending_observations.append(obs)
+            else:
+                # All other metrics go into Measurement table
+                unit_map = {
+                    'steps': '/d',
+                    'active_minutes': 'min',
+                    'resting_hr': '/min',
+                    'hrv_sdnn': 'ms',
+                    'spo2': '%',
+                    'respiratory_rate': '/min',
+                }
+                m = Measurement(
+                    measurement_id=0,  # allocated below
+                    person=person,
+                    measurement_concept=concept,
+                    measurement_date=sample.date,
+                    measurement_type_concept=type_concept,
+                    value_as_number=sample.value,
+                    measurement_source_value=WEARABLE_LOINC[sample.metric_key],
+                    unit_source_value=unit_map.get(sample.metric_key),
+                )
+                m._skip_patient_record_refresh = True
+                pending_measurements.append(m)
+
+        created_count = 0
+        with transaction.atomic():
+            if pending_measurements:
+                m_ids = _next_pk_batch(Measurement, 'measurement_id', len(pending_measurements))
+                for m, mid in zip(pending_measurements, m_ids):
+                    m.measurement_id = mid
+                Measurement.objects.bulk_create(pending_measurements)
+                created_count += len(pending_measurements)
+
+            if pending_observations:
+                obs_ids = _next_pk_batch(Observation, 'observation_id', len(pending_observations))
+                for obs, oid in zip(pending_observations, obs_ids):
+                    obs.observation_id = oid
+                Observation.objects.bulk_create(pending_observations)
+                created_count += len(pending_observations)
+
+        # Refresh the PatientRecord to recompute 30-day summaries
+        try:
+            refresh_patient_record(person)
+        except Exception:
+            logger.exception('wearable_refresh_failed person_id=%s', person.person_id)
+
+        logger.info(
+            'wearable_upload_complete device=%s person_id=%s created=%d duplicates=%d',
+            device_type, person.person_id, created_count, duplicates_skipped,
+        )
+        return Response({
+            'samples_created': created_count,
+            'duplicates_skipped': duplicates_skipped,
+        })
+
     @action(detail=False, methods=['delete'], permission_classes=[ScopedTokenPermission])
     def bulk_delete(self, request):
         """Delete multiple patients by person_ids"""

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -3570,6 +3570,12 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             )
 
         uploaded = request.FILES['file']
+        MAX_WEARABLE_UPLOAD_BYTES = 200 * 1024 * 1024  # 200 MB
+        if uploaded.size and uploaded.size > MAX_WEARABLE_UPLOAD_BYTES:
+            return Response(
+                {'error': f'File too large. Maximum size is {MAX_WEARABLE_UPLOAD_BYTES // (1024 * 1024)} MB.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         file_bytes = uploaded.read()
 
         # Validate file extension
@@ -3598,7 +3604,11 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                 samples = parse_apple_health_export(file_bytes)
         except Exception as e:
             logger.exception('wearable_parse_error device=%s', device_type)
-            return Response({'error': f'Failed to parse file: {e}'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {'error': 'Failed to parse file. Please ensure it is a valid '
+                          f'{"Garmin .fit" if device_type == "garmin" else "Apple Health export.zip"} file.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         if not samples:
             return Response({'samples_created': 0, 'duplicates_skipped': 0})
@@ -3622,18 +3632,25 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         from django.db.models import Q
 
         existing_keys = set()
-        # Build set of (metric_key, date, value) that already exist
+        # Build set of (metric_key, date, value) that already exist.
+        # Most metrics live in Measurement; sleep_duration lives in Observation.
         for metric_key in set(s.metric_key for s in samples):
             concept = loinc_concepts.get(metric_key)
             if concept is None:
                 continue
-            existing_measurements = Measurement.objects.filter(
-                person=person,
-                measurement_concept=concept,
-            ).values_list('measurement_date', 'value_as_number')
-            for m_date, m_val in existing_measurements:
-                if m_val is not None:
-                    existing_keys.add((metric_key, m_date, float(m_val)))
+            if metric_key == 'sleep_duration':
+                existing_rows = Observation.objects.filter(
+                    person=person,
+                    observation_concept=concept,
+                ).values_list('observation_date', 'value_as_number')
+            else:
+                existing_rows = Measurement.objects.filter(
+                    person=person,
+                    measurement_concept=concept,
+                ).values_list('measurement_date', 'value_as_number')
+            for row_date, row_val in existing_rows:
+                if row_val is not None:
+                    existing_keys.add((metric_key, row_date, float(row_val)))
 
         pending_measurements = []
         pending_observations = []
@@ -3668,6 +3685,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                     observation_source_value=WEARABLE_LOINC[sample.metric_key],
                     unit_source_value='h',
                 )
+                obs._skip_patient_record_refresh = True
                 pending_observations.append(obs)
             else:
                 # All other metrics go into Measurement table

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -3570,20 +3570,21 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             )
 
         uploaded = request.FILES['file']
-        MAX_WEARABLE_UPLOAD_BYTES = 200 * 1024 * 1024  # 200 MB
-        if uploaded.size and uploaded.size > MAX_WEARABLE_UPLOAD_BYTES:
-            return Response(
-                {'error': f'File too large. Maximum size is {MAX_WEARABLE_UPLOAD_BYTES // (1024 * 1024)} MB.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        file_bytes = uploaded.read()
 
-        # Validate file extension
+        # Validate file extension before reading the file body
         name = (uploaded.name or '').lower()
         if device_type == 'garmin' and not name.endswith('.fit'):
             return Response({'error': 'Garmin uploads must be .fit files'}, status=status.HTTP_400_BAD_REQUEST)
         if device_type == 'apple' and not name.endswith('.zip'):
             return Response({'error': 'Apple Health uploads must be .zip files'}, status=status.HTTP_400_BAD_REQUEST)
+
+        MAX_WEARABLE_UPLOAD_BYTES = 200 * 1024 * 1024  # 200 MB
+        if uploaded.size is not None and uploaded.size > MAX_WEARABLE_UPLOAD_BYTES:
+            return Response(
+                {'error': f'File too large. Maximum size is {MAX_WEARABLE_UPLOAD_BYTES // (1024 * 1024)} MB.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        file_bytes = uploaded.read()
 
         # Resolve the Person for the current user
         from patient_portal.models import PatientUser

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -15270,3 +15270,297 @@ class MeetsCrabSlimFieldTest(_SmartBase):
         self.assertEqual(resp.status_code, 200)
         self.mm_record.refresh_from_db()
         self.assertEqual(self.mm_record.myeloma_type, 'IgA Lambda')
+
+
+# =============================================================================
+# Wearable Upload Tests
+# =============================================================================
+
+class WearableParserUnitTest(TestCase):
+    """Unit tests for the Garmin FIT and Apple Health parsers."""
+
+    def test_parse_apple_health_export_basic(self):
+        """Parse a minimal Apple Health export.zip with step count records."""
+        import zipfile
+        from omop_core.services.wearable_parsers import parse_apple_health_export
+
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Record type="HKQuantityTypeIdentifierStepCount"
+          startDate="2024-06-01 08:00:00 -0700"
+          endDate="2024-06-01 08:30:00 -0700"
+          value="1500"/>
+  <Record type="HKQuantityTypeIdentifierStepCount"
+          startDate="2024-06-01 12:00:00 -0700"
+          endDate="2024-06-01 12:30:00 -0700"
+          value="2000"/>
+  <Record type="HKQuantityTypeIdentifierRestingHeartRate"
+          startDate="2024-06-01 06:00:00 -0700"
+          endDate="2024-06-01 06:00:00 -0700"
+          value="62"/>
+  <Record type="HKQuantityTypeIdentifierOxygenSaturation"
+          startDate="2024-06-02 07:00:00 -0700"
+          endDate="2024-06-02 07:00:00 -0700"
+          value="0.97"/>
+</HealthData>
+"""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('apple_health_export/export.xml', xml_content)
+        zip_bytes = buf.getvalue()
+
+        samples = parse_apple_health_export(zip_bytes)
+        self.assertTrue(len(samples) >= 3)
+
+        by_key = {}
+        for s in samples:
+            by_key.setdefault(s.metric_key, []).append(s)
+
+        # Steps should be summed for the day
+        steps = by_key.get('steps', [])
+        self.assertEqual(len(steps), 1)
+        self.assertEqual(steps[0].value, 3500.0)
+        self.assertEqual(steps[0].date, date(2024, 6, 1))
+
+        # Resting HR
+        hr = by_key.get('resting_hr', [])
+        self.assertEqual(len(hr), 1)
+        self.assertEqual(hr[0].value, 62.0)
+
+        # SpO2 should be converted from fraction to percentage
+        spo2 = by_key.get('spo2', [])
+        self.assertEqual(len(spo2), 1)
+        self.assertEqual(spo2[0].value, 97.0)
+
+    def test_parse_apple_health_bad_zip(self):
+        from omop_core.services.wearable_parsers import parse_apple_health_export
+        with self.assertRaises(ValueError):
+            parse_apple_health_export(b'not a zip file')
+
+    def test_parse_apple_health_no_export_xml(self):
+        import zipfile
+        from omop_core.services.wearable_parsers import parse_apple_health_export
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('readme.txt', 'no export.xml here')
+        with self.assertRaises(ValueError):
+            parse_apple_health_export(buf.getvalue())
+
+
+class WearableUploadEndpointTest(TestCase):
+    """Integration tests for POST /api/v1/patient-records/upload-wearable/."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+
+        _make_vocab_fixtures()
+
+        # Create LOINC concepts for wearable metrics — must use vocabulary_id='LOINC'
+        # so concept_by_loinc() can find them.
+        from omop_core.services.mappings import WEARABLE_LOINC
+        from omop_core.services.concept_cache import concept_cache_clear
+        concept_cache_clear()
+
+        loinc_vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id='LOINC',
+            defaults={'vocabulary_name': 'LOINC', 'vocabulary_concept_id': 0},
+        )
+        cc = ConceptClass.objects.get(concept_class_id='Clinical Finding')
+        domain_m = Domain.objects.get(domain_id='Measurement')
+        today = date.today()
+        far_future = date(2099, 12, 31)
+
+        cls.wearable_concepts = {}
+        concept_id_base = 990000
+        for metric_key, loinc_code in WEARABLE_LOINC.items():
+            concept_id_base += 1
+            c, _ = Concept.objects.get_or_create(
+                concept_id=concept_id_base,
+                defaults={
+                    'concept_name': f'Wearable {metric_key}',
+                    'domain': domain_m,
+                    'vocabulary': loinc_vocab,
+                    'concept_class': cc,
+                    'concept_code': loinc_code,
+                    'valid_start_date': today,
+                    'valid_end_date': far_future,
+                },
+            )
+            cls.wearable_concepts[metric_key] = c
+
+        # Type concept for wearable measurements
+        type_domain = Domain.objects.get(domain_id='Type Concept')
+        test_vocab = Vocabulary.objects.get(vocabulary_id='TEST')
+        Concept.objects.get_or_create(
+            concept_id=32883,
+            defaults={
+                'concept_name': 'Patient self-report',
+                'domain': type_domain,
+                'vocabulary': test_vocab,
+                'concept_class': cc,
+                'concept_code': '32883',
+                'valid_start_date': today,
+                'valid_end_date': far_future,
+            },
+        )
+
+        cls.person = Person.objects.create(person_id=99001, family_name='Wearable', given_name='Wendy')
+        cls.patient_rec = PatientRecord.objects.create(person=cls.person)
+        cls.identity = Identity.objects.create_user(email='wendy-wearable@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.identity, person=cls.person)
+
+        # Unlinked user (no PatientUser)
+        cls.unlinked_identity = Identity.objects.create_user(email='nolink@test.com', password='pw')
+
+    def _client_as(self, identity):
+        c = APIClient()
+        c.force_authenticate(user=identity)
+        return c
+
+    def _make_apple_zip(self, xml_content):
+        import zipfile
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('apple_health_export/export.xml', xml_content)
+        buf.seek(0)
+        return buf
+
+    def test_upload_apple_health_creates_measurements(self):
+        """Uploading an Apple Health zip creates Measurement rows."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Record type="HKQuantityTypeIdentifierStepCount"
+          startDate="2024-07-01 08:00:00 -0700"
+          endDate="2024-07-01 08:30:00 -0700"
+          value="5000"/>
+  <Record type="HKQuantityTypeIdentifierRestingHeartRate"
+          startDate="2024-07-01 06:00:00 -0700"
+          endDate="2024-07-01 06:00:00 -0700"
+          value="65"/>
+</HealthData>
+"""
+        zip_file = self._make_apple_zip(xml)
+        client = self._client_as(self.identity)
+        resp = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': zip_file, 'device_type': 'apple'},
+            format='multipart',
+            HTTP_CONTENT_DISPOSITION='attachment; filename="export.zip"',
+        )
+        # Override the filename since SimpleUploadedFile isn't used here
+        self.assertIn(resp.status_code, [200, 400])
+        # If 400 it's because file extension validation — let's use proper file name
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        zip_file = self._make_apple_zip(xml)
+        uploaded = SimpleUploadedFile('export.zip', zip_file.read(), content_type='application/zip')
+        resp = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'apple'},
+            format='multipart',
+        )
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertGreaterEqual(resp.data['samples_created'], 2)
+
+        # Verify Measurement rows created
+        steps_concept = self.wearable_concepts['steps']
+        steps_rows = Measurement.objects.filter(person=self.person, measurement_concept=steps_concept)
+        self.assertTrue(steps_rows.exists())
+
+    def test_upload_deduplication(self):
+        """Uploading the same file twice does not create duplicate rows."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Record type="HKQuantityTypeIdentifierStepCount"
+          startDate="2024-08-01 08:00:00 -0700"
+          endDate="2024-08-01 08:30:00 -0700"
+          value="3000"/>
+</HealthData>
+"""
+        client = self._client_as(self.identity)
+
+        # First upload
+        zip_file = self._make_apple_zip(xml)
+        uploaded = SimpleUploadedFile('export.zip', zip_file.read(), content_type='application/zip')
+        resp1 = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'apple'},
+            format='multipart',
+        )
+        self.assertEqual(resp1.status_code, 200)
+        first_created = resp1.data['samples_created']
+
+        # Second upload — same data
+        zip_file = self._make_apple_zip(xml)
+        uploaded = SimpleUploadedFile('export.zip', zip_file.read(), content_type='application/zip')
+        resp2 = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'apple'},
+            format='multipart',
+        )
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(resp2.data['samples_created'], 0)
+        self.assertEqual(resp2.data['duplicates_skipped'], first_created)
+
+    def test_upload_missing_file(self):
+        """POST without a file returns 400."""
+        client = self._client_as(self.identity)
+        resp = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'device_type': 'apple'},
+            format='multipart',
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('error', resp.data)
+
+    def test_upload_invalid_device_type(self):
+        """POST with invalid device_type returns 400."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        uploaded = SimpleUploadedFile('export.zip', b'fake', content_type='application/zip')
+        client = self._client_as(self.identity)
+        resp = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'oura'},
+            format='multipart',
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('device_type', resp.data['error'])
+
+    def test_upload_wrong_extension(self):
+        """POST with wrong file extension returns 400."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        uploaded = SimpleUploadedFile('data.csv', b'fake', content_type='text/csv')
+        client = self._client_as(self.identity)
+        resp = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'garmin'},
+            format='multipart',
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('.fit', resp.data['error'])
+
+    def test_upload_no_patient_user(self):
+        """POST from unlinked user returns 403."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        uploaded = SimpleUploadedFile('export.zip', b'fake', content_type='application/zip')
+        client = self._client_as(self.unlinked_identity)
+        resp = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'apple'},
+            format='multipart',
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_upload_unauthenticated(self):
+        """POST without authentication returns 401/403."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        uploaded = SimpleUploadedFile('export.zip', b'fake', content_type='application/zip')
+        client = APIClient()
+        resp = client.post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'apple'},
+            format='multipart',
+        )
+        self.assertIn(resp.status_code, [401, 403])

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,8 @@ whitenoise==6.7.0
 django-anymail[mailgun]==12.0
 drf-spectacular==0.28.0
 
+python-fitparse>=2.0.0
+
 # Testing
 pytest==8.4.2
 pytest-django==4.11.1


### PR DESCRIPTION
## Summary

- Add Upload button to Wearables tab with source picker modal (Garmin/Apple enabled, Oura/Fitbit "Coming soon")
- New `omop_core/services/wearable_parsers.py` — Garmin FIT parser (via `python-fitparse`) and Apple Health XML parser (streaming `iterparse`)
- New `upload_wearable` endpoint on `PatientRecordViewSet` — validates files, parses samples, creates OMOP Measurement/Observation rows with deduplication and artifact filtering, then calls `refresh_patient_record()`
- Reorganize patient tabs: Immunizations moved into Treatment tab bottom, Allergies after Labs, Surveys as last tab

## Test plan

- [x] Backend: 10 new tests (3 parser unit tests, 7 endpoint integration tests) — all pass
- [x] Full backend suite: 1159 tests pass
- [x] Frontend: 158 tests pass (21 files)
- [ ] Manual: upload a real Apple Health export.zip and verify 30-day summaries update
- [ ] Manual: upload Garmin .fit files and verify measurements appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)