### PR TITLE
feat(omop): emit aggregate patient therapy_release_id for EXACT #286 Gate 1 (#393)

### DIFF
--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -245,6 +245,7 @@ class PatientRecordSerializer(serializers.ModelSerializer):
     second_line_therapy_display = serializers.SerializerMethodField()
     later_therapy_display = serializers.SerializerMethodField()
     lines_of_therapy = serializers.SerializerMethodField()
+    therapy_release_id = serializers.SerializerMethodField()
 
     class Meta:
         model = PatientRecord
@@ -256,7 +257,7 @@ class PatientRecordSerializer(serializers.ModelSerializer):
         read_only_fields = (
             'organization', 'person', 'created_at', 'updated_at',
             'first_line_therapy_display', 'second_line_therapy_display', 'later_therapy_display',
-            'lines_of_therapy',
+            'lines_of_therapy', 'therapy_release_id',
             'death_date',
             # Derived therapy-id read model (issue #236): written only by the
             # derivation pipeline (refresh_patient_record / FHIR upload) from
@@ -530,6 +531,68 @@ class PatientRecordSerializer(serializers.ModelSerializer):
                     obj.later_discontinuation_reason, later_aggregate=True,
                     comp_class=obj.later_therapy_type_ids))
         return lines
+
+    def get_therapy_release_id(self, obj):
+        """Patient-level aggregate therapy-vocab release for the class ids the
+        patient emits (ADR 0002 / EXACT #286 Gate 1).
+
+        Each therapy line's `release_id` (`therapy_ids_provenance`) certifies the
+        vocabulary generation that line's regimen -> components -> classes were
+        derived against. EXACT matches drug-class "types" by OVERLAP against the
+        patient's AGGREGATE `therapy_type_ids` (the union across all lines), so a
+        single release must certify that whole union — it is well-defined only
+        when every class-contributing line agrees on one release.
+
+        Rule (unanimous-or-null, fail-closed): reduce over the lines that
+        contribute `type_ids`; unanimous non-null release -> that release;
+        anything weaker -> null ("overlap not release-consistent", so Gate 1
+        fails closed rather than trust a possibly-stale overlap). A line is
+        NOT individually release-certified — and therefore forces null — when:
+
+        - its `release_id` is null / has no provenance entry, OR
+        - its regimen did not resolve (`regimen_concept_id is None`): such a
+          line still contributes class ids (expanded from components), but
+          provenance is keyed by the resolved regimen id, so no per-line release
+          covers it. This matters for 3L+ lines especially: `get_lines_of_therapy`
+          smears the shared `later_therapy_ids` release onto EVERY later entry,
+          including an unresolved sibling whose class contribution that shared
+          release does not actually certify — gating on the null concept_id
+          keeps that case fail-closed (codex #393 review).
+
+        Normal derivation stamps every resolved line with the release active at
+        derivation time, so a fully-resolved patient converges to one value;
+        null is the safe default until per-line provenance is populated.
+        """
+        releases = []
+        covered = set()
+        for line in self.get_lines_of_therapy(obj):
+            tids = line.get('type_ids')
+            if not tids:
+                continue  # no class ids -> not part of the overlap to certify
+            rel = line.get('release_id')
+            # A valid release_id is a non-empty string token
+            # (_latest_published_release_id). Anything else — null, empty, or a
+            # non-string/unhashable JSON value from a malformed provenance row —
+            # is uncertified; reject BEFORE set() so a list/dict can't raise
+            # TypeError and 500 the payload (#393 codex review). Likewise a
+            # class-contributing line whose regimen did not resolve.
+            if not isinstance(rel, str) or not rel or line.get('regimen_concept_id') is None:
+                return None  # uncertified class-contributing line -> fail-closed
+            releases.append(rel)
+            covered.update(tids)
+        if not releases:
+            return None
+        distinct = set(releases)
+        if len(distinct) != 1:
+            return None
+        # Defense-in-depth: EXACT overlaps the stored aggregate `therapy_type_ids`.
+        # Every class id in it must be vouched for by a certified line above; a
+        # class present in the aggregate but emitted by no certified line (only
+        # reachable via a hand-built/corrupt row, never the derivation pipeline)
+        # would be un-certified -> fail closed rather than trust it (#393 review).
+        if not set(obj.therapy_type_ids or []).issubset(covered):
+            return None
+        return distinct.pop()
 
     def validate_sct_date(self, value):
         if value is not None and value > localdate():

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -11806,6 +11806,208 @@ class LinesOfTherapyPayloadTest(TestCase):
         self.assertEqual(lot[1]['regimen'], 'Dara')
 
 
