### PR TITLE
Fix lockout test to expect 403 instead of 401

### DIFF
--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -13507,12 +13507,15 @@ class AuthControlsTest(TestCase):
     # --- lockout (TI.1.1#03) ---
 
     def test_lockout_after_threshold_failures(self):
-        for _ in range(3):
+        # First two failures return 401 (invalid credentials).
+        for _ in range(2):
             self.assertEqual(self._login('wrong-password').status_code, status.HTTP_401_UNAUTHORIZED)
+        # The third failure triggers lockout; the view returns 403 (account locked).
+        self.assertEqual(self._login('wrong-password').status_code, status.HTTP_403_FORBIDDEN)
         self.identity.refresh_from_db()
         self.assertTrue(self.identity.is_locked)
-        # Correct password is refused while locked.
-        self.assertEqual(self._login(self.password).status_code, status.HTTP_401_UNAUTHORIZED)
+        # Correct password is also refused while locked (403).
+        self.assertEqual(self._login(self.password).status_code, status.HTTP_403_FORBIDDEN)
 
     def test_successful_login_resets_failure_count(self):
         self._login('wrong-password')


### PR DESCRIPTION
## Summary

- Fix `test_lockout_after_threshold_failures` which was asserting 401 on all failed login attempts, but the login view returns 403 once the account is locked
- The 3rd failed attempt triggers the lockout in the auth backend (`EmailBackend`), so the view detects `is_locked` and returns 403 on that same request
- Split the loop: first 2 attempts assert 401 (invalid credentials), 3rd asserts 403 (account locked), correct-password-while-locked asserts 403

## Test plan

- [x] `test_lockout_after_threshold_failures` passes
- [x] Full backend suite: 1182 tests, 0 failures