### PR TITLE
fix: prevent browser from navigating away on file drop

### DIFF
--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -255,6 +255,18 @@ export default function PatientDetail({
   const editedNameRef = useRef("");
   const patientNameRef = useRef("");
 
+  // Prevent the browser from navigating away when files are dropped outside the
+  // WearableTab drop zone (browser default is to open the file as a new page).
+  useEffect(() => {
+    const prevent = (e: DragEvent) => { e.preventDefault(); };
+    document.addEventListener('dragover', prevent);
+    document.addEventListener('drop', prevent);
+    return () => {
+      document.removeEventListener('dragover', prevent);
+      document.removeEventListener('drop', prevent);
+    };
+  }, []);
+
   useEffect(() => { editedInfoRef.current = editedInfo; }, [editedInfo]);
   useEffect(() => { editedNameRef.current = editedName; }, [editedName]);
   useEffect(() => { patientNameRef.current = patientName; }, [patientName]);


### PR DESCRIPTION
## Summary
- Adds document-level dragover/drop event prevention in PatientDetail so the browser does not open dropped .FIT/.zip files as a new page
- Ensures the WearableTab drag-and-drop handler receives the event reliably, especially for files dragged from OS-level MTP file managers (e.g. Garmin watches on Mac)

## Test plan
- [x] All 169 frontend tests pass
- [ ] Drop .FIT file onto Wearables tab — upload handler fires instead of browser navigation

Generated with [Claude Code](https://claude.com/claude-code)