### PR TITLE
fix: make remap_wearable_concepts actually runnable

### DIFF
--- a/omop_core/management/commands/remap_wearable_concepts.py
+++ b/omop_core/management/commands/remap_wearable_concepts.py
@@ -78,6 +78,9 @@ class Command(BaseCommand):
         parser.add_argument(
             '--metric', action='append', default=None,
             help='Limit to one metric key. Repeatable.')
+        parser.add_argument(
+            '--keep-mints', action='store_true',
+            help='Do not delete the retired 900xxxx mint concepts after remapping.')
 
     def handle(self, *args, **options):
         apply_changes = options['apply']
@@ -93,26 +96,51 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING(
                 'DRY RUN — no changes will be written. Re-run with --apply.\n'))
 
-        totals = {'repointed': 0, 'recoded': 0, 'moved': 0, 'skipped_no_concept': 0}
+        totals = {
+            'repointed': 0, 'recoded': 0, 'moved': 0,
+            'skipped_no_concept': 0, 'mints_deleted': 0, 'mints_still_referenced': 0,
+            'skipped_metrics': set(),
+        }
+        delete_mints = not options['keep_mints'] and not options['metric']
+        if options['metric'] and not options['keep_mints']:
+            self.stdout.write(self.style.WARNING(
+                'Retired mints are only deleted on a full run (no --metric), since '
+                'a partial remap can leave rows still pointing at them.\n'))
 
-        with transaction.atomic():
+        if apply_changes:
+            with transaction.atomic():
+                for metric in metrics:
+                    self._remap_metric(metric, totals, apply_changes=True)
+                if delete_mints:
+                    self._delete_retired_mints(totals, apply_changes=True)
+        else:
+            # A dry run only counts. Doing the work inside a transaction and
+            # rolling back would be correct but unusably slow — ~78k rows move
+            # between tables, which takes over ten minutes against a remote
+            # database before discarding every byte of it.
             for metric in metrics:
-                self._remap_metric(metric, totals)
-
-            if not apply_changes:
-                transaction.set_rollback(True)
+                self._remap_metric(metric, totals, apply_changes=False)
+            if delete_mints:
+                self._delete_retired_mints(totals, apply_changes=False)
 
         self.stdout.write('')
+        label = 'Would remap' if not apply_changes else 'Remapped'
         self.stdout.write(self.style.SUCCESS(
-            'Repointed: {repointed}  |  Recoded: {recoded}  |  '
-            'Moved between tables: {moved}  |  Skipped (no target concept): '
-            '{skipped_no_concept}'.format(**totals)))
+            f'{label} — recoded in place: {{recoded}}  |  '
+            'moved between tables: {moved}  |  skipped (no target concept): '
+            '{skipped_no_concept}  |  retired mints removed: {mints_deleted}'
+            .format(**totals)))
+        if totals['mints_still_referenced']:
+            self.stdout.write(self.style.WARNING(
+                f"{totals['mints_still_referenced']} retired mint(s) still referenced "
+                f'and were left in place.'))
         if not apply_changes:
-            self.stdout.write(self.style.WARNING('Rolled back (dry run).'))
+            self.stdout.write(self.style.WARNING(
+                'Nothing was written. Re-run with --apply to perform the remap.'))
 
     # ------------------------------------------------------------------
 
-    def _remap_metric(self, metric, totals):
+    def _remap_metric(self, metric, totals, apply_changes):
         new_code = WEARABLE_CONCEPT_CODE[metric]
         vocabulary_id = WEARABLE_CONCEPT_VOCAB[metric]
 
@@ -128,6 +156,7 @@ class Command(BaseCommand):
                 f'  {metric:28s} SKIPPED — no concept for '
                 f'({vocabulary_id}, {new_code}). Run seed_omop_concepts first.'))
             totals['skipped_no_concept'] += 1
+            totals['skipped_metrics'].add(metric)
             return
 
         old_codes = OLD_CODES.get(metric, [])
@@ -145,27 +174,90 @@ class Command(BaseCommand):
         if not (m_count or o_count):
             return
 