+class TherapyReleaseIdAggregateTest(TestCase):
+    """PatientRecordSerializer.therapy_release_id reduces the per-line therapy
+    provenance release_ids to ONE aggregate patient release for EXACT #286
+    Gate 1: unanimous non-null across the class-contributing lines -> that
+    release; any such line with an unknown/null or divergent release -> null
+    (fail-closed). Only lines that contribute `type_ids` to the aggregate
+    `therapy_type_ids` overlap are considered."""
+
+    def _record(self, person_id=91000, **kwargs):
+        from omop_core.models import Person, PatientRecord
+        person = Person.objects.create(person_id=person_id)
+        return PatientRecord(person=person, **kwargs)
+
+    def _release(self, record):
+        from patient_portal.api.serializers import PatientRecordSerializer
+        return PatientRecordSerializer(record).data['therapy_release_id']
+
+    def test_field_present_in_payload(self):
+        # Additive, always-emitted patient-level field (null until provenance).
+        from patient_portal.api.serializers import PatientRecordSerializer
+        data = PatientRecordSerializer(self._record(person_id=91001)).data
+        self.assertIn('therapy_release_id', data)
+        self.assertIsNone(data['therapy_release_id'])
+
+    def test_unanimous_release_across_contributing_lines(self):
+        rec = self._record(
+            person_id=91002,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            second_line_therapy='Kadcyla', second_line_therapy_id=202,
+            second_line_therapy_type_ids=[9102],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'},
+                'second_line_therapy_id': {'value': 202, 'origin': 'inferred', 'release_id': 'rel-a'},
+            })
+        self.assertEqual(self._release(rec), 'rel-a')
+
+    def test_null_release_on_contributing_line_fails_closed(self):
+        rec = self._record(
+            person_id=91003,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            second_line_therapy='Kadcyla', second_line_therapy_id=202,
+            second_line_therapy_type_ids=[9102],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'},
+                'second_line_therapy_id': {'value': 202, 'origin': 'inferred', 'release_id': None},
+            })
+        self.assertIsNone(self._release(rec))
+
+    def test_disagreeing_releases_fail_closed(self):
+        rec = self._record(
+            person_id=91004,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            second_line_therapy='Kadcyla', second_line_therapy_id=202,
+            second_line_therapy_type_ids=[9102],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'},
+                'second_line_therapy_id': {'value': 202, 'origin': 'inferred', 'release_id': 'rel-b'},
+            })
+        self.assertIsNone(self._release(rec))
+
+    def test_only_type_id_lines_count_noncontributing_line_ignored(self):
+        # Second line has NO type_ids (does not contribute to the overlap), so
+        # its divergent release must NOT taint the aggregate.
+        rec = self._record(
+            person_id=91005,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            second_line_therapy='Kadcyla', second_line_therapy_id=202,
+            second_line_therapy_type_ids=[],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'},
+                'second_line_therapy_id': {'value': 202, 'origin': 'inferred', 'release_id': 'rel-b'},
+            })
+        self.assertEqual(self._release(rec), 'rel-a')
+
+    def test_classes_without_provenance_fail_closed(self):
+        # A line yields type_ids (from components) but its regimen didn't resolve,
+        # so no provenance entry exists -> release unknown -> null (fail-closed).
+        rec = self._record(
+            person_id=91006,
+            first_line_therapy='AC-T',
+            first_line_therapy_type_ids=[9101],
+            therapy_ids_provenance={})
+        self.assertIsNone(self._release(rec))
+
+    def test_no_type_ids_anywhere_is_null(self):
+        # Patient has a therapy line but no class ids -> no overlap to certify.
+        rec = self._record(
+            person_id=91007,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'}})
+        self.assertIsNone(self._release(rec))
+
+    def test_later_lines_agree_with_earlier(self):
+        # Later lines share one provenance release_id and the later type aggregate;
+        # unanimous with the first line -> that release.
+        rec = self._record(
+            person_id=91008,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            later_therapy='RegA',
+            later_therapies=[
+                {'lineNumber': 3, 'therapy': 'RegA', 'startDate': None,
+                 'endDate': None, 'concept_id': 401, 'origin': 'inferred'}],
+            later_therapy_ids=[401],
+            later_therapy_type_ids=[9200],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'},
+                'later_therapy_ids': {'value': [401], 'origin': 'inferred', 'release_id': 'rel-a'}})
+        self.assertEqual(self._release(rec), 'rel-a')
+
+    def test_later_line_release_disagrees_fails_closed(self):
+        rec = self._record(
+            person_id=91009,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            later_therapy='RegA',
+            later_therapies=[
+                {'lineNumber': 3, 'therapy': 'RegA', 'startDate': None,
+                 'endDate': None, 'concept_id': 401, 'origin': 'inferred'}],
+            later_therapy_ids=[401],
+            later_therapy_type_ids=[9200],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'},
+                'later_therapy_ids': {'value': [401], 'origin': 'inferred', 'release_id': 'rel-b'}})
+        self.assertIsNone(self._release(rec))
+
+    def test_unresolved_later_sibling_fails_closed(self):
+        # #393 codex P1: a later set with one resolved + one unresolved line
+        # shares ONE later provenance release and the aggregate later type ids.
+        # The unresolved sibling (concept_id None) contributes class ids the
+        # shared release does not per-line certify -> null (fail-closed), even
+        # though the resolved sibling carries the release.
+        rec = self._record(
+            person_id=91010,
+            later_therapy='RegA',
+            later_therapies=[
+                {'lineNumber': 3, 'therapy': 'RegA', 'startDate': None,
+                 'endDate': None, 'concept_id': 401, 'origin': 'inferred'},
+                {'lineNumber': 4, 'therapy': 'RegB', 'startDate': None,
+                 'endDate': None, 'concept_id': None, 'origin': None}],
+            later_therapy_ids=[401],
+            later_therapy_type_ids=[9200],
+            therapy_ids_provenance={
+                'later_therapy_ids': {'value': [401], 'origin': 'inferred', 'release_id': 'rel-a'}})
+        self.assertIsNone(self._release(rec))
+
+    def test_multiple_resolved_later_lines_share_release(self):
+        # All later lines resolved and stamped with one release -> that release.
+        rec = self._record(
+            person_id=91011,
+            later_therapy='RegA',
+            later_therapies=[
+                {'lineNumber': 3, 'therapy': 'RegA', 'startDate': None,
+                 'endDate': None, 'concept_id': 401, 'origin': 'inferred'},
+                {'lineNumber': 4, 'therapy': 'RegB', 'startDate': None,
+                 'endDate': None, 'concept_id': 402, 'origin': 'inferred'}],
+            later_therapy_ids=[401, 402],
+            later_therapy_type_ids=[9200],
+            therapy_ids_provenance={
+                'later_therapy_ids': {'value': [401, 402], 'origin': 'inferred', 'release_id': 'rel-a'}})
+        self.assertEqual(self._release(rec), 'rel-a')
+
+    def test_malformed_provenance_is_null_no_crash(self):
+        # A non-dict therapy_ids_provenance must not 500; release reads null.
+        rec = self._record(
+            person_id=91012,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            therapy_ids_provenance=['not', 'a', 'dict'])
+        self.assertIsNone(self._release(rec))
+
+    def test_unhashable_release_id_is_null_no_crash(self):
+        # #393 codex P2: a JSON-valid but non-scalar release_id (list/dict) must
+        # not reach set() and 500 the payload — reject as uncertified -> null.
+        rec = self._record(
+            person_id=91014,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': []}})
+        self.assertIsNone(self._release(rec))
+
+    def test_aggregate_class_not_covered_by_a_line_fails_closed(self):
+        # Defense-in-depth (#393 review P3): a class id in the stored aggregate
+        # therapy_type_ids that no emitted line vouches for -> null. Only a
+        # corrupt/hand-built row can reach this; the gate must not trust it.
+        rec = self._record(
+            person_id=91013,
+            first_line_therapy='AC-T', first_line_therapy_id=101,
+            first_line_therapy_type_ids=[9101],
+            therapy_type_ids=[9101, 9999],   # 9999 emitted by no line
+            therapy_ids_provenance={
+                'first_line_therapy_id': {'value': 101, 'origin': 'asserted', 'release_id': 'rel-a'}})
+        self.assertIsNone(self._release(rec))
+
+
 # ---------------------------------------------------------------------------
 # PatientSelfScopePermission tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #393.

## What

Adds a read-only, patient-level **`therapy_release_id`** to `PatientRecordSerializer` — the single vocabulary release the patient's aggregate drug-class `therapy_type_ids` were derived against.

## Why

EXACT matches drug-class **types** by concept_id **overlap** against the patient's **aggregate** `therapy_type_ids` (union across therapy lines). Its **Gate 1** (release-consistency, exact#286) requires **one** patient release to compare (strict equality) against the trial's materialization release. PR #362 carries `release_id` **per line**, so this reduces the per-line release_ids to a single aggregate.

## Reduction rule (codex-validated option A)

Reduce over the lines that **contribute `type_ids`** to the overlap:
- **Unanimous non-null** release → that release.
- **Anything weaker → null (fail-closed):** a line is not release-certified when its `release_id` is null/empty/non-string, **or** its regimen did not resolve (`regimen_concept_id is None`) — such a line still contributes class ids but no per-line provenance covers it (this matters for the smeared 3L+ later-line aggregate).
- **Defense-in-depth:** every class id in the stored `therapy_type_ids` must be vouched for by a certified line, else null (guards corrupt/hand-built rows).
- **Crash-safety:** a non-string/unhashable `release_id` is rejected **before** `set()`, so a malformed JSON provenance value fails closed instead of 500-ing the payload.

**Not** option B (max/latest) — that is fail-OPEN (an older line's stale-release class ids masked by a newer line's release).

Additive, always emitted; **null until per-line provenance is populated** (Gate 1 stays fail-closed until then — intended posture). No model migration (pure derivation from `therapy_ids_provenance`).

## Emission chain

1. **promop** (this PR): emit aggregate `therapy_release_id`.
2. **ht-phr**: forward into the EXACT patient payload.
3. **EXACT** exact#286 Gate 1: strict equality vs the trial's `omop_therapy_release_id` + digest (cancerbot #4664/#4667).

## Tests

`TherapyReleaseIdAggregateTest` (14): unanimous / null / disagreement / non-contributing line ignored / classes-without-provenance / **unresolved later sibling (fail-open guard)** / multiple later lines share release / **malformed + unhashable provenance** / aggregate-coverage / field-present.

- Backend: full `omop_core patient_portal` suite green.
- Frontend: 169 passed (no frontend change).

## Self-review (two-part, reconciled)

- **codex** `--uncommitted` ×3: found + fixed a later-line **fail-OPEN [P1]** and an **unhashable-`release_id` 500 [P2]**; final pass clean.
- **fresh-context subagent**: confirmed no fail-open on the dangerous axis; prompted the aggregate-coverage guard [P3].