### PR TITLE
ci: run the pytest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,17 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      # pytest runs with --no-migrations, so the test DB is built by reflecting
+      # model state. That recreates concept's GIN trigram index during CREATE
+      # TABLE, inside pytest-django's base django_db_setup fixture — before any
+      # fixture override could enable the extension. Enabling it on template1
+      # instead means every database cloned from it already has pg_trgm, which
+      # is what conftest.py prescribes as the required environment setup.
+      - name: Enable pg_trgm on template1 (required by the pytest suite)
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -U postgres -d template1 -c "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+
       - name: Run migrations
         run: python manage.py migrate --noinput
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,17 @@ jobs:
       - name: Run migrations
         run: python manage.py migrate --noinput
 
-      - name: Run tests
+      - name: Run tests (Django runner)
         run: python manage.py test omop_core patient_portal --verbosity=2 --noinput
+
+      # The tests/ package is pytest-based (pytest.ini sets testpaths = tests,
+      # conftest.py does session-level DB setup that --no-migrations skips).
+      # Django's runner does not discover it, so these 166 tests ran in CI for
+      # the first time here — they had been green-by-omission, and were in fact
+      # 14-of-15 red in tests/test_enrich_breast_cancer_omop_data.py after #413
+      # expanded WEARABLE_CONCEPT_CODE without anyone noticing.
+      - name: Run tests (pytest)
+        run: pytest -q
 
   frontend:
     name: Frontend lint & build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,13 +372,23 @@ describe('LabsTab - new_field', () => {
 ### Running Tests
 
 ```bash
-# Backend tests — run against local PostgreSQL (matches CI)
+# Backend tests, Django runner — omop_core + patient_portal
 DATABASE_URL="postgresql://postgres@localhost:5432/promop_test" \
   .venv/bin/python manage.py test omop_core patient_portal --verbosity=2 --noinput
+
+# Backend tests, pytest — the tests/ package (18 files, 166 tests)
+DATABASE_URL="postgresql://postgres@localhost:5432/promop_test" DEBUG=True \
+  .venv/bin/python -m pytest -q
 
 # Frontend tests (install deps first if needed: cd frontend && npm ci)
 cd frontend && npm test -- --run
 ```
+
+**Both backend suites must be run.** Django's test runner discovers only
+`omop_core.tests` and `patient_portal.tests`; the `tests/` package is
+pytest-based and is invisible to it. CI runs both as of PR #426 — before that
+those 166 tests had never run in CI and sat at 14 failures for some time
+without anyone noticing.
 
 ### Rule: Feature Branch + PR for Every Code Change
 
@@ -430,6 +440,15 @@ PATH="/opt/homebrew/opt/postgresql@14/bin:$PATH" psql -U postgres -d postgres \
 # Apply migrations
 DATABASE_URL="postgresql://postgres@localhost:5432/promop_test" \
   .venv/bin/python manage.py migrate --noinput
+
+# Enable pg_trgm on template1 — REQUIRED by the pytest suite.
+# pytest runs with --no-migrations, so the test DB is built by reflecting model
+# state, which recreates concept's GIN trigram index during CREATE TABLE before
+# any fixture can enable the extension. Putting it on template1 means every
+# database cloned from it already has pg_trgm. Without this, all 166 pytest
+# tests error with: operator class "gin_trgm_ops" does not exist
+PATH="/opt/homebrew/opt/postgresql@14/bin:$PATH" psql -U postgres -d template1 \
+  -c "CREATE EXTENSION IF NOT EXISTS pg_trgm"
 
 # Connect (use @14 bin directly — system psql binary has OpenSSL crash on this machine)
 PATH="/opt/homebrew/opt/postgresql@14/bin:$PATH" psql -d promop_test


### PR DESCRIPTION
## The gap

`tests/` is a pytest package — `pytest.ini` sets `testpaths = tests`, `conftest.py` does session-level database setup that `--no-migrations` skips, and `pytest==8.4.2` / `pytest-django==4.11.1` are both in `requirements.txt`. Everything is wired except the CI invocation.

CI runs only:

```
python manage.py test omop_core patient_portal --verbosity=2 --noinput
```

Django's runner discovers `omop_core.tests` and `patient_portal.tests` and nothing else, so **18 files and 166 tests have never run in CI.**

## Why it matters

They were green by omission, not by passing.

When #413 expanded `WEARABLE_CONCEPT_CODE` from 7 to 17 metrics without `_WEARABLE_RANGES` following, `enrich_breast_cancer_omop_data` began raising `KeyError` on the first ungenerated metric and `tests/test_enrich_breast_cancer_omop_data.py` went to **14 failures out of 15**. CI reported "Backend tests pass" the whole time, and #417 merged on that signal. It surfaced only because I ran pytest by hand while fixing an unrelated review finding.

Coverage this brings under the gate: `episode_service`, `patient_record_service` treatment sync and BC fallbacks, therapy class/component ids, the three Synthea import pipelines, org analytics, `delete_org_patients`, and the PHR token provider.

## Rehearsal

Run against a **freshly created database with only migrations applied**, matching what the CI job does rather than a local database carrying accumulated state:

```
createdb promop_ci_check
manage.py migrate --noinput
pytest -q     →  166 passed, 21 warnings in 11.97s
```

The job-level `env` block already provides `DATABASE_URL`, `SECRET_KEY` and `DEBUG`, so the new step needs no extra configuration. Runtime is ~12s, negligible next to the Django suite's ~6 minutes.

## Note

This turns 166 previously-invisible tests into a merge gate. They pass on `dev` as of this branch, but it is worth watching the first few runs — anything that was quietly relying on these not running will now surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