+        # Rows already in the destination table are recoded in place; rows in
+        # the other table have to move, because the concept's domain changed.
+        if wants_observation:
+            target_table, to_move, to_recode = 'Observation', m_count, o_count
+        else:
+            target_table, to_move, to_recode = 'Measurement', o_count, m_count
+
+        if not apply_changes:
+            totals['moved'] += to_move
+            totals['recoded'] += to_recode
+            self.stdout.write(
+                f'  {metric:28s} -> {target_table} {target.concept_id} '
+                f'({new_code}): would move {to_move}, recode {to_recode}')
+            return
+
         if wants_observation:
             moved = self._move_measurements_to_observation(m_qs, target, new_code)
             recoded = o_qs.update(
                 observation_concept=target, observation_source_value=new_code)
-            totals['moved'] += moved
-            totals['recoded'] += recoded
-            self.stdout.write(
-                f'  {metric:28s} -> Observation {target.concept_id} '
-                f'({new_code}): moved {moved}, recoded {recoded}')
         else:
             moved = self._move_observations_to_measurement(o_qs, target, new_code)
             recoded = m_qs.update(
                 measurement_concept=target, measurement_source_value=new_code)
-            totals['moved'] += moved
-            totals['recoded'] += recoded
-            self.stdout.write(
-                f'  {metric:28s} -> Measurement {target.concept_id} '
-                f'({new_code}): moved {moved}, recoded {recoded}')
+
+        totals['moved'] += moved
+        totals['recoded'] += recoded
+        self.stdout.write(
+            f'  {metric:28s} -> {target_table} {target.concept_id} '
+            f'({new_code}): moved {moved}, recoded {recoded}')
+
+    def _delete_retired_mints(self, totals, apply_changes):
+        """Remove the retired 900xxxx mint concepts once nothing references them.
+
+        Remapping rows off a mint is not enough on its own: the mint row still
+        shares (vocabulary_id, concept_code) with the genuine Athena concept, and
+        concept_by_vocab resolves duplicates with .first() and no ordering — so a
+        later upload could resolve straight back onto the orphan and recreate the
+        problem. Deleting the mints is what actually closes it.
+
+        Every Concept FK is on_delete=PROTECT, so a still-referenced mint raises
+        ProtectedError rather than cascading. That is the safety net: we report it
+        and move on instead of enumerating every referencing column by hand.
+        """
+        from django.db.models import ProtectedError
+
+        self.stdout.write('')
+        for metric, mint_id in sorted(RETIRED_MINT_BY_METRIC.items()):
+            mint = Concept.objects.filter(concept_id=mint_id).first()
+            if mint is None:
+                continue
+
+            if not apply_changes:
+                # Reason about the state AFTER the remap, not before it. The
+                # remap claims every row carrying this mint, so the mint ends up
+                # unreferenced — unless its metric was skipped for want of a
+                # target concept, in which case its rows stay put.
+                if metric in totals['skipped_metrics']:
+                    refs = (
+                        Measurement.objects.filter(measurement_concept_id=mint_id).count()
+                        + Observation.objects.filter(observation_concept_id=mint_id).count()
+                    )
+                    self.stdout.write(
+                        f'  mint {mint_id} ({metric}): metric skipped, {refs} row(s) '
+                        f'would remain — not removable')
+                    totals['mints_still_referenced'] += 1
+                else:
+                    self.stdout.write(f'  mint {mint_id} ({metric}): would be removed')
+                    totals['mints_deleted'] += 1
+                continue
+
+            try:
+                with transaction.atomic():
+                    mint.delete()
+            except ProtectedError as exc:
+                self.stdout.write(self.style.WARNING(
+                    f'  mint {mint_id} ({metric}): still referenced, left in place '
+                    f'({exc.__class__.__name__})'))
+                totals['mints_still_referenced'] += 1
+            else:
+                self.stdout.write(f'  mint {mint_id} ({metric}): removed')
+                totals['mints_deleted'] += 1
 
     def _move_measurements_to_observation(self, qs, target, new_code):
