### PR TITLE
fix: expose death_date through the patient_info view

### DIFF
--- a/omop_core/migrations/0139_patient_info_view_death_date.py
+++ b/omop_core/migrations/0139_patient_info_view_death_date.py
@@ -1,0 +1,270 @@
+from django.db import migrations
+
+
+# `PatientRecord.death_date` is fully covered by the migration chain (0110), so
+# the *column* exists everywhere. The `patient_info` compatibility view is the
+# gap: 0104 created it as `SELECT * FROM patient_record` and PostgreSQL freezes
+# that star into a fixed column list at creation time. 0110 runs after 0104, so
+# a chain-built view can never contain `death_date`. Staging has it only because
+# the view was rebuilt out-of-band at some point after 0110 -- which is why the
+# view is 297 columns there and 296 in CI.
+#
+# This converges them. `death_date` is inserted immediately after `race`, which
+# is where it sits in staging (ordinal 281, before `mrd_status`); the rest of
+# the ordering already matches, so this reproduces staging's layout exactly
+# rather than appending and handing `SELECT *` consumers a different order.
+#
+# Idempotent: databases whose view already exposes `death_date` are left
+# untouched, so their ACL is not churned for a no-op rebuild. As in 0138, the
+# view's owner and grants are captured before the drop and reapplied after --
+# `DROP VIEW` discards both, and this view exists solely for consumers outside
+# this codebase. Restoration failures warn rather than abort the deploy.
+
+ADD_DEATH_DATE_SQL = """
+DO $$
+DECLARE
+    col_list   text;
+    has_anchor boolean;
+    view_acl   aclitem[];
+    view_owner text;
+    stmt       text;
+BEGIN
+    IF to_regclass('public.patient_info') IS NULL THEN
+        RAISE NOTICE 'patient_info view not found; nothing to do';
+        RETURN;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'patient_record'
+                      AND column_name = 'death_date') THEN
+        RAISE NOTICE 'patient_record.death_date missing; nothing to do';
+        RETURN;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'patient_info'
+                  AND column_name = 'death_date') THEN
+        RAISE NOTICE 'patient_info already exposes death_date; leaving view untouched';
+        RETURN;
+    END IF;
+
+    SELECT bool_or(name = 'race')
+      INTO has_anchor
+      FROM (
+        SELECT a.attname AS name,
+               a.attnum  AS attnum,
+               CASE WHEN EXISTS (
+                        SELECT 1 FROM pg_attribute t
+                         WHERE t.attrelid = to_regclass('public.patient_record')
+                           AND t.attname = a.attname
+                           AND t.attnum > 0
+                           AND NOT t.attisdropped)
+                    THEN quote_ident(a.attname)
+                    ELSE format('NULL::%s AS %I',
+                                format_type(a.atttypid, a.atttypmod), a.attname)
+               END AS expr
+          FROM pg_attribute a
+         WHERE a.attrelid = to_regclass('public.patient_info')
+           AND a.attnum > 0
+           AND NOT a.attisdropped
+     ) AS v;
+
+    -- Not every view column is backed by a table column: 0138 replaced
+    -- `status` with a typed NULL literal. Reproduce any such column as a
+    -- literal rather than emitting a bare identifier that does not resolve.
+    SELECT string_agg(
+               CASE WHEN v.name = 'race'
+                    THEN v.expr || ', death_date'
+                    ELSE v.expr
+               END,
+               ', ' ORDER BY v.attnum)
+      INTO col_list
+      FROM (
+        SELECT a.attname AS name,
+               a.attnum  AS attnum,
+               CASE WHEN EXISTS (
+                        SELECT 1 FROM pg_attribute t
+                         WHERE t.attrelid = to_regclass('public.patient_record')
+                           AND t.attname = a.attname
+                           AND t.attnum > 0
+                           AND NOT t.attisdropped)
+                    THEN quote_ident(a.attname)
+                    ELSE format('NULL::%s AS %I',
+                                format_type(a.atttypid, a.atttypmod), a.attname)
+               END AS expr
+          FROM pg_attribute a
+         WHERE a.attrelid = to_regclass('public.patient_info')
+           AND a.attnum > 0
+           AND NOT a.attisdropped
+     ) AS v;
+
+    IF NOT has_anchor THEN
+        -- No `race` column to anchor against; append rather than skip.
+        col_list := col_list || ', death_date';
+    END IF;
+
+    SELECT c.relacl, pg_get_userbyid(c.relowner)
+      INTO view_acl, view_owner
+      FROM pg_class c
+     WHERE c.oid = to_regclass('public.patient_info');
+
+    EXECUTE 'DROP VIEW public.patient_info';
+    EXECUTE format(
+        'CREATE VIEW public.patient_info AS SELECT %s FROM public.patient_record',
+        col_list);
+    EXECUTE '
+        CREATE TRIGGER patient_info_readonly_trigger
+        INSTEAD OF INSERT OR UPDATE OR DELETE ON public.patient_info
+        FOR EACH ROW EXECUTE FUNCTION patient_info_readonly()';
+
+    BEGIN
+        IF view_owner IS NOT NULL AND view_owner <> current_user THEN
+            EXECUTE format('ALTER VIEW public.patient_info OWNER TO %I', view_owner);
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'patient_info: could not restore owner %: %', view_owner, SQLERRM;
+    END;
+
+    IF view_acl IS NOT NULL THEN
+        FOR stmt IN
+            SELECT format('GRANT %s ON public.patient_info TO %s%s',
+                          a.privilege_type,
+                          CASE WHEN a.grantee = 0
+                               THEN 'PUBLIC'
+                               ELSE quote_ident(pg_get_userbyid(a.grantee))
+                          END,
+                          CASE WHEN a.is_grantable
+                               THEN ' WITH GRANT OPTION'
+                               ELSE ''
+                          END)
+              FROM aclexplode(view_acl) a
+        LOOP
+            BEGIN
+                EXECUTE stmt;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE WARNING 'patient_info: could not restore grant (%): %', stmt, SQLERRM;
+            END;
+        END LOOP;
+    END IF;
+END
+$$;
+"""
+
+
+# Rebuilds the view without `death_date`, restoring the pre-migration shape.
+# Databases that never had it in the view are left untouched.
+REMOVE_DEATH_DATE_SQL = """
+DO $$
+DECLARE
+    col_list   text;
+    view_acl   aclitem[];
+    view_owner text;
+    stmt       text;
+BEGIN
+    IF to_regclass('public.patient_info') IS NULL THEN
+        RAISE NOTICE 'patient_info view not found; nothing to do';
+        RETURN;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'patient_info'
+                      AND column_name = 'death_date') THEN
+        RAISE NOTICE 'patient_info does not expose death_date; leaving view untouched';
+        RETURN;
+    END IF;
+
+    SELECT string_agg(v.expr, ', ' ORDER BY v.attnum)
+      INTO col_list
+      FROM (
+        SELECT a.attname AS name,
+               a.attnum  AS attnum,
+               CASE WHEN EXISTS (
+                        SELECT 1 FROM pg_attribute t
+                         WHERE t.attrelid = to_regclass('public.patient_record')
+                           AND t.attname = a.attname
+                           AND t.attnum > 0
+                           AND NOT t.attisdropped)
+                    THEN quote_ident(a.attname)
+                    ELSE format('NULL::%s AS %I',
+                                format_type(a.atttypid, a.atttypmod), a.attname)
+               END AS expr
+          FROM pg_attribute a
+         WHERE a.attrelid = to_regclass('public.patient_info')
+           AND a.attnum > 0
+           AND NOT a.attisdropped
+     ) AS v
+     WHERE v.name <> 'death_date';
+
+    SELECT c.relacl, pg_get_userbyid(c.relowner)
+      INTO view_acl, view_owner
+      FROM pg_class c
+     WHERE c.oid = to_regclass('public.patient_info');
+
+    EXECUTE 'DROP VIEW public.patient_info';
+    EXECUTE format(
+        'CREATE VIEW public.patient_info AS SELECT %s FROM public.patient_record',
+        col_list);
+    EXECUTE '
+        CREATE TRIGGER patient_info_readonly_trigger
+        INSTEAD OF INSERT OR UPDATE OR DELETE ON public.patient_info
+        FOR EACH ROW EXECUTE FUNCTION patient_info_readonly()';
+
+    BEGIN
+        IF view_owner IS NOT NULL AND view_owner <> current_user THEN
+            EXECUTE format('ALTER VIEW public.patient_info OWNER TO %I', view_owner);
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'patient_info: could not restore owner %: %', view_owner, SQLERRM;
+    END;
+
+    IF view_acl IS NOT NULL THEN
+        FOR stmt IN
+            SELECT format('GRANT %s ON public.patient_info TO %s%s',
+                          a.privilege_type,
+                          CASE WHEN a.grantee = 0
+                               THEN 'PUBLIC'
+                               ELSE quote_ident(pg_get_userbyid(a.grantee))
+                          END,
+                          CASE WHEN a.is_grantable
+                               THEN ' WITH GRANT OPTION'
+                               ELSE ''
+                          END)
+              FROM aclexplode(view_acl) a
+        LOOP
+            BEGIN
+                EXECUTE stmt;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE WARNING 'patient_info: could not restore grant (%): %', stmt, SQLERRM;
+            END;
+        END LOOP;
+    END IF;
+END
+$$;
+"""
+
+
+class Migration(migrations.Migration):
+    """
+    Expose ``death_date`` through the ``patient_info`` compatibility view.
+
+    The column itself has been present since ``0110_patientrecord_death_date``;
+    only the view was missing it, because ``0104`` froze the view's column list
+    before ``0110`` existed. Staging picked the column up through an
+    out-of-band view rebuild, leaving it at 297 columns against CI's 296. This
+    closes that gap so ``SELECT death_date FROM patient_info`` behaves the same
+    everywhere.
+
+    No Django state changes -- the view is not modelled -- so this is a
+    database-only operation.
+    """
+
+    dependencies = [
+        ("omop_core", "0138_drop_orphan_patient_record_status"),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=ADD_DEATH_DATE_SQL, reverse_sql=REMOVE_DEATH_DATE_SQL),
+    ]

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -2075,6 +2075,32 @@ class PatientInfoCompatViewTest(TestCase):
         unbacked = set(self._view_columns()) - table_cols - {'status'}
         self.assertEqual(sorted(unbacked), [])
 
