### PR TITLE
feat: drag-and-drop support for wearable uploads

### DIFF
--- a/frontend/src/components/PatientInfo/tabs/WearableTab.test.tsx
+++ b/frontend/src/components/PatientInfo/tabs/WearableTab.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import WearableTab from './WearableTab';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPost = vi.fn();
+vi.mock('@/api/axios', () => ({
+  default: { post: (...args: unknown[]) => mockPost(...args) },
+}));
+
+// Stub Section and Field to simplify rendering
+vi.mock('../Section', () => ({
+  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div data-testid={`section-${title}`}>{children}</div>
+  ),
+}));
+
+vi.mock('../Field', () => ({
+  default: ({ label }: { label: string }) => <div data-testid={`field-${label}`} />,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderTab(props: Partial<React.ComponentProps<typeof WearableTab>> = {}) {
+  const defaultProps = {
+    formData: {},
+    onChange: vi.fn(),
+    onRefresh: vi.fn(),
+    ...props,
+  };
+  return render(<WearableTab {...defaultProps} />);
+}
+
+function createFile(name: string, content = 'fake-data'): File {
+  return new File([content], name, { type: 'application/octet-stream' });
+}
+
+function createDropEvent(files: File[]): Partial<React.DragEvent> {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: {
+      files: files as unknown as FileList,
+      types: ['Files'],
+    } as unknown as DataTransfer,
+  };
+}
+
+function createDragEnterEvent(): Partial<React.DragEvent> {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: { types: ['Files'] } as unknown as DataTransfer,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockPost.mockReset();
+});
+
+describe('WearableTab', () => {
+  it('renders the Upload button', () => {
+    renderTab();
+    expect(screen.getByRole('button', { name: /upload/i })).toBeInTheDocument();
+  });
+
+  it('shows drag-and-drop hint text', () => {
+    renderTab();
+    expect(screen.getByText(/or drag & drop files here/i)).toBeInTheDocument();
+  });
+
+  it('shows no-data message when wearable_last_sync_at is absent', () => {
+    renderTab({ formData: {} });
+    expect(screen.getByText(/no wearable data synced yet/i)).toBeInTheDocument();
+  });
+
+  it('hides no-data message when wearable_last_sync_at is present', () => {
+    renderTab({ formData: { wearable_last_sync_at: '2024-07-01T00:00:00Z' } });
+    expect(screen.queryByText(/no wearable data synced yet/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('WearableTab — drag and drop', () => {
+  it('shows drop overlay on dragEnter', () => {
+    renderTab();
+    const container = screen.getByText(/or drag & drop files here/i).closest('div[class*="relative"]')!;
+    fireEvent.dragEnter(container, createDragEnterEvent());
+    expect(screen.getByText(/drop .fit or .zip files to upload/i)).toBeInTheDocument();
+  });
+
+  it('hides drop overlay on dragLeave', () => {
+    renderTab();
+    const container = screen.getByText(/or drag & drop files here/i).closest('div[class*="relative"]')!;
+    fireEvent.dragEnter(container, createDragEnterEvent());
+    expect(screen.getByText(/drop .fit or .zip files to upload/i)).toBeInTheDocument();
+    fireEvent.dragLeave(container, createDragEnterEvent());
+    expect(screen.queryByText(/drop .fit or .zip files to upload/i)).not.toBeInTheDocument();
+  });
+
+  it('uploads .fit files as garmin on drop', async () => {
+    mockPost.mockResolvedValue({ data: { samples_created: 5, duplicates_skipped: 0 } });
+    const onRefresh = vi.fn();
+    renderTab({ onRefresh });
+
+    const container = screen.getByText(/or drag & drop files here/i).closest('div[class*="relative"]')!;
+    const files = [createFile('activity.fit')];
+    fireEvent.drop(container, createDropEvent(files));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/v1/patient-records/upload-wearable/',
+        expect.any(FormData),
+        expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }),
+      );
+    });
+
+    // Verify device_type=garmin was sent
+    const sentFormData = mockPost.mock.calls[0][1] as FormData;
+    expect(sentFormData.get('device_type')).toBe('garmin');
+
+    await waitFor(() => {
+      expect(screen.getByText(/uploaded 5 samples/i)).toBeInTheDocument();
+    });
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('uploads .zip files as apple on drop', async () => {
+    mockPost.mockResolvedValue({ data: { samples_created: 3, duplicates_skipped: 1 } });
+    renderTab();
+
+    const container = screen.getByText(/or drag & drop files here/i).closest('div[class*="relative"]')!;
+    fireEvent.drop(container, createDropEvent([createFile('export.zip')]));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalled();
+    });
+
+    const sentFormData = mockPost.mock.calls[0][1] as FormData;
+    expect(sentFormData.get('device_type')).toBe('apple');
+  });
+
+  it('rejects unsupported file extensions', async () => {
+    renderTab();
+    const container = screen.getByText(/or drag & drop files here/i).closest('div[class*="relative"]')!;
+    fireEvent.drop(container, createDropEvent([createFile('data.csv')]));
+
+    await waitFor(() => {
+      expect(screen.getByText(/unsupported file type/i)).toBeInTheDocument();
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects mixed file types in a single drop', async () => {
+    renderTab();
+    const container = screen.getByText(/or drag & drop files here/i).closest('div[class*="relative"]')!;
+    fireEvent.drop(container, createDropEvent([createFile('a.fit'), createFile('b.zip')]));
+
+    await waitFor(() => {
+      expect(screen.getByText(/one type at a time/i)).toBeInTheDocument();
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('uploads multiple .fit files in a single drop', async () => {
+    mockPost
+      .mockResolvedValueOnce({ data: { samples_created: 3, duplicates_skipped: 0 } })
+      .mockResolvedValueOnce({ data: { samples_created: 2, duplicates_skipped: 1 } });
+    renderTab();
+
+    const container = screen.getByText(/or drag & drop files here/i).closest('div[class*="relative"]')!;
+    fireEvent.drop(container, createDropEvent([createFile('a.fit'), createFile('b.fit')]));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledTimes(2);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/uploaded 5 samples/i)).toBeInTheDocument();
+      expect(screen.getByText(/1 duplicate.*skipped/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/PatientInfo/tabs/WearableTab.tsx
+++ b/frontend/src/components/PatientInfo/tabs/WearableTab.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import Field from '../Field';
 import Section from '../Section';
 import api from '@/api/axios';
@@ -29,6 +29,14 @@ function formatSyncDate(raw: unknown): string {
   }
 }
 
+/** Infer device type from file extension. Returns null for unsupported extensions. */
+function detectDeviceType(name: string): 'garmin' | 'apple' | null {
+  const lower = name.toLowerCase();
+  if (lower.endsWith('.fit')) return 'garmin';
+  if (lower.endsWith('.zip')) return 'apple';
+  return null;
+}
+
 export default function WearableTab({ formData, onRefresh }: Props) {
   const noData = !formData?.wearable_last_sync_at;
   const [showPicker, setShowPicker] = useState(false);
@@ -37,24 +45,11 @@ export default function WearableTab({ formData, onRefresh }: Props) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedSource, setSelectedSource] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const dragCounter = useRef(0);
 
-  const handleSourceSelect = (sourceKey: string) => {
-    const source = SOURCES.find(s => s.key === sourceKey);
-    if (!source || !source.enabled) return;
-    setSelectedSource(sourceKey);
-    setShowPicker(false);
-    // Trigger file picker
-    if (fileInputRef.current) {
-      fileInputRef.current.accept = source.accept;
-      fileInputRef.current.multiple = source.multiple;
-      fileInputRef.current.click();
-    }
-  };
-
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0 || !selectedSource) return;
-
+  /** Upload a list of files with a given device type. Shared by file-picker and drag-and-drop. */
+  const uploadFiles = useCallback(async (files: File[], deviceType: string) => {
     setUploading(true);
     setUploadResult(null);
     setUploadError(null);
@@ -63,10 +58,10 @@ export default function WearableTab({ formData, onRefresh }: Props) {
     let totalDuplicates = 0;
 
     try {
-      for (let i = 0; i < files.length; i++) {
+      for (const file of files) {
         const payload = new FormData();
-        payload.append('file', files[i]);
-        payload.append('device_type', selectedSource);
+        payload.append('file', file);
+        payload.append('device_type', deviceType);
 
         const res = await api.post('/v1/patient-records/upload-wearable/', payload, {
           headers: { 'Content-Type': 'multipart/form-data' },
@@ -81,7 +76,6 @@ export default function WearableTab({ formData, onRefresh }: Props) {
         (totalDuplicates > 0 ? ` (${totalDuplicates} duplicate${totalDuplicates !== 1 ? 's' : ''} skipped)` : '')
       );
 
-      // Trigger parent refresh to update displayed summaries
       if (totalCreated > 0 && onRefresh) {
         onRefresh();
       }
@@ -91,16 +85,104 @@ export default function WearableTab({ formData, onRefresh }: Props) {
       setUploadError(msg);
     } finally {
       setUploading(false);
-      setSelectedSource(null);
-      // Reset file input so the same file can be re-selected
-      if (fileInputRef.current) {
-        fileInputRef.current.value = '';
-      }
+    }
+  }, [onRefresh]);
+
+  const handleSourceSelect = (sourceKey: string) => {
+    const source = SOURCES.find(s => s.key === sourceKey);
+    if (!source || !source.enabled) return;
+    setSelectedSource(sourceKey);
+    setShowPicker(false);
+    if (fileInputRef.current) {
+      fileInputRef.current.accept = source.accept;
+      fileInputRef.current.multiple = source.multiple;
+      fileInputRef.current.click();
     }
   };
 
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0 || !selectedSource) return;
+    await uploadFiles(Array.from(files), selectedSource);
+    setSelectedSource(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  // ── Drag-and-drop handlers ──────────────────────────────────────────────
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current += 1;
+    if (e.dataTransfer.types.includes('Files')) {
+      setDragOver(true);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current -= 1;
+    if (dragCounter.current === 0) {
+      setDragOver(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDrop = useCallback(async (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current = 0;
+    setDragOver(false);
+
+    if (uploading) return;
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length === 0) return;
+
+    // Detect device type from extensions — all files must be the same type
+    const types = new Set(files.map(f => detectDeviceType(f.name)));
+
+    if (types.has(null)) {
+      setUploadError('Unsupported file type. Please drop .fit (Garmin) or .zip (Apple Health) files.');
+      return;
+    }
+
+    if (types.size > 1) {
+      setUploadError('Please drop files of one type at a time (.fit or .zip, not both).');
+      return;
+    }
+
+    const deviceType = types.values().next().value as string;
+    await uploadFiles(files, deviceType);
+  }, [uploading, uploadFiles]);
+
   return (
-    <div>
+    <div
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      className="relative"
+    >
+      {/* Drop zone overlay */}
+      {dragOver && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-lg border-2 border-dashed border-portal-brand bg-portal-brand/5">
+          <div className="flex flex-col items-center gap-2 text-portal-brand">
+            <svg className="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5-5m0 0l5 5m-5-5v12" />
+            </svg>
+            <span className="text-sm font-medium">Drop .fit or .zip files to upload</span>
+          </div>
+        </div>
+      )}
+
       {/* Upload controls */}
       <div className="mb-4 flex items-center gap-3">
         <div className="relative">
@@ -152,6 +234,8 @@ export default function WearableTab({ formData, onRefresh }: Props) {
           )}
         </div>
 
+        <span className="text-xs text-gray-400">or drag &amp; drop files here</span>
+
         {uploadResult && (
           <span className="text-sm text-green-600">{uploadResult}</span>
         )}
@@ -170,7 +254,7 @@ export default function WearableTab({ formData, onRefresh }: Props) {
 
       {noData && (
         <p className="mb-4 text-sm text-gray-500 italic">
-          No wearable data synced yet. Click Upload to contribute wearable data to your record.
+          No wearable data synced yet. Upload or drag &amp; drop wearable data files to contribute to your record.
         </p>
       )}
 
@@ -249,7 +333,7 @@ export default function WearableTab({ formData, onRefresh }: Props) {
       <Section title="Respiratory (30-Day)">
         <div className="grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
           <Field
-            label="Min SpO\u2082 (%)"
+            label="Min SpO&#8322; (%)"
             name="oxygen_saturation_min_30d"
             type="number"
             value={formData?.oxygen_saturation_min_30d}


### PR DESCRIPTION
## Summary

- Add drag-and-drop zone to the Wearables tab for uploading .fit (Garmin) and .zip (Apple Health) files
- Auto-detects device type from file extension -- no need to pick source first when dragging
- Visual overlay on drag-over with upload icon and prompt text
- Rejects mixed file types (.fit + .zip in same drop) and unsupported extensions with clear error messages
- Coexists with the existing Upload button (click-to-browse still works)
- Extracted shared uploadFiles function used by both file-picker and drop handler

Closes #385

## Test plan

- [x] 11 new WearableTab tests (4 basic rendering + 7 drag-and-drop scenarios)
- [x] All 169 frontend tests pass
- [ ] Manual: drag .fit files from Garmin MTP file manager onto Wearables tab

Generated with [Claude Code](https://claude.com/claude-code)