### PR TITLE
fix: correct wearable OMOP concept mappings and quarantine local mints

### DIFF
--- a/omop_core/management/commands/_mm_generator.py
+++ b/omop_core/management/commands/_mm_generator.py
@@ -908,7 +908,7 @@ class Command(BaseCommand):
     def _wearable_obs(self, p, today):
         """7 days of synthetic daily wearable readings, correlated to ECOG.
 
-        Uses the exact LOINC codes that patient_record_service WEARABLE_LOINC
+        Uses the exact LOINC codes that patient_record_service WEARABLE_CONCEPT_CODE
         expects so _get_wearable_data() can aggregate them automatically.
         """
         pid = p['id']

--- a/omop_core/management/commands/enrich_breast_cancer_omop_data.py
+++ b/omop_core/management/commands/enrich_breast_cancer_omop_data.py
@@ -48,7 +48,7 @@ from omop_core.models import (
     Domain, ConceptClass, DrugExposure,
 )
 from omop_core.services.mappings import (
-    WEARABLE_LOINC, WEARABLE_MIN_VALID_DAYS, CONCEPT_EHR_TYPE, CONCEPT_GENERIC_LAB,
+    WEARABLE_CONCEPT_CODE, WEARABLE_MIN_VALID_DAYS, CONCEPT_EHR_TYPE, CONCEPT_GENERIC_LAB,
 )
 from omop_core.services.pk import next_pk, next_pk_batch
 from omop_core.services.patient_record_service import refresh_patient_record
@@ -426,7 +426,7 @@ class Command(BaseCommand):
         # and provides an early abort if any required concept is missing.
         self._write_progress('Pre-fetching wearable LOINC concepts...')
         wearable_concepts = {}
-        for metric_key, loinc_code in WEARABLE_LOINC.items():
+        for metric_key, loinc_code in WEARABLE_CONCEPT_CODE.items():
             concept = Concept.objects.filter(concept_code=loinc_code).first()
             if concept is None:
                 raise CommandError(
@@ -851,7 +851,7 @@ class Command(BaseCommand):
         measurements_to_create = []
         observations_to_create = []
 
-        for metric_key, loinc_code in WEARABLE_LOINC.items():
+        for metric_key, loinc_code in WEARABLE_CONCEPT_CODE.items():
             if metric_key == 'sleep_duration':
                 continue
 

--- a/omop_core/management/commands/generate_fhir_bundle.py
+++ b/omop_core/management/commands/generate_fhir_bundle.py
@@ -1710,7 +1710,7 @@ class Command(BaseCommand):
         """Generate 30 days of synthetic wearable Observations (steps, HR, SpO2, sleep, etc.)."""
         today = datetime.now().date()
         entries = []
-        # LOINC codes matching WEARABLE_LOINC in omop_core/services/mappings.py
+        # LOINC codes matching WEARABLE_CONCEPT_CODE in omop_core/services/mappings.py
         metrics = [
             ('55423-8', 'Steps count', 'steps', '/d',  '/d',
              lambda: round(random.gauss(7500, 2500))),

--- a/omop_core/management/commands/remap_wearable_concepts.py
+++ b/omop_core/management/commands/remap_wearable_concepts.py
@@ -1,0 +1,246 @@
+"""
+Remap wearable Measurement/Observation rows onto the corrected concepts.
+
+Deliberately a management command rather than a data migration: it rewrites
+clinical rows in bulk (~190k on staging) and moves rows between the measurement
+and observation tables. `start.sh` runs `migrate` on every deploy, so putting
+this in a migration would fire it automatically on deploy with no dry-run and no
+operator present. Run it explicitly instead.
+
+It fixes three things left behind by the pre-#413 mapping:
+
+  1. Rows pointing at the retired 900xxxx local mints are repointed at the real
+     Athena concept for the same metric.
+  2. Rows carrying a wrong or invented concept_code get the corrected code.
+  3. Rows sitting in the wrong table are moved, because four wearable concepts
+     are Observation-domain (steps, active_minutes, sleep_duration,
+     flights_climbed) and were previously all written to measurement.
+
+Usage:
+    python manage.py remap_wearable_concepts --dry-run     # default, reports only
+    python manage.py remap_wearable_concepts --apply
+    python manage.py remap_wearable_concepts --apply --metric steps
+"""
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from omop_core.models import Concept, Measurement, Observation
+from omop_core.services.mappings import (
+    WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB,
+)
+
+logger = logging.getLogger(__name__)
+
+# concept_ids of the retired local mints (seed_omop_concepts, pre-#413), keyed
+# by the metric each one carried. Scoped per-metric so remapping one metric
+# cannot sweep up rows belonging to another.
+RETIRED_MINT_BY_METRIC = {
+    'steps':            9001019,
+    'active_minutes':   9001020,
+    'resting_hr':       9001021,
+    'hrv_sdnn':         9001022,
+    'respiratory_rate': 9001023,
+    'sleep_duration':   9001024,
+}
+RETIRED_MINT_IDS = frozenset(RETIRED_MINT_BY_METRIC.values())
+
+# Pre-#413 concept_code for each metric, where it differed from the corrected
+# one. Only codes that are UNIQUELY wearable appear here.
+#
+# Deliberately excluded: body_mass (29463-7) and spo2 (59408-5). Both codes are
+# correct already, and both are written by the vitals/FHIR ingestion paths as
+# well — matching on them would sweep up non-wearable rows. Those metrics are
+# only remapped via RETIRED_MINT_IDS, which is unambiguous.
+OLD_CODES = {
+    'active_minutes':             ['77592-4'],   # was the IPAQ survey concept
+    'walking_speed':              ['41909-3'],   # was Deprecated BMI
+    'walking_hr_avg':             ['89270-3'],   # was BMI [Ratio] Estimated
+    'basal_energy':               ['41982-0'],   # was Percentage of body fat
+    'active_energy':              ['55424-6'],   # was pedometer-scoped
+    'flights_climbed':            ['96340-0'],   # not a valid LOINC code
+    'walking_step_length':        ['96341-8'],   # not a valid LOINC code
+    'walking_double_support_pct': ['96343-4'],   # not a valid LOINC code
+}
+
+
+class Command(BaseCommand):
+    help = 'Remap wearable OMOP rows onto the corrected concepts (see #413).'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--apply', action='store_true',
+            help='Write changes. Without this the command reports and rolls back.')
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help='Explicitly request a dry run (the default).')
+        parser.add_argument(
+            '--metric', action='append', default=None,
+            help='Limit to one metric key. Repeatable.')
+
+    def handle(self, *args, **options):
+        apply_changes = options['apply']
+        if apply_changes and options['dry_run']:
+            raise CommandError('--apply and --dry-run are mutually exclusive.')
+
+        metrics = options['metric'] or sorted(WEARABLE_CONCEPT_CODE)
+        unknown = [m for m in metrics if m not in WEARABLE_CONCEPT_CODE]
+        if unknown:
+            raise CommandError(f'Unknown metric key(s): {unknown}')
+
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING(
+                'DRY RUN — no changes will be written. Re-run with --apply.\n'))
+
+        totals = {'repointed': 0, 'recoded': 0, 'moved': 0, 'skipped_no_concept': 0}
+
+        with transaction.atomic():
+            for metric in metrics:
+                self._remap_metric(metric, totals)
+
+            if not apply_changes:
+                transaction.set_rollback(True)
+
+        self.stdout.write('')
+        self.stdout.write(self.style.SUCCESS(
+            'Repointed: {repointed}  |  Recoded: {recoded}  |  '
+            'Moved between tables: {moved}  |  Skipped (no target concept): '
+            '{skipped_no_concept}'.format(**totals)))
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING('Rolled back (dry run).'))
+
+    # ------------------------------------------------------------------
+
+    def _remap_metric(self, metric, totals):
+        new_code = WEARABLE_CONCEPT_CODE[metric]
+        vocabulary_id = WEARABLE_CONCEPT_VOCAB[metric]
+
+        target = (
+            Concept.objects
+            .filter(vocabulary_id=vocabulary_id, concept_code=new_code)
+            .exclude(concept_id__in=RETIRED_MINT_IDS)
+            .order_by('concept_id')
+            .first()
+        )
+        if target is None:
+            self.stdout.write(self.style.ERROR(
+                f'  {metric:28s} SKIPPED — no concept for '
+                f'({vocabulary_id}, {new_code}). Run seed_omop_concepts first.'))
+            totals['skipped_no_concept'] += 1
+            return
+
+        old_codes = OLD_CODES.get(metric, [])
+        mint_id = RETIRED_MINT_BY_METRIC.get(metric)
+        wants_observation = target.domain_id == 'Observation'
+
+        # Rows to fix: this metric's retired mint, or a superseded code.
+        m_qs = Measurement.objects.filter(
+            _wearable_row_filter('measurement', mint_id, old_codes))
+        o_qs = Observation.objects.filter(
+            _wearable_row_filter('observation', mint_id, old_codes))
+
+        m_count = m_qs.count()
+        o_count = o_qs.count()
+        if not (m_count or o_count):
+            return
+
+        if wants_observation:
+            moved = self._move_measurements_to_observation(m_qs, target, new_code)
+            recoded = o_qs.update(
+                observation_concept=target, observation_source_value=new_code)
+            totals['moved'] += moved
+            totals['recoded'] += recoded
+            self.stdout.write(
+                f'  {metric:28s} -> Observation {target.concept_id} '
+                f'({new_code}): moved {moved}, recoded {recoded}')
+        else:
+            moved = self._move_observations_to_measurement(o_qs, target, new_code)
+            recoded = m_qs.update(
+                measurement_concept=target, measurement_source_value=new_code)
+            totals['moved'] += moved
+            totals['recoded'] += recoded
+            self.stdout.write(
+                f'  {metric:28s} -> Measurement {target.concept_id} '
+                f'({new_code}): moved {moved}, recoded {recoded}')
+
+    def _move_measurements_to_observation(self, qs, target, new_code):
+        from patient_portal.api.views import _next_pk_batch
+
+        rows = list(qs.values(
+            'measurement_id', 'person_id', 'measurement_date',
+            'measurement_type_concept_id', 'value_as_number', 'unit_source_value'))
+        if not rows:
+            return 0
+
+        new_ids = _next_pk_batch(Observation, 'observation_id', len(rows))
+        pending = []
+        for row, oid in zip(rows, new_ids):
+            obs = Observation(
+                observation_id=oid,
+                person_id=row['person_id'],
+                observation_concept=target,
+                observation_date=row['measurement_date'],
+                observation_type_concept_id=row['measurement_type_concept_id'],
+                value_as_number=row['value_as_number'],
+                observation_source_value=new_code,
+                unit_source_value=row['unit_source_value'],
+            )
+            obs._skip_patient_record_refresh = True
+            pending.append(obs)
+
+        Observation.objects.bulk_create(pending)
+        Measurement.objects.filter(
+            measurement_id__in=[r['measurement_id'] for r in rows]).delete()
+        return len(pending)
+
+    def _move_observations_to_measurement(self, qs, target, new_code):
+        from patient_portal.api.views import _next_pk_batch
+
+        rows = list(qs.values(
+            'observation_id', 'person_id', 'observation_date',
+            'observation_type_concept_id', 'value_as_number', 'unit_source_value'))
+        if not rows:
+            return 0
+
+        new_ids = _next_pk_batch(Measurement, 'measurement_id', len(rows))
+        pending = []
+        for row, mid in zip(rows, new_ids):
+            m = Measurement(
+                measurement_id=mid,
+                person_id=row['person_id'],
+                measurement_concept=target,
+                measurement_date=row['observation_date'],
+                measurement_type_concept_id=row['observation_type_concept_id'],
+                value_as_number=row['value_as_number'],
+                measurement_source_value=new_code,
+                unit_source_value=row['unit_source_value'],
+            )
+            m._skip_patient_record_refresh = True
+            pending.append(m)
+
+        Measurement.objects.bulk_create(pending)
+        Observation.objects.filter(
+            observation_id__in=[r['observation_id'] for r in rows]).delete()
+        return len(pending)
+
+
+def _wearable_row_filter(table, mint_id, old_codes):
+    """Q() matching this metric's retired mint or its superseded concept_codes.
+
+    Scoped to a single mint_id: matching the whole retired range would let one
+    metric claim another metric's rows.
+    """
+    from django.db.models import Q
+
+    if table == 'measurement':
+        concept_field, source_field = 'measurement_concept_id', 'measurement_source_value'
+    else:
+        concept_field, source_field = 'observation_concept_id', 'observation_source_value'
+
+    q = Q(pk__in=[])  # matches nothing
+    if mint_id is not None:
+        q |= Q(**{concept_field: mint_id})
+    if old_codes:
+        q |= Q(**{f'{source_field}__in': old_codes})
+    return q