+    def test_view_exposes_death_date(self):
+        """
+        Migration 0139 adds `death_date` to the view. The column has existed on
+        the table since 0110, but 0104 froze the view's column list before that,
+        so chain-built databases were missing it while staging had it.
+        """
+        self.assertIn('death_date', self._view_columns())
+
+    def test_death_date_readable_through_view(self):
+        person = Person.objects.create(person_id=880004, year_of_birth=1980)
+        PatientRecord.objects.create(person=person, death_date=date(2024, 3, 1))
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT death_date FROM patient_info WHERE person_id = %s",
+                           [person.person_id])
+            self.assertEqual(cursor.fetchone()[0], date(2024, 3, 1))
+
+    def test_death_date_ordered_after_race(self):
+        """
+        0139 inserts the column after `race` to reproduce staging's ordinal
+        position rather than appending, so `SELECT *` consumers see the same
+        column order in every environment.
+        """
+        cols = self._view_columns()
+        self.assertIn('race', cols)
+        self.assertEqual(cols[cols.index('race') + 1], 'death_date')
+
     def test_view_remains_read_only(self):
         """The INSTEAD OF trigger must survive the rebuild."""
         person = Person.objects.create(person_id=880003, year_of_birth=1980)


### PR DESCRIPTION
Closes #418. Follow-up to #416.