-        from patient_portal.api.views import _next_pk_batch
+        from omop_core.services.pk import next_pk_batch as _next_pk_batch
 
         rows = list(qs.values(
             'measurement_id', 'person_id', 'measurement_date',
@@ -195,7 +287,7 @@ class Command(BaseCommand):
         return len(pending)
 
     def _move_observations_to_measurement(self, qs, target, new_code):
-        from patient_portal.api.views import _next_pk_batch
+        from omop_core.services.pk import next_pk_batch as _next_pk_batch
 
         rows = list(qs.values(
             'observation_id', 'person_id', 'observation_date',

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -2254,3 +2254,132 @@ class WearableConceptMappingTest(TestCase):
             self.assertEqual(
                 domain, expected,
                 f'{metric} ({code}) is seeded domain {domain} but the metric set says {expected}')
+
+
+class RemapWearableConceptsCommandTest(TestCase):
+    """Exercises remap_wearable_concepts against real rows.
+
+    The first version of this command failed with ImportError the moment it had
+    a row to move, because nothing in the suite ever gave it one — every test
+    database was empty of wearable rows. These tests create rows on the retired
+    mints so the move path actually executes.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import Person
+        call_command('seed_omop_concepts', verbosity=0)
+        cls.person = Person.objects.create(person_id=770001, year_of_birth=1970)
+
+    def _mint(self, concept_id, concept_code, domain_id='Measurement'):
+        """Recreate a retired 900xxxx mint, as a pre-#413 database would have."""
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+        return Concept.objects.create(
+            concept_id=concept_id,
+            concept_name=f'Retired mint {concept_code}',
+            domain=Domain.objects.get(domain_id=domain_id),
+            vocabulary=Vocabulary.objects.get(vocabulary_id='LOINC'),
+            concept_class=ConceptClass.objects.get(concept_class_id='Clinical Observation'),
+            standard_concept='S',
+            concept_code=concept_code,
+            valid_start_date=date(1970, 1, 1),
+            valid_end_date=date(2099, 12, 31),
+        )
+
+    def _measurement(self, concept, value, day=1):
+        from omop_core.models import Concept, Measurement
+        m = Measurement.objects.create(
+            measurement_id=Measurement.objects.count() + 900001,
+            person=self.person,
+            measurement_concept=concept,
+            measurement_date=date(2024, 7, day),
+            measurement_type_concept=Concept.objects.get(concept_id=32856),
+            value_as_number=value,
+            measurement_source_value=concept.concept_code,
+        )
+        return m
+
+    def test_dry_run_writes_nothing(self):
+        from omop_core.models import Measurement, Observation
+
+        mint = self._mint(9001019, '55423-8')
+        self._measurement(mint, 7000)
+
+        call_command('remap_wearable_concepts', '--dry-run', verbosity=0)
+
+        self.assertTrue(
+            Measurement.objects.filter(measurement_concept=mint).exists(),
+            'dry run must not move rows')
+        self.assertEqual(Observation.objects.count(), 0)
+
+    def test_apply_moves_observation_domain_rows_out_of_measurement(self):
+        """steps is Observation-domain, so its rows must move tables.
+
+        This is the path that previously raised ImportError.
+        """
+        from omop_core.models import Measurement, Observation
+
+        mint = self._mint(9001019, '55423-8')
+        self._measurement(mint, 7000, day=1)
+        self._measurement(mint, 8000, day=2)
+
+        call_command('remap_wearable_concepts', '--apply', verbosity=0)
+
+        self.assertFalse(
+            Measurement.objects.filter(measurement_source_value='55423-8').exists(),
+            'steps rows must not remain in measurement')
+        moved = Observation.objects.filter(observation_source_value='55423-8')
+        self.assertEqual(moved.count(), 2)
+        self.assertEqual(
+            sorted(float(o.value_as_number) for o in moved), [7000.0, 8000.0],
+            'values must survive the move')
+        self.assertEqual(moved.first().observation_concept.concept_id, 40758552)
+
+    def test_apply_recodes_measurement_domain_rows_in_place(self):
+        from omop_core.models import Measurement
+
+        mint = self._mint(9001021, '40443-4')
+        self._measurement(mint, 58)
+
+        call_command('remap_wearable_concepts', '--apply', verbosity=0)
+
+        row = Measurement.objects.get(measurement_source_value='40443-4')
+        self.assertEqual(row.measurement_concept.concept_id, 3040891)
+        self.assertEqual(float(row.value_as_number), 58.0)
+
+    def test_apply_deletes_retired_mints_once_unreferenced(self):
+        """The mint row itself must go, or a later upload can resolve back onto it."""
+        from omop_core.models import Concept
+
+        self._mint(9001019, '55423-8')
+        self._measurement(Concept.objects.get(concept_id=9001019), 7000)
+
+        call_command('remap_wearable_concepts', '--apply', verbosity=0)
+
+        self.assertFalse(
+            Concept.objects.filter(concept_id=9001019).exists(),
+            'retired mint must be deleted once nothing references it')
+
+    def test_keep_mints_leaves_the_mint_in_place(self):
+        from omop_core.models import Concept
+
+        self._mint(9001019, '55423-8')
+        self._measurement(Concept.objects.get(concept_id=9001019), 7000)
+
+        call_command('remap_wearable_concepts', '--apply', '--keep-mints', verbosity=0)
+
+        self.assertTrue(Concept.objects.filter(concept_id=9001019).exists())
+
+    def test_metric_scope_does_not_touch_other_metrics(self):
+        from omop_core.models import Measurement
+
+        steps_mint = self._mint(9001019, '55423-8')
+        rhr_mint = self._mint(9001021, '40443-4')
+        self._measurement(steps_mint, 7000, day=1)
+        self._measurement(rhr_mint, 58, day=2)
+
+        call_command('remap_wearable_concepts', '--apply', '--metric', 'steps', verbosity=0)
+
+        self.assertTrue(
+            Measurement.objects.filter(measurement_concept=rhr_mint).exists(),
+            'a scoped run must leave other metrics alone')


### PR DESCRIPTION
Follow-up to #417. Three defects in `remap_wearable_concepts`, all surfaced by running the command against staging for the first time.

## 1. Wrong import path — the command could never move a row

`_next_pk_batch` was imported from `patient_portal.api.views`, where it does not exist. It lives in `omop_core.services.pk` as `next_pk_batch`. The command raised `ImportError` the instant it had a row to move, i.e. on any database with real data.

Nothing in the suite caught it because no test database contained wearable rows to move — the move path had never executed. That gap is closed below.

## 2. Dry run did the full work, then rolled back

Correct in principle, unusable in practice. ~78k rows move between tables; against staging it ran past **ten minutes** before discarding every byte. A dry run should count, not do the work. It now does.

Before / after on staging:

```
before:  timed out at 10m, no output
after:   completes in seconds

  steps            -> Observation 40758552 (55423-8): would move 36249, recode 0
  active_minutes   -> Observation 40758540 (55411-3): would move 36243, recode 0
  sleep_duration   -> Observation 1002368  (93832-4): would move  6232, recode 0
  hrv_sdnn         -> Measurement 21491502 (80404-7): would move 0, recode 36232
  respiratory_rate -> Measurement 3024171  (9279-1):  would move 0, recode  6232
  resting_hr       -> Measurement 3040891  (40443-4): would move 0, recode  6232

  Would remap — recoded in place: 48696 | moved between tables: 78724
```

## 3. Retired mints were never deleted

The important one. Remapping rows *off* a `900xxxx` mint left the mint row itself in place, still sharing `(vocabulary_id, concept_code)` with the genuine Athena concept. Since `concept_by_vocab` resolves duplicates with `.first()` and no ordering, a later upload could resolve straight back onto the orphan and recreate the very problem the remap just fixed.

Mints are now deleted once unreferenced. Three safeguards:

- Every `Concept` FK is `on_delete=PROTECT`, so a still-referenced mint raises `ProtectedError` rather than cascading — reported and left in place instead of enumerating every referencing column by hand.
- Deletion runs only on a full pass. A `--metric`-scoped run can leave rows pointing at a mint, so it warns and skips deletion.
- `--keep-mints` opts out entirely.

This also removes 6 of the 21 LOINC duplicate pairs in #415, and is a prerequisite for that issue's `UNIQUE (vocabulary_id, concept_code)` constraint.

## Tests

Six new tests that create rows on the retired mints so the move path actually executes: dry-run writes nothing, Observation-domain rows move out of `measurement` with values intact, Measurement-domain rows recode in place, mints are deleted when unreferenced, `--keep-mints` preserves them, and `--metric` scoping leaves other metrics alone.

Verified they guard the regression: restoring the bad import fails five of the six with the original `ImportError`.

- Backend: `Ran 1207 tests` — `OK (skipped=1)`
- Frontend: 22 files, 173 tests passed

## Still outstanding

Four metrics (`basal_energy`, `walking_step_length`, `walking_double_support_pct`, `walking_hr_avg`) remain skipped on staging because the `HK-Wearable` concepts do not exist there. They are local mints, so only `seed_omop_concepts` creates them — that needs running on staging before the remap can cover those four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