--- a/omop_core/management/commands/seed_omop_concepts.py
+++ b/omop_core/management/commands/seed_omop_concepts.py
@@ -11,7 +11,7 @@ Usage:
 """
 from datetime import date
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
@@ -41,6 +41,13 @@ _VOCABULARIES = [
          vocabulary_name='OMOP CDM',
          vocabulary_reference='OMOP generated',
          vocabulary_version='CDM v5',
+         vocabulary_concept_id=0),
+    # Locally-authored wearable concepts with no LOINC equivalent. Rows in this
+    # vocabulary always carry source='HealthKey' and concept_id >= 2e9.
+    dict(vocabulary_id='HK-Wearable',
+         vocabulary_name='HealthKey Wearable Metrics',
+         vocabulary_reference='HealthKey local mint',
+         vocabulary_version='v1',
          vocabulary_concept_id=0),
     dict(vocabulary_id='Episode',
          vocabulary_name='OMOP Episode',
@@ -93,7 +100,14 @@ _END   = date(2099, 12, 31)
 
 def _c(concept_id, concept_name, domain_id, vocabulary_id, concept_class_id,
         standard_concept, concept_code,
-        valid_start=None, valid_end=None):
+        valid_start=None, valid_end=None, source=None):
+    """Build a concept row.
+
+    ``source`` follows Concept.source semantics: None means the row mirrors an
+    externally-loaded vocabulary release (Athena), 'HealthKey' means it is
+    authored locally. Locally-authored rows MUST use an HK-* vocabulary and a
+    concept_id in the OHDSI custom range (>= 2e9) — see _assert_local_mint.
+    """
     return dict(
         concept_id=concept_id,
         concept_name=concept_name,
@@ -105,6 +119,22 @@ def _c(concept_id, concept_name, domain_id, vocabulary_id, concept_class_id,
         valid_start_date=valid_start or _START,
         valid_end_date=valid_end or _END,
         invalid_reason=None,
+        source=source,
+    )
+
+
+# OHDSI reserves concept_id >= 2e9 for locally-authored concepts; Athena never
+# allocates there. HK-Labs occupies 2029606279-2029606349 on staging, so the
+# wearable block continues immediately above it.
+LOCAL_CONCEPT_ID_MIN = 2_000_000_000
+_HK_WEARABLE_ID_BASE = 2_029_606_350
+
+
+def _hk(offset, concept_name, domain_id, concept_class_id, concept_code):
+    """Build a locally-minted HK-Wearable concept, correctly quarantined."""
+    return _c(
+        _HK_WEARABLE_ID_BASE + offset, concept_name, domain_id, 'HK-Wearable',
+        concept_class_id, None, concept_code, source='HealthKey',
     )
 
 
@@ -262,17 +292,43 @@ _CONCEPTS = [
     _c(9001018, 'Glomerular filtration rate by CKD-EPI',          'Measurement', 'LOINC', 'Lab Test', 'S', '62238-1'),
 
     # ------------------------------------------------------------------
-    # Wearable / remote-monitoring LOINCs
-    # Required for wearable_last_sync_at and related PatientRecord fields.
-    # patient_record_service._get_wearable_data() queries by both
-    # measurement_concept__concept_code and measurement_source_value.
+    # Wearable / remote-monitoring concepts.
+    #
+    # These MIRROR genuine Athena rows: concept_id, name, domain and class are
+    # copied verbatim from the LOINC vocabulary. Because seeding is keyed on
+    # concept_id, a row seeded here is created on a database with no Athena load
+    # and matches the existing row where Athena IS loaded — so no duplicate
+    # (vocabulary_id, concept_code) pair can arise. Never mint a fresh id for a
+    # code Athena already owns; that is what produced the duplicates in #415.
+    #
+    # Note the domains: steps, active_minutes, sleep_duration and flights_climbed
+    # are Observation-domain concepts. upload_wearable routes on concept.domain_id.
     # ------------------------------------------------------------------
-    _c(9001019, 'Number of steps in 24 hours',                    'Measurement', 'LOINC', 'Clinical Observation', 'S', '55423-8'),
-    _c(9001020, 'Moderate-vigorous physical activity duration',   'Measurement', 'LOINC', 'Clinical Observation', 'S', '77592-4'),
-    _c(9001021, 'Heart rate -- resting',                          'Measurement', 'LOINC', 'Clinical Observation', 'S', '40443-4'),
-    _c(9001022, 'Heart rate variability SDNN',                    'Measurement', 'LOINC', 'Clinical Observation', 'S', '80404-7'),
-    _c(9001023, 'Respiratory rate',                               'Measurement', 'LOINC', 'Clinical Observation', 'S', '9279-1'),
-    _c(9001024, 'Sleep duration',                                 'Measurement', 'LOINC', 'Clinical Observation', 'S', '93832-4'),
+    _c(40758552, 'Number of steps in unspecified time Pedometer',              'Observation', 'LOINC', 'Clinical Observation', 'S', '55423-8',  date(2009, 4, 23)),
+    _c(40758540, 'Exercise duration',                                          'Observation', 'LOINC', 'Clinical Observation', 'S', '55411-3',  date(2009, 4, 23)),
+    _c(3040891,  'Heart rate --resting',                                       'Measurement', 'LOINC', 'Clinical Observation', 'S', '40443-4'),
+    _c(21491502, 'R-R interval.standard deviation (Heart rate variability)',   'Measurement', 'LOINC', 'Clinical Observation', 'S', '80404-7',  date(2016, 6, 24)),
+    # spo2 (59408-5 / 40762499) and body_mass (29463-7 / 3025315) are already
+    # seeded in the vitals block above and must not be repeated here — a second
+    # row for the same (vocabulary_id, concept_code) is exactly the duplication
+    # this block exists to avoid.
+    _c(3024171,  'Respiratory rate',                                           'Measurement', 'LOINC', 'Clinical Observation', 'S', '9279-1',   date(1996, 9, 6)),
+    _c(1002368,  'Sleep duration',                                             'Observation', 'LOINC', 'Clinical Observation', 'S', '93832-4',  date(2019, 12, 13)),
+    _c(1002246,  'Oxygen consumption (VO2)/Body weight [Volume Rate Content]', 'Measurement', 'LOINC', 'Clinical Observation', 'S', '94122-9',  date(2019, 12, 13)),
+    _c(3031111,  'Walking distance 24 hour Calculated',                        'Measurement', 'LOINC', 'Clinical Observation', 'S', '41953-1',  date(2005, 7, 27)),
+    _c(3032289,  'Walking speed 24 hour mean Calculated',                      'Measurement', 'LOINC', 'Clinical Observation', 'S', '41957-2',  date(2005, 7, 27)),
+    _c(1761351,  'Flights climbed [#] Reporting Period',                       'Observation', 'LOINC', 'Clinical Observation', 'S', '100304-5', date(2022, 8, 8)),
+    _c(1001786,  'Calories burned in unspecified time --during activity',      'Measurement', 'LOINC', 'Clinical Observation', 'S', '93819-1',  date(2019, 12, 13)),
+
+    # Wearable metrics with NO LOINC equivalent — locally minted, quarantined
+    # under HK-Wearable with source='HealthKey' and ids in the OHDSI custom
+    # range. LOINC has no concept for step length, double-support percentage,
+    # walking heart rate, or basal energy expenditure in kcal/day (50042-1 is
+    # "Basal metabolic rate index", a normalized index, not an energy rate).
+    _hk(0, 'Walking step length',                    'Measurement', 'Clinical Observation', 'HK-WEAR-STEP-LENGTH'),
+    _hk(1, 'Walking double support time percentage', 'Measurement', 'Clinical Observation', 'HK-WEAR-DBL-SUPPORT'),
+    _hk(2, 'Heart rate during walking',              'Measurement', 'Clinical Observation', 'HK-WEAR-WALK-HR'),
+    _hk(3, 'Basal energy expenditure',               'Measurement', 'Clinical Observation', 'HK-WEAR-BASAL-ENERGY'),
 
     # ------------------------------------------------------------------
     # HemOnc therapy regimen concepts — required for first_line_therapy_id
@@ -309,6 +365,45 @@ _CONCEPTS = [
 ]
 
 
+def _assert_local_mint_convention():
+    """Fail fast if any seeded row breaks the local-mint quarantine rules.
+
+    Guards the three invariants that, when violated, produced #413 and #415:
+      - a locally-authored row must live in an HK-* vocabulary,
+      - it must carry source='HealthKey',
+      - and its concept_id must be in the OHDSI custom range (>= 2e9), which
+        Athena never allocates, so it cannot collide on the primary key.
+    """
+    problems = []
+    for row in _CONCEPTS:
+        is_hk_vocab = row['vocabulary_id'].startswith('HK-')
+        is_tagged = row.get('source') == 'HealthKey'
+        in_local_range = row['concept_id'] >= LOCAL_CONCEPT_ID_MIN
+
+        if is_hk_vocab or is_tagged:
+            if not is_hk_vocab:
+                problems.append(
+                    f"{row['concept_id']} {row['concept_code']}: source='HealthKey' "
+                    f"but vocabulary is {row['vocabulary_id']!r}, not HK-*")
+            if not is_tagged:
+                problems.append(
+                    f"{row['concept_id']} {row['concept_code']}: HK-* vocabulary "
+                    f"but source is {row.get('source')!r}, not 'HealthKey'")
+            if not in_local_range:
+                problems.append(
+                    f"{row['concept_id']} {row['concept_code']}: local mint must have "
+                    f"concept_id >= {LOCAL_CONCEPT_ID_MIN}")
+        elif in_local_range:
+            problems.append(
+                f"{row['concept_id']} {row['concept_code']}: concept_id is in the local "
+                f"range but the row is not marked as a HealthKey mint")
+
+    if problems:
+        raise CommandError(
+            'Seed rows violate the local-mint convention:\n  '
+            + '\n  '.join(problems))
+
+
 class Command(BaseCommand):
     help = (
         'Seed the minimal OMOP concept rows required for mCODE FHIR import. '
@@ -323,6 +418,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dry_run = options['dry_run']
+
+        _assert_local_mint_convention()
 
         if dry_run:
             self.stdout.write(self.style.WARNING('Dry-run mode — no changes will be written.\n'))

--- a/omop_core/services/mappings.py
+++ b/omop_core/services/mappings.py
@@ -87,26 +87,50 @@ CONCEPT_TREATMENT_REGIMEN = 32531     # Treatment Regimen (episode concept)
 CONCEPT_DRUG_EXPOSURE_FIELD = 1147094  # drug_exposure_id field concept (EpisodeEvent)
 
 
-# Wearable metric LOINC codes → PatientRecord field (for 30-day aggregation)
-WEARABLE_LOINC = {
-    'steps':              '55423-8',   # Number of steps in 24 hours
-    'active_minutes':     '77592-4',   # Moderate-vigorous physical activity duration
-    'resting_hr':         '40443-4',   # Heart rate -- resting
-    'hrv_sdnn':           '80404-7',   # Heart rate variability SDNN
-    'spo2':               '59408-5',   # Oxygen saturation by pulse oximetry
+# Wearable metric → controlled-vocabulary concept_code.
+#
+# Most entries are LOINC. Four metrics have no LOINC equivalent and are minted
+# locally under the HK-Wearable vocabulary (see WEARABLE_CONCEPT_VOCAB), so this
+# map is NOT LOINC-only despite most of its contents.
+#
+# Every code here is verified to resolve to a concept whose meaning matches the
+# metric. Do not add an entry without checking the concept_name in Athena — four
+# codes in the original version resolved to BMI and body-fat-percentage concepts.
+WEARABLE_CONCEPT_CODE = {
+    'steps':              '55423-8',   # Number of steps in unspecified time Pedometer
+    'active_minutes':     '55411-3',   # Exercise duration
+    'resting_hr':         '40443-4',   # Heart rate --resting
+    'hrv_sdnn':           '80404-7',   # R-R interval.standard deviation (HRV SDNN)
+    'spo2':               '59408-5',   # Oxygen saturation in Arterial blood by Pulse oximetry
     'respiratory_rate':   '9279-1',    # Respiratory rate
     'sleep_duration':     '93832-4',   # Sleep duration
-    'vo2_max':            '94122-9',   # VO2 max (mL/kg/min)
-    'distance':           '41953-1',   # Walking distance
-    'walking_speed':      '41909-3',   # Gait speed
-    'walking_step_length': '96341-8',  # Step length
-    'walking_double_support_pct': '96343-4',  # Double support time percent
-    'walking_hr_avg':     '89270-3',   # Heart rate during walking
-    'flights_climbed':    '96340-0',   # Floors ascended
-    'active_energy':      '55424-6',   # Calories burned in exercise
-    'basal_energy':       '41982-0',   # Basal energy expenditure
+    'vo2_max':            '94122-9',   # Oxygen consumption (VO2)/Body weight
+    'distance':           '41953-1',   # Walking distance 24 hour Calculated
+    'walking_speed':      '41957-2',   # Walking speed 24 hour mean Calculated
+    'walking_step_length': 'HK-WEAR-STEP-LENGTH',        # no LOINC equivalent
+    'walking_double_support_pct': 'HK-WEAR-DBL-SUPPORT',  # no LOINC equivalent
+    'walking_hr_avg':     'HK-WEAR-WALK-HR',             # no LOINC equivalent
+    'flights_climbed':    '100304-5',  # Flights climbed [#] Reporting Period
+    'active_energy':      '93819-1',   # Calories burned in unspecified time --during activity
+    'basal_energy':       'HK-WEAR-BASAL-ENERGY',        # no LOINC equivalent
     'body_mass':          '29463-7',   # Body weight
 }
+
+# Vocabulary each code above belongs to. Concept resolution must be scoped by
+# (vocabulary_id, concept_code) — a bare concept_code is ambiguous, since 852
+# codes are reused across vocabularies.
+WEARABLE_CONCEPT_VOCAB = {
+    metric: ('HK-Wearable' if code.startswith('HK-') else 'LOINC')
+    for metric, code in WEARABLE_CONCEPT_CODE.items()
+}
+
+# Metrics whose concept is Observation-domain and therefore belong in the
+# `observation` table rather than `measurement`. This mirrors the domain_id of
+# the concepts above and exists for tests and fixtures; the runtime write path
+# reads concept.domain_id directly so it stays correct if a code changes.
+WEARABLE_OBSERVATION_METRICS = frozenset({
+    'steps', 'active_minutes', 'sleep_duration', 'flights_climbed',
+})
 
 # Artifact-filter bounds: readings outside [lo, hi] are discarded before aggregation
 WEARABLE_ARTIFACT_BOUNDS = {

--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -23,7 +23,7 @@ from omop_core.models import (
 )
 from omop_core.services.concept_cache import concept_by_id as _cc_by_id, concept_by_loinc as _cc_by_loinc
 from omop_core.services.mappings import (
-    WEARABLE_LOINC, WEARABLE_ARTIFACT_BOUNDS, WEARABLE_MIN_VALID_DAYS,
+    WEARABLE_CONCEPT_CODE, WEARABLE_ARTIFACT_BOUNDS, WEARABLE_MIN_VALID_DAYS,
     WEARABLE_TREND_IMPROVING_PCT, WEARABLE_TREND_DECLINING_PCT,
 )
 from omop_core.services.lot_regimens import (
@@ -2488,8 +2488,8 @@ def _get_wearable_data(person: Person) -> dict:
             qs = qs.filter(measurement_date__gte=date_filter)
         return list(
             qs.filter(
-                models.Q(measurement_concept__concept_code__in=WEARABLE_LOINC.values())
-                | models.Q(measurement_source_value__in=WEARABLE_LOINC.values())
+                models.Q(measurement_concept__concept_code__in=WEARABLE_CONCEPT_CODE.values())
+                | models.Q(measurement_source_value__in=WEARABLE_CONCEPT_CODE.values())
             )
             .values_list(
                 'measurement_concept__concept_code',
@@ -2500,6 +2500,10 @@ def _get_wearable_data(person: Person) -> dict:
         )
 
     def _wearable_observations(date_filter=None):
+        # Several wearable concepts are Observation-domain (steps, active_minutes,
+        # sleep_duration, flights_climbed), so this must match every wearable code
+        # — not just sleep — and return the code alongside the value so rows are
+        # keyed identically to the Measurement rows below.
         qs = Observation.objects.filter(
             person=person,
             value_as_number__isnull=False,
@@ -2508,10 +2512,15 @@ def _get_wearable_data(person: Person) -> dict:
             qs = qs.filter(observation_date__gte=date_filter)
         return list(
             qs.filter(
-                models.Q(observation_concept__concept_code=WEARABLE_LOINC['sleep_duration'])
-                | models.Q(observation_source_value=WEARABLE_LOINC['sleep_duration'])
+                models.Q(observation_concept__concept_code__in=WEARABLE_CONCEPT_CODE.values())
+                | models.Q(observation_source_value__in=WEARABLE_CONCEPT_CODE.values())
             )
-            .values_list('observation_date', 'value_as_number')
+            .values_list(
+                'observation_concept__concept_code',
+                'observation_source_value',
+                'observation_date',
+                'value_as_number',
+            )
         )
 
     # Try recent data first; fall back to all data if nothing within 90 days
@@ -2528,16 +2537,19 @@ def _get_wearable_data(person: Person) -> dict:
     # unrelated concept_code (e.g. an unmapped source concept) yet a wearable
     # measurement_source_value — prefer whichever is a known wearable code so
     # the source_value fallback isn't shadowed by a present-but-unrelated concept.
-    _wearable_codes = set(WEARABLE_LOINC.values())
+    _wearable_codes = set(WEARABLE_CONCEPT_CODE.values())
     rows_by_code: dict[str, list[tuple[date, float]]] = {}
-    for concept_code, source_value, mdate, val in measurement_rows:
+    # Measurement and Observation rows are merged into one index keyed by code,
+    # so a metric is read the same way regardless of which table its concept's
+    # domain routed it to.
+    for concept_code, source_value, mdate, val in measurement_rows + observation_rows:
         code = concept_code if concept_code in _wearable_codes else source_value
         if code not in _wearable_codes:
             continue
         rows_by_code.setdefault(code, []).append((mdate, float(val)))
 
     def _metric_daily(metric_key):
-        loinc_code = WEARABLE_LOINC[metric_key]
+        loinc_code = WEARABLE_CONCEPT_CODE[metric_key]
         lo, hi = WEARABLE_ARTIFACT_BOUNDS[metric_key]
         daily: dict[date, list[float]] = {}
         for mdate, val in rows_by_code.get(loinc_code, []):
@@ -2562,15 +2574,8 @@ def _get_wearable_data(person: Person) -> dict:
     basal_energy_daily = _metric_daily('basal_energy')
     body_mass_daily = _metric_daily('body_mass')
 
-    sleep_daily: dict[date, list[float]] = {}
-    lo_s, hi_s = WEARABLE_ARTIFACT_BOUNDS['sleep_duration']
-    for odate, val in observation_rows:
-        fval = float(val)
-        if lo_s <= fval <= hi_s:
-            sleep_daily.setdefault(odate, []).append(fval)
-    for mdate, val in rows_by_code.get(WEARABLE_LOINC['sleep_duration'], []):
-        if lo_s <= val <= hi_s:
-            sleep_daily.setdefault(mdate, []).append(val)
+    # Sleep needs no special-casing now that observation rows are merged above.
+    sleep_daily = _metric_daily('sleep_duration')
 
     all_valid_days = sorted(
         steps_daily.keys() | active_daily.keys()

--- a/omop_core/services/wearable_parsers.py
+++ b/omop_core/services/wearable_parsers.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class WearableSample(NamedTuple):
     """A single daily metric extracted from a wearable data file."""
-    metric_key: str   # one of WEARABLE_LOINC keys
+    metric_key: str   # one of WEARABLE_CONCEPT_CODE keys
     date: date
     value: float
 

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -2114,3 +2114,143 @@ class PatientInfoCompatViewTest(TestCase):
                         "UPDATE patient_info SET disease = 'x' WHERE person_id = %s",
                         [person.person_id],
                     )
+
+
+class WearableConceptMappingTest(TestCase):
+    """Guards the concept-mapping invariants that #413 and #415 were caused by.
+
+    These assert on the seed definitions rather than a loaded database, so they
+    run everywhere and fail at the point a bad mapping is written rather than
+    when an upload silently drops data.
+    """
+
+    def _seed_rows(self):
+        from omop_core.management.commands.seed_omop_concepts import _CONCEPTS
+        return _CONCEPTS
+
+    def test_every_wearable_metric_is_seeded(self):
+        """Each metric's (vocabulary, code) must exist in the seed set.
+
+        Without this, upload_wearable resolves None and silently discards every
+        sample for the metric while still reporting HTTP 200.
+        """
+        from omop_core.services.mappings import (
+            WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB,
+        )
+        seeded = {(r['vocabulary_id'], r['concept_code']) for r in self._seed_rows()}
+        missing = [
+            (metric, WEARABLE_CONCEPT_VOCAB[metric], code)
+            for metric, code in WEARABLE_CONCEPT_CODE.items()
+            if (WEARABLE_CONCEPT_VOCAB[metric], code) not in seeded
+        ]
+        self.assertEqual(missing, [], f'wearable metrics absent from seed set: {missing}')
+
+    def test_seeded_wearable_concept_names_match_their_metric(self):
+        """A code that resolves is not necessarily the RIGHT code.
+
+        The original mapping pointed walking_speed and walking_hr_avg at BMI
+        concepts and basal_energy at body-fat percentage — all of which resolved
+        fine. This asserts the concept_name is semantically consistent, which is
+        what a mere code-exists check would have missed.
+        """
+        from omop_core.services.mappings import (
+            WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB,
+        )
+        # Substrings that must appear (lowercased) in the seeded concept_name.
+        expected_terms = {
+            'steps': ['step'],
+            'active_minutes': ['exercise', 'activity'],
+            'resting_hr': ['heart rate'],
+            'hrv_sdnn': ['r-r interval', 'heart rate variability'],
+            'spo2': ['oxygen saturation'],
+            'respiratory_rate': ['respiratory rate'],
+            'sleep_duration': ['sleep'],
+            'vo2_max': ['oxygen consumption'],
+            'distance': ['distance'],
+            'walking_speed': ['walking speed'],
+            'walking_step_length': ['step length'],
+            'walking_double_support_pct': ['double support'],
+            'walking_hr_avg': ['heart rate'],
+            'flights_climbed': ['flights'],
+            'active_energy': ['calories', 'energy'],
+            'basal_energy': ['basal energy'],
+            'body_mass': ['body weight', 'body mass'],
+        }
+        by_key = {
+            (r['vocabulary_id'], r['concept_code']): r['concept_name']
+            for r in self._seed_rows()
+        }
+        for metric, code in WEARABLE_CONCEPT_CODE.items():
+            name = by_key.get((WEARABLE_CONCEPT_VOCAB[metric], code))
+            self.assertIsNotNone(name, f'{metric} ({code}) not seeded')
+            lowered = name.lower()
+            self.assertTrue(
+                any(term in lowered for term in expected_terms[metric]),
+                f'{metric} maps to {code} = "{name}", which does not look like '
+                f'{expected_terms[metric]}',
+            )
+
+    def test_no_duplicate_vocabulary_code_pairs_in_seed(self):
+        """Two seed rows must never claim the same (vocabulary_id, concept_code).
+
+        A duplicate pair makes concept resolution nondeterministic, since
+        concept_by_vocab does .first() with no ordering.
+        """
+        seen, dupes = set(), []
+        for row in self._seed_rows():
+            key = (row['vocabulary_id'], row['concept_code'])
+            if key in seen:
+                dupes.append(key)
+            seen.add(key)
+        self.assertEqual(dupes, [], f'duplicate (vocabulary_id, concept_code): {dupes}')
+
+    def test_local_mints_are_quarantined(self):
+        """source='HealthKey' <-> HK-* vocabulary <-> concept_id >= 2e9."""
+        from omop_core.management.commands.seed_omop_concepts import (
+            _assert_local_mint_convention, LOCAL_CONCEPT_ID_MIN,
+        )
+        _assert_local_mint_convention()  # raises CommandError on violation
+
+        for row in self._seed_rows():
+            if row['vocabulary_id'].startswith('HK-'):
+                self.assertEqual(
+                    row.get('source'), 'HealthKey',
+                    f"{row['concept_code']} is HK-* but not tagged as a HealthKey mint")
+                self.assertGreaterEqual(
+                    row['concept_id'], LOCAL_CONCEPT_ID_MIN,
+                    f"{row['concept_code']} is a local mint below the OHDSI custom range")
+            else:
+                self.assertIsNone(
+                    row.get('source'),
+                    f"{row['concept_code']} is in an external vocabulary but tagged local")
+
+    def test_no_local_mint_shadows_an_external_code(self):
+        """A local mint must not reuse a real LOINC/SNOMED/RxNorm code string.
+
+        Reusing one asserts an externally-defined meaning for a locally-authored
+        concept and makes code-only lookups ambiguous.
+        """
+        from omop_core.services.mappings import (
+            WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB,
+        )
+        for metric, code in WEARABLE_CONCEPT_CODE.items():
+            if WEARABLE_CONCEPT_VOCAB[metric] == 'HK-Wearable':
+                self.assertTrue(
+                    code.startswith('HK-'),
+                    f'{metric} is locally minted but uses external-looking code {code}')
+
+    def test_observation_metric_set_matches_seeded_domains(self):
+        """WEARABLE_OBSERVATION_METRICS must agree with the seeded domain_ids."""
+        from omop_core.services.mappings import (
+            WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB, WEARABLE_OBSERVATION_METRICS,
+        )
+        by_key = {
+            (r['vocabulary_id'], r['concept_code']): r['domain_id']
+            for r in self._seed_rows()
+        }
+        for metric, code in WEARABLE_CONCEPT_CODE.items():
+            domain = by_key.get((WEARABLE_CONCEPT_VOCAB[metric], code))
+            expected = 'Observation' if metric in WEARABLE_OBSERVATION_METRICS else 'Measurement'
+            self.assertEqual(
+                domain, expected,
+                f'{metric} ({code}) is seeded domain {domain} but the metric set says {expected}')

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -3556,8 +3556,10 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         """
         from omop_core.services.wearable_parsers import parse_garmin_fit, parse_apple_health_export
         from omop_core.services.pk import next_pk_batch as _next_pk_batch
