### PR TITLE
Let a patient delete the visit behind their own lab report

### DIFF
--- a/patient_portal/api/lab_results/tests.py
+++ b/patient_portal/api/lab_results/tests.py
@@ -514,6 +514,38 @@ class VisitDeleteViewTest(TestCase):
         resp = self.client.delete('/api/lab-results/visits/9999/')
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_patient_can_delete_own_visit(self):
+        """hk-labs forwards the patient's own token when they delete a report.
+
+        Non-staff patients were denied DELETE, so the report vanished from
+        hk-labs while its measurements stayed in the record forever.
+        """
+        self.user.is_staff = False
+        self.user.save(update_fields=['is_staff'])
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        resp = client.delete('/api/lab-results/visits/500/')
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['deleted_measurements'], 3)
+        self.assertFalse(VisitOccurrence.objects.filter(visit_occurrence_id=500).exists())
+
+    def test_patient_cannot_delete_another_persons_visit(self):
+        """Widening the permission must not widen who a patient can reach."""
+        other_person = Person.objects.create(person_id=5002)
+        PatientRecord.objects.create(person=other_person)
+        stranger = Identity.objects.create_user(email='stranger@test.com', password='test')
+        PatientUser.objects.create(identity=stranger, person=other_person)
+        client = APIClient()
+        client.force_authenticate(user=stranger)
+
+        resp = client.delete('/api/lab-results/visits/500/')
+
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(VisitOccurrence.objects.filter(visit_occurrence_id=500).exists())
+        self.assertEqual(Measurement.objects.filter(visit_occurrence_id=500).count(), 3)
+
 
 class SyncOnBehalfOfTest(TestCase):
     """Tests for actor_iss/actor_sub on-behalf-of sync flow.

--- a/patient_portal/api/lab_results/views.py
+++ b/patient_portal/api/lab_results/views.py
@@ -12,7 +12,11 @@ from omop_core.models import (
     Measurement, MeasurementOwnership, PatientRecord,
     ProvenanceRecord, VisitOccurrence,
 )
-from patient_portal.api.permissions import ScopedTokenPermission, get_request_org
+from patient_portal.api.permissions import (
+    LabSyncPermission,
+    ScopedTokenPermission,
+    get_request_org,
+)
 
 from .serializers import LabResultCardSerializer, LabValueSerializer, MeasurementUpdateSerializer
 
@@ -679,8 +683,15 @@ class VisitDeleteView(APIView):
 
     Deletes a VisitOccurrence and all its associated Measurements.
     Used by hk-labs to cascade-delete when an upload is removed.
+
+    LabSyncPermission, not the base class: hk-labs calls this with the
+    patient's own token when they delete a report, and the base class
+    denies DELETE to non-staff patients. Removing results that came from
+    a report you are deleting is the same self-service write as committing
+    them. The per-patient ownership check below is what keeps a patient
+    from reaching anyone else's visit.
     """
-    permission_classes = [ScopedTokenPermission]
+    permission_classes = [LabSyncPermission]
 
     def delete(self, request, visit_id):
         from omop_core.authorization import can_access_patient


### PR DESCRIPTION
## The bug

Deleting an uploaded lab report in the portal left its results in the patient's record forever.

`VisitDeleteView` uses `ScopedTokenPermission`, which denies DELETE to non-staff patients. hk-labs calls this endpoint with the patient's own token when they delete a report, so the call came back 403 — and hk-labs logged the failure, swallowed it, and deleted the upload anyway. The report disappeared from the uploads list while its measurements stayed in the record, with nothing left in any UI able to reach them.

Observed live: 55 orphaned measurements on one visit after a single report delete.

## The change

`VisitDeleteView` now uses `LabSyncPermission`, which already exists for exactly this shape of call — committing labs is legitimate patient self-service, and removing results that came from a report you are deleting is the same write.

Authorization is unchanged: the per-patient ownership check inside the view (`own_pid` / `can_access_patient`) is what keeps a patient from reaching another person's visit. New tests pin both directions — a patient can delete their own visit, and a stranger still gets 404 with the visit and its measurements intact. Reverting the permission line fails both.

## Testing

- `patient_portal/api/lab_results/tests.py` — 77 passed
- permission tests — 20 passed
- End to end with hk-labs: deleting a report through the portal removed its 3 measurements from promop, the visit was gone, and Lab Results fell back to its empty state.

Pairs with hk-labs PR #41, which forwards the patient's token and aborts the delete rather than orphaning results when this call fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)