## Problem

`PatientRecord.death_date` is chain-covered by `omop_core/migrations/0110_patientrecord_death_date.py`, so the **column** exists in every environment and was never at risk.

The `patient_info` compatibility view is the gap. `0104` created it as `SELECT * FROM patient_record`, and PostgreSQL freezes that star into a fixed column list at creation time. `0110` runs *after* `0104`, so a chain-built view can never contain `death_date`. Staging has it only because the view was rebuilt out-of-band at some point after `0110`.

| | `patient_record.death_date` | `patient_info.death_date` |
|---|---|---|
| Staging | yes (from `0110`) | yes (out-of-band rebuild) |
| Fresh / CI | yes (from `0110`) | **no** |

So `SELECT death_date FROM patient_info` works against staging and fails against CI or any freshly built database.

## Approach

`0139` inserts the column where it is missing, converging every environment on the same 297-column shape.

It is placed immediately after `race` rather than appended. That is where staging has it -- ordinal 281, before `mrd_status` -- and the surrounding order already matches, so `SELECT *` consumers see identical column order everywhere:

```
278: preexisting_conditions
279: organization_id
280: race
281: death_date      <- inserted here
282: mrd_status
```

Deliberately out of scope: resyncing the view to the full 324-column table. That changes the external surface far more broadly and was considered and declined during #416.

## The bug this caught in testing

The first version built the column list with `quote_ident` over every view column. `0138` left `status` as a typed NULL literal with **no backing table column**, so the rebuild emitted an identifier that does not resolve:

```
ERROR: column "status" does not exist
CONTEXT: PL/pgSQL function inline_code_block line 56 at EXECUTE
```

This would have failed every deploy. The column list now derives from `pg_attribute` and reproduces any literal-backed column as a literal of its original type, so the view survives regardless of which columns are physically present.

## Behaviour

- Idempotent -- a view already exposing `death_date` is left untouched rather than rebuilt for a no-op, so its ACL is not churned.
- Owner and grants captured and reapplied, as in `0138`: `DROP VIEW` discards both, and this view exists solely for consumers outside this codebase. Restoration failures warn rather than abort the deploy.
- No Django state changes -- the view is not modelled, so this is database-only.

## Verification

Run on scratch databases with an external `GRANT SELECT` in place:

| Path | Result |
|---|---|
| Forward on chain-built shape | 296 -> 297, `death_date` at ordinal 281 between `race` and `mrd_status` |
| `status` NULL literal + read-only trigger | intact |
| View ACL | byte-identical |
| Reverse | back to 296, `status` and ACL preserved |
| Re-run when column already present | viewdef checksum unchanged -- genuine no-op |

**Staging will no-op** -- it already has the column. This migration exists to fix CI and every future database.

## Tests

Three added to `PatientInfoCompatViewTest`: column present in the view, value readable through the view, and ordinal position immediately after `race`. All 10 view/schema tests pass.

## Note for the reviewer

The full backend and frontend suites were **not** run on this commit, at the author's request -- a suite run drops and recreates `test_promop_test`, which would collide with concurrent work in another terminal. The 10 relevant tests were run against an isolated `promop_selftest` base database so that DB was never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)