-        from omop_core.services.mappings import WEARABLE_LOINC, WEARABLE_ARTIFACT_BOUNDS
-        from omop_core.services.concept_cache import concept_by_loinc as _cc_by_loinc
+        from omop_core.services.mappings import (
+            WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB, WEARABLE_ARTIFACT_BOUNDS,
+        )
+        from omop_core.services.concept_cache import concept_by_vocab as _cc_by_vocab
 
         if 'file' not in request.FILES:
             return Response({'error': 'No file provided'}, status=status.HTTP_400_BAD_REQUEST)
@@ -3614,10 +3616,21 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if not samples:
             return Response({'samples_created': 0, 'duplicates_skipped': 0})
 
-        # Look up LOINC concepts for each metric
-        loinc_concepts: dict[str, Concept | None] = {}
-        for metric_key, loinc_code in WEARABLE_LOINC.items():
-            loinc_concepts[metric_key] = _cc_by_loinc(loinc_code)
+        # Resolve each metric's concept, scoped by (vocabulary_id, concept_code).
+        # A bare concept_code is ambiguous — 852 codes are reused across
+        # vocabularies — and four wearable metrics live in HK-Wearable, not LOINC.
+        metric_concepts: dict[str, Concept | None] = {}
+        for metric_key, concept_code in WEARABLE_CONCEPT_CODE.items():
+            metric_concepts[metric_key] = _cc_by_vocab(
+                WEARABLE_CONCEPT_VOCAB[metric_key], concept_code)
+
+        unresolved = sorted(k for k, c in metric_concepts.items() if c is None)
+        if unresolved:
+            logger.warning(
+                'wearable_concepts_unresolved person_id=%s metrics=%s — samples for these '
+                'metrics will be discarded. Run seed_omop_concepts or load_athena_vocabularies.',
+                person.person_id, unresolved,
+            )
 
         # Measurement type concept (wearable device = 32883 / Patient self-report)
         type_concept = None
@@ -3632,14 +3645,41 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         # Filter out artifact values and deduplicate
         from django.db.models import Q
 
+        # UCUM unit for each metric, written to *_source_value.
+        unit_map = {
+            'steps': '/d',
+            'active_minutes': 'min',
+            'resting_hr': '/min',
+            'hrv_sdnn': 'ms',
+            'spo2': '%',
+            'respiratory_rate': '/min',
+            'sleep_duration': 'h',
+            'vo2_max': 'mL/kg/min',
+            'distance': 'km',
+            'walking_speed': 'km/hr',
+            'walking_step_length': 'cm',
+            'walking_double_support_pct': '%',
+            'walking_hr_avg': '/min',
+            'flights_climbed': '{flights}',
+            'active_energy': 'kcal',
+            'basal_energy': 'kcal',
+            'body_mass': 'kg',
+        }
+
+        # OMOP routes a row by its concept's domain, not by a hard-coded metric
+        # list: steps, active_minutes, sleep_duration and flights_climbed are
+        # Observation-domain concepts, the rest are Measurement.
+        def _is_observation(concept):
+            return concept.domain_id == 'Observation'
+
         existing_keys = set()
-        # Build set of (metric_key, date, value) that already exist.
-        # Most metrics live in Measurement; sleep_duration lives in Observation.
+        # Build set of (metric_key, date, value) that already exist, reading
+        # whichever table the concept's domain routes it to.
         for metric_key in set(s.metric_key for s in samples):
-            concept = loinc_concepts.get(metric_key)
+            concept = metric_concepts.get(metric_key)
             if concept is None:
                 continue
-            if metric_key == 'sleep_duration':
+            if _is_observation(concept):
                 existing_rows = Observation.objects.filter(
                     person=person,
                     observation_concept=concept,
@@ -3656,10 +3696,14 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         pending_measurements = []
         pending_observations = []
         duplicates_skipped = 0
+        unmapped_samples = 0
+        unmapped_metrics = set()
 
         for sample in samples:
-            concept = loinc_concepts.get(sample.metric_key)
+            concept = metric_concepts.get(sample.metric_key)
             if concept is None:
+                unmapped_samples += 1
+                unmapped_metrics.add(sample.metric_key)
                 continue
 
             # Artifact filter
@@ -3674,8 +3718,10 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                 continue
             existing_keys.add(dedup_key)
 
-            if sample.metric_key == 'sleep_duration':
-                # Sleep goes into Observation table
+            unit = unit_map.get(sample.metric_key)
+            source_code = WEARABLE_CONCEPT_CODE[sample.metric_key]
+
+            if _is_observation(concept):
                 obs = Observation(
                     observation_id=0,  # allocated below
                     person=person,
@@ -3683,31 +3729,12 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                     observation_date=sample.date,
                     observation_type_concept=type_concept,
                     value_as_number=sample.value,
-                    observation_source_value=WEARABLE_LOINC[sample.metric_key],
-                    unit_source_value='h',
+                    observation_source_value=source_code,
+                    unit_source_value=unit,
                 )
                 obs._skip_patient_record_refresh = True
                 pending_observations.append(obs)
             else:
-                # All other metrics go into Measurement table
-                unit_map = {
-                    'steps': '/d',
-                    'active_minutes': 'min',
-                    'resting_hr': '/min',
-                    'hrv_sdnn': 'ms',
-                    'spo2': '%',
-                    'respiratory_rate': '/min',
-                    'vo2_max': 'mL/kg/min',
-                    'distance': 'km',
-                    'walking_speed': 'km/hr',
-                    'walking_step_length': 'cm',
-                    'walking_double_support_pct': '%',
-                    'walking_hr_avg': '/min',
-                    'flights_climbed': '{flights}',
-                    'active_energy': 'kcal',
-                    'basal_energy': 'kcal',
-                    'body_mass': 'kg',
-                }
                 m = Measurement(
                     measurement_id=0,  # allocated below
                     person=person,
@@ -3715,8 +3742,8 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                     measurement_date=sample.date,
                     measurement_type_concept=type_concept,
                     value_as_number=sample.value,
-                    measurement_source_value=WEARABLE_LOINC[sample.metric_key],
-                    unit_source_value=unit_map.get(sample.metric_key),
+                    measurement_source_value=source_code,
+                    unit_source_value=unit,
                 )
                 m._skip_patient_record_refresh = True
                 pending_measurements.append(m)
@@ -3761,13 +3788,23 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         except Exception:
             logger.exception('wearable_upload_history_save_failed person_id=%s', person.person_id)
 
+        if unmapped_samples:
+            logger.warning(
+                'wearable_upload_unmapped device=%s person_id=%s samples=%d metrics=%s',
+                device_type, person.person_id, unmapped_samples, sorted(unmapped_metrics),
+            )
+
         logger.info(
-            'wearable_upload_complete device=%s person_id=%s created=%d duplicates=%d',
-            device_type, person.person_id, created_count, duplicates_skipped,
+            'wearable_upload_complete device=%s person_id=%s created=%d duplicates=%d unmapped=%d',
+            device_type, person.person_id, created_count, duplicates_skipped, unmapped_samples,
         )
+        # unmapped_* is reported so a missing concept is distinguishable from
+        # "the device exported no data for this metric" — previously identical.
         return Response({
             'samples_created': created_count,
             'duplicates_skipped': duplicates_skipped,
+            'unmapped_samples': unmapped_samples,
+            'unmapped_metrics': sorted(unmapped_metrics),
         })
 
     @action(detail=False, methods=['get'], url_path='wearable-uploads',
@@ -3797,8 +3834,8 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             permission_classes=[IsAuthenticated])
     def delete_wearable_upload(self, request, upload_id=None):
         """Delete a wearable upload and its associated Measurement/Observation rows."""
-        from omop_core.services.mappings import WEARABLE_LOINC
-        from omop_core.services.concept_cache import concept_by_loinc as _cc_by_loinc
+        from omop_core.services.mappings import WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB
+        from omop_core.services.concept_cache import concept_by_vocab as _cc_by_vocab
 
         patient_user = getattr(request.user, 'patient_user', None)
         if not patient_user:
@@ -3819,16 +3856,17 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             if not metric_key or not date_str or value is None:
                 continue
 
-            loinc_code = WEARABLE_LOINC.get(metric_key)
-            if not loinc_code:
+            concept_code = WEARABLE_CONCEPT_CODE.get(metric_key)
+            if not concept_code:
                 continue
-            concept = _cc_by_loinc(loinc_code)
+            concept = _cc_by_vocab(WEARABLE_CONCEPT_VOCAB[metric_key], concept_code)
             if not concept:
                 continue
 
             sample_date = _date.fromisoformat(date_str)
 
-            if metric_key == 'sleep_duration':
+            # Route by the concept's domain, matching how upload_wearable wrote it.
+            if concept.domain_id == 'Observation':
                 count, _ = Observation.objects.filter(
                     person=person,
                     observation_concept=concept,

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -9639,7 +9639,7 @@ class WearablePatientRecordTest(TestCase):
     def setUp(self):
         import datetime
         from omop_core.models import Concept, Vocabulary, Domain, ConceptClass
-        from omop_core.services.mappings import WEARABLE_LOINC
+        from omop_core.services.mappings import WEARABLE_CONCEPT_CODE
 
         self.today = datetime.date.today()
 
@@ -9664,7 +9664,7 @@ class WearablePatientRecordTest(TestCase):
 
         base_id = 9_900_000
         self.concepts = {}
-        for i, (key, loinc_code) in enumerate(WEARABLE_LOINC.items()):
+        for i, (key, loinc_code) in enumerate(WEARABLE_CONCEPT_CODE.items()):
             c, _ = Concept.objects.get_or_create(
                 concept_id=base_id + i,
                 defaults={
@@ -15604,33 +15604,49 @@ class WearableUploadEndpointTest(TestCase):
 
         _make_vocab_fixtures()
 
-        # Create LOINC concepts for wearable metrics — must use vocabulary_id='LOINC'
-        # so concept_by_loinc() can find them.
-        from omop_core.services.mappings import WEARABLE_LOINC
+        # Create concepts for wearable metrics in the vocabulary and domain each
+        # metric actually uses — most are LOINC, four are locally-minted
+        # HK-Wearable, and four are Observation-domain. upload_wearable resolves
+        # by (vocabulary_id, concept_code) and routes on concept.domain_id, so a
+        # fixture that flattens either would not exercise the real behaviour.
+        from omop_core.services.mappings import (
+            WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB, WEARABLE_OBSERVATION_METRICS,
+        )
         from omop_core.services.concept_cache import concept_cache_clear
         concept_cache_clear()
 
-        loinc_vocab, _ = Vocabulary.objects.get_or_create(
-            vocabulary_id='LOINC',
-            defaults={'vocabulary_name': 'LOINC', 'vocabulary_concept_id': 0},
-        )
+        vocabs = {}
+        for vocabulary_id in set(WEARABLE_CONCEPT_VOCAB.values()):
+            vocabs[vocabulary_id], _ = Vocabulary.objects.get_or_create(
+                vocabulary_id=vocabulary_id,
+                defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0},
+            )
         cc = ConceptClass.objects.get(concept_class_id='Clinical Finding')
-        domain_m = Domain.objects.get(domain_id='Measurement')
+        domains = {}
+        for domain_id in ('Measurement', 'Observation'):
+            domains[domain_id], _ = Domain.objects.get_or_create(
+                domain_id=domain_id,
+                defaults={'domain_name': domain_id, 'domain_concept_id': 0},
+            )
         today = date.today()
         far_future = date(2099, 12, 31)
 
         cls.wearable_concepts = {}
         concept_id_base = 990000
-        for metric_key, loinc_code in WEARABLE_LOINC.items():
+        for metric_key, concept_code in WEARABLE_CONCEPT_CODE.items():
             concept_id_base += 1
+            domain_id = (
+                'Observation' if metric_key in WEARABLE_OBSERVATION_METRICS
+                else 'Measurement'
+            )
             c, _ = Concept.objects.get_or_create(
                 concept_id=concept_id_base,
                 defaults={
                     'concept_name': f'Wearable {metric_key}',
-                    'domain': domain_m,
-                    'vocabulary': loinc_vocab,
+                    'domain': domains[domain_id],
+                    'vocabulary': vocabs[WEARABLE_CONCEPT_VOCAB[metric_key]],
                     'concept_class': cc,
-                    'concept_code': loinc_code,
+                    'concept_code': concept_code,
                     'valid_start_date': today,
                     'valid_end_date': far_future,
                 },
@@ -15674,6 +15690,112 @@ class WearableUploadEndpointTest(TestCase):
         buf.seek(0)
         return buf
 
+    def _upload_apple(self, xml):
+        """Upload an Apple Health export and return the parsed JSON response."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        buf = self._make_apple_zip(xml)
+        uploaded = SimpleUploadedFile('export.zip', buf.read(), content_type='application/zip')
+        resp = self._client_as(self.identity).post(
+            '/api/v1/patient-records/upload-wearable/',
+            data={'file': uploaded, 'device_type': 'apple'},
+            format='multipart',
+        )
+        self.assertEqual(resp.status_code, 200, resp.data)
+        return resp.data
+
+    def test_observation_domain_metrics_are_written_to_observation(self):
+        """Routing follows concept.domain_id, not a hard-coded metric list.
+
+        steps and flights_climbed are Observation-domain concepts; writing them
+        to `measurement` would contradict the concept's own domain and fail DQD
+        domain checks.
+        """
+        from omop_core.models import Measurement, Observation
+
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Record type="HKQuantityTypeIdentifierStepCount"
+          startDate="2024-07-02 08:00:00 -0700"
+          endDate="2024-07-02 08:30:00 -0700" value="7200"/>
+  <Record type="HKQuantityTypeIdentifierFlightsClimbed"
+          startDate="2024-07-02 09:00:00 -0700"
+          endDate="2024-07-02 09:10:00 -0700" value="9"/>
+  <Record type="HKQuantityTypeIdentifierRestingHeartRate"
+          startDate="2024-07-02 06:00:00 -0700"
+          endDate="2024-07-02 06:00:00 -0700" value="61"/>
+</HealthData>
+"""
+        self._upload_apple(xml)
+
+        steps_concept = self.wearable_concepts['steps']
+        flights_concept = self.wearable_concepts['flights_climbed']
+        rhr_concept = self.wearable_concepts['resting_hr']
+
+        self.assertTrue(
+            Observation.objects.filter(
+                person=self.person, observation_concept=steps_concept).exists(),
+            'steps is an Observation-domain concept and must land in observation')
+        self.assertFalse(
+            Measurement.objects.filter(
+                person=self.person, measurement_concept=steps_concept).exists(),
+            'steps must not be written to measurement')
+        self.assertTrue(
+            Observation.objects.filter(
+                person=self.person, observation_concept=flights_concept).exists())
+
+        # resting_hr is Measurement-domain and must still go to measurement.
+        self.assertTrue(
+            Measurement.objects.filter(
+                person=self.person, measurement_concept=rhr_concept).exists())
+        self.assertFalse(
+            Observation.objects.filter(
+                person=self.person, observation_concept=rhr_concept).exists())
+
+    def test_locally_minted_metric_resolves_in_hk_vocabulary(self):
+        """HK-Wearable metrics resolve by (vocabulary_id, concept_code).
+
+        walking_step_length has no LOINC equivalent, so it is minted under
+        HK-Wearable. A LOINC-scoped lookup would miss it and drop the sample.
+        """
+        from omop_core.models import Measurement
+
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Record type="HKQuantityTypeIdentifierWalkingStepLength"
+          startDate="2024-07-03 08:00:00 -0700"
+          endDate="2024-07-03 08:00:00 -0700" value="72"/>
+</HealthData>
+"""
+        data = self._upload_apple(xml)
+        self.assertEqual(data['unmapped_samples'], 0, data)
+        self.assertTrue(
+            Measurement.objects.filter(
+                person=self.person,
+                measurement_concept=self.wearable_concepts['walking_step_length'],
+            ).exists())
+
+    def test_unresolvable_metric_is_reported_not_silently_dropped(self):
+        """A missing concept must be distinguishable from "no data exported"."""
+        from omop_core.models import Concept
+        from omop_core.services.concept_cache import concept_cache_clear
+
+        Concept.objects.filter(
+            concept_id=self.wearable_concepts['vo2_max'].concept_id).delete()
+        concept_cache_clear()
+        self.addCleanup(concept_cache_clear)
+
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Record type="HKQuantityTypeIdentifierVO2Max"
+          startDate="2024-07-04 08:00:00 -0700"
+          endDate="2024-07-04 08:00:00 -0700" value="34.5"/>
+</HealthData>
+"""
+        data = self._upload_apple(xml)
+        self.assertEqual(data['samples_created'], 0)
+        self.assertEqual(data['unmapped_samples'], 1, data)
+        self.assertIn('vo2_max', data['unmapped_metrics'])
+
     def test_upload_apple_health_creates_measurements(self):
         """Uploading an Apple Health zip creates Measurement rows."""
         xml = """<?xml version="1.0" encoding="UTF-8"?>
@@ -15710,10 +15832,21 @@ class WearableUploadEndpointTest(TestCase):
         self.assertEqual(resp.status_code, 200, resp.data)
         self.assertGreaterEqual(resp.data['samples_created'], 2)
 
-        # Verify Measurement rows created
-        steps_concept = self.wearable_concepts['steps']
-        steps_rows = Measurement.objects.filter(person=self.person, measurement_concept=steps_concept)
-        self.assertTrue(steps_rows.exists())
+        # steps is an Observation-domain concept, so it lands in `observation`;
+        # resting_hr is Measurement-domain and lands in `measurement`. Rows are
+        # routed by concept.domain_id — see
+        # test_observation_domain_metrics_are_written_to_observation.
+        from omop_core.models import Observation
+        self.assertTrue(
+            Observation.objects.filter(
+                person=self.person,
+                observation_concept=self.wearable_concepts['steps'],
+            ).exists())
+        self.assertTrue(
+            Measurement.objects.filter(
+                person=self.person,
+                measurement_concept=self.wearable_concepts['resting_hr'],
+            ).exists())
 
     def test_upload_deduplication(self):
         """Uploading the same file twice does not create duplicate rows."""


### PR DESCRIPTION
Closes #413.

## The defect

Five of seventeen wearable concept codes resolved to **unrelated concepts**, so device data was filed under the wrong clinical meaning rather than dropped. That is the worse failure mode: the rows look valid, and anything trusting `measurement_concept_id` reads walking speed as BMI.

| Metric | Old code | What it actually was |
|---|---|---|
| `walking_speed` | 41909-3 | Deprecated Body mass index (BMI) — also non-standard |
| `walking_hr_avg` | 89270-3 | Body mass index (BMI) [Ratio] Estimated |
| `basal_energy` | 41982-0 | Percentage of body fat Measured |
| `active_minutes` | 77592-4 | Moderate physical activity **[IPAQ]** — a questionnaire item |
| `active_energy` | 55424-6 | Calories burned … **Pedometer** — too narrow for watch-derived energy |

Three more — 96340-0, 96341-8, 96343-4 — are not LOINC codes at all (the `963xx` range is loaded; these simply do not exist).

`active_minutes` was found only after reading the real Athena metadata: the seeder had invented the name "Moderate-vigorous physical activity duration" for 77592-4, which masked the mismatch.

## The fix

**Corrected codes**, each verified against the loaded vocabulary: `41957-2` walking speed, `55411-3` exercise duration, `100304-5` flights climbed, `93819-1` active calories.

**Four local mints.** LOINC has no concept for step length, double-support percentage, walking heart rate, or basal energy expenditure in kcal/day (50042-1 is "Basal metabolic rate *index*", normalized, not an energy rate). These are minted under a new `HK-Wearable` vocabulary with `source='HealthKey'`, `HK-*` concept_codes, and concept_ids from 2,029,606,350 — continuing the `HK-Labs` block inside the OHDSI custom range.

**Vocabulary-scoped resolution.** Lookups now use `(vocabulary_id, concept_code)`; 852 codes are reused across vocabularies, so a bare code is ambiguous.

**Domain-driven routing.** Rows are routed by `concept.domain_id` instead of a hard-coded metric list. `steps`, `active_minutes`, `sleep_duration` and `flights_climbed` are Observation-domain and previously all went to `measurement`. The read path merges both tables, so a metric reads identically either way and sleep's special-casing collapses.

**Seeding mirrors Athena.** Wearable concepts are seeded with their genuine Athena `concept_id`. Since seeding is keyed on `concept_id`, a real id no-ops where Athena is loaded and creates the row where it is not — so the seeder can no longer manufacture duplicate `(vocabulary_id, concept_code)` pairs (#415). `_c()` gains a `source` parameter, and `_assert_local_mint_convention()` fails the command outright on a violation.

**Visible failures.** Unresolvable metrics log at WARNING and return `unmapped_samples` / `unmapped_metrics`, instead of vanishing behind an HTTP 200 that was indistinguishable from "the device exported no data".

## Existing data

`remap_wearable_concepts` repoints rows off the retired `900xxxx` mints, recodes superseded codes, and moves rows between tables where the domain changed. Dry-run by default.

**Deliberately a management command, not a migration** — it rewrites ~190k rows on staging and moves ~78k between tables, and `start.sh` runs `migrate` unattended on every deploy. `body_mass` (29463-7) and `spo2` (59408-5) are matched only via their retired mint ids, never by source_value, because those codes are also written by the vitals/FHIR paths.

**Not yet run anywhere.** Staging remediation is a separate, deliberate step.

## Tests

Nine new tests. The one that matters most asserts each `concept_name` is semantically consistent with its metric — a code-exists check would have passed on all five wrong codes. The duplicate-pair test earned its keep immediately, catching two duplicates introduced while writing this change.

- Backend: `Ran 1191 tests` — `OK (skipped=1)`
- Frontend: 22 files, 173 tests passed

## Follow-ups not in this PR

- The other 18 `900xxxx` mints (labs, GFR, electrolytes) have the identical defect — #415.
- The 94 SNOMED/CVX/FHIR duplicate pairs come from an ingestion-time mint path that still needs finding — #415.
- Type concept 32883 is `Survey` and 32856 is `Lab`; neither is right for a device reading. Documented in `docs/wearable-omop-mapping.md`, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
