### PR TITLE
feat: backfill Concept.source for locally-minted concepts

### DIFF
--- a/omop_core/management/commands/backfill_concept_source.py
+++ b/omop_core/management/commands/backfill_concept_source.py
@@ -1,0 +1,197 @@
+"""
+Fill in Concept.source='HealthKey' for locally-minted concept rows.
+
+`Concept.source` records provenance: NULL means the row came from an external
+vocabulary release (Athena), 'HealthKey' means it was authored or minted locally
+— per the field's own definition, that covers HK-* vocabularies, FHIR-upload
+quarantine rows, and HealthKey-curated loads.
+
+The column was added after most of these rows existed and was never populated,
+so on staging only 19 of 1,979,422 rows carry it while 224 are demonstrably
+local. The practical damage is to the vocabulary mirror:
+`/api/v1/vocab-releases/{id}/snapshot/concept/?source=external` is meant to give
+consumers genuine vocabulary content and currently hands them locally-invented
+concepts labelled as external.
+
+This command only writes the `source` column. It does not touch concept
+identity, codes, domains, or any clinical row.
+
+Why this is worth doing before the rest of #415: once `source` means what it
+claims, the illegitimate rows become a one-line query rather than the id-range
+guesswork this command has to use --
+
+    SELECT * FROM concept WHERE source='HealthKey' AND vocabulary_id NOT LIKE 'HK-%'
+
+A local row in an *external* vocabulary is always wrong: it shadows a real
+concept and makes resolution nondeterministic, which is the defect behind #413
+and #415. That query is the worklist for the remaining phases, and it should
+eventually return zero rows.
+
+Usage:
+    python manage.py backfill_concept_source                      # dry run
+    python manage.py backfill_concept_source --apply
+    python manage.py backfill_concept_source --apply --rule seed_mint
+"""
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Count, Q
+
+from omop_core.models import Concept
+
+logger = logging.getLogger(__name__)
+
+LOCAL_SOURCE = 'HealthKey'
+
+# Vocabularies that are not Athena vocabulary releases. Their own Vocabulary
+# rows say as much:
+#   LOCAL  reference=''            version='synthetic enrichment'
+#   sct    reference='synthetic'   version='synthetic'
+#   FHIR   reference='FHIR import' version='local'
+# 'sct' is the FHIR system-URI form of SNOMED (http://snomed.info/sct), which
+# only appears when something minted a concept from a FHIR Coding rather than
+# resolving it — Athena's SNOMED rows use vocabulary_id 'SNOMED'.
+_LOCAL_VOCABULARIES = ['LOCAL', 'sct', 'FHIR']
+
+# OHDSI reserves concept_id >= 2e9 for locally-authored concepts.
+LOCAL_CONCEPT_ID_MIN = 2_000_000_000
+
+# Each rule identifies rows that are locally minted, with the evidence for that
+# claim. They are deliberately separate and separately reportable: the operator
+# should be able to review each group in the dry run before applying, rather
+# than trusting one opaque predicate.
+RULES = [
+    (
+        'hk_vocabulary',
+        Q(vocabulary__vocabulary_id__startswith='HK-'),
+        "Rows in an HK-* vocabulary — deliberate HealthKey concepts",
+    ),
+    (
+        'local_vocabulary',
+        Q(vocabulary_id__in=_LOCAL_VOCABULARIES),
+        f"Rows in a non-Athena vocabulary ({', '.join(_LOCAL_VOCABULARIES)})",
+    ),
+    (
+        'seed_mint',
+        Q(concept_id__gte=9_000_000, concept_id__lte=9_099_999),
+        "seed_omop_concepts mints in the legacy 900xxxx range",
+    ),
+    (
+        'fhir_ingest_block',
+        Q(concept_id__gte=392_021_000, concept_id__lte=392_022_000),
+        "Contiguous block minted by FHIR ingestion (all valid_start 1970-01-01)",
+    ),
+    (
+        'ohdsi_custom_range',
+        Q(concept_id__gte=LOCAL_CONCEPT_ID_MIN),
+        "concept_id in the OHDSI custom range, which Athena never allocates",
+    ),
+]
+_RULE_NAMES = [name for name, _, _ in RULES]
+
+
+class Command(BaseCommand):
+    help = "Set Concept.source='HealthKey' on locally-minted concepts (see #415)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--apply', action='store_true',
+            help='Write the change. Without this the command only reports.')
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help='Explicitly request a dry run (the default).')
+        parser.add_argument(
+            '--rule', action='append', default=None,
+            choices=_RULE_NAMES,
+            help='Limit to one rule. Repeatable. Default: all rules.')
+
+    def handle(self, *args, **options):
+        apply_changes = options['apply']
+        if apply_changes and options['dry_run']:
+            raise CommandError('--apply and --dry-run are mutually exclusive.')
+
+        selected = options['rule'] or _RULE_NAMES
+        rules = [r for r in RULES if r[0] in selected]
+
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING(
+                'DRY RUN — nothing will be written. Re-run with --apply.\n'))
+
+        # Union of all selected rules, so a row matching two rules is counted
+        # and updated once rather than twice.
+        combined = Q()
+        for _, predicate, _ in rules:
+            combined |= predicate
+
+        untagged = Concept.objects.filter(combined).filter(source__isnull=True)
+
+        self.stdout.write('Rows matched per rule (rules overlap; totals are de-duplicated):')
+        for name, predicate, description in rules:
+            n = Concept.objects.filter(predicate).filter(source__isnull=True).count()
+            self.stdout.write(f'  {name:22s} {n:6d}   {description}')
+
+        total = untagged.count()
+        self.stdout.write('')
+        self.stdout.write('Breakdown by vocabulary:')
+        for row in (untagged.values('vocabulary_id')
+                    .annotate(n=Count('concept_id'))
+                    .order_by('-n')):
+            self.stdout.write(f"  {row['vocabulary_id']:16s} {row['n']}")
+
+        updated = 0
+        if apply_changes and total:
+            with transaction.atomic():
+                updated = untagged.update(source=LOCAL_SOURCE)
+            logger.info('backfill_concept_source updated=%d', updated)
+
+        self.stdout.write('')
+        verb = 'Would tag' if not apply_changes else 'Tagged'
+        self.stdout.write(self.style.SUCCESS(
+            f"{verb} {total if not apply_changes else updated} row(s) as source='{LOCAL_SOURCE}'"))
+
+        self._report_invariant(untagged if not apply_changes else None)
+
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING(
+                'Nothing was written. Re-run with --apply.'))
+
+    def _report_invariant(self, would_tag_qs):
+        """Report local rows sitting in an external vocabulary.
+
+        In dry-run mode this must project the state AFTER the backfill, not
+        before it: reporting only rows already tagged would say "invariant
+        holds" right up until the moment the update makes it false. The preview
+        an operator acts on has to describe the world the command will create.
+
+        This is the set that should eventually be empty: a locally-authored row
+        claiming a code in LOINC/SNOMED/CVX/HemOnc shadows the genuine concept
+        and makes concept_by_vocab's unordered .first() nondeterministic. After
+        this backfill the set is queryable directly instead of by id range,
+        which is the point of running it first.
+        """
+        tagged = Q(source=LOCAL_SOURCE)
+        if would_tag_qs is not None:
+            # Dry run: include the rows this command would tag.
+            tagged |= Q(concept_id__in=would_tag_qs.values('concept_id'))
+        offenders = (
+            Concept.objects
+            .filter(tagged)
+            .exclude(vocabulary__vocabulary_id__startswith='HK-')
+            .exclude(vocabulary_id__in=_LOCAL_VOCABULARIES)
+        )
+        n = offenders.count()
+        self.stdout.write('')
+        if not n:
+            self.stdout.write(self.style.SUCCESS(
+                'Invariant holds: no HealthKey-sourced row sits in an external vocabulary.'))
+            return
+        verb = 'would sit' if would_tag_qs is not None else 'sit'
+        self.stdout.write(self.style.WARNING(
+            f'{n} HealthKey-sourced row(s) {verb} in an EXTERNAL vocabulary — each one '
+            f'shadows a real concept and should be retired or remapped to the genuine '
+            f'Athena concept. This is the worklist for the rest of #415:'))
+        for row in (offenders.values('vocabulary_id')
+                    .annotate(n=Count('concept_id'))
+                    .order_by('-n')):
+            self.stdout.write(f"  {row['vocabulary_id']:16s} {row['n']}")

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -2506,3 +2506,100 @@ class ConceptZeroTest(TestCase):
         self.assertEqual(c.vocabulary_id, 'None')
         self.assertEqual(c.concept_class_id, 'Undefined')
         self.assertIsNone(c.source)
+
+
+
+class BackfillConceptSourceCommandTest(TestCase):
+    """Covers backfill_concept_source (see #415).
+
+    Concept.source separates locally-authored rows from vocabulary-release rows.
+    It was added after most rows existed and never populated, so the column
+    claims a guarantee it does not provide — on staging 19 of 1,979,422 rows
+    were tagged while 224 were demonstrably local.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        call_command('seed_omop_concepts', verbosity=0)
+
+    def _concept(self, concept_id, code, vocabulary_id='LOINC', source=None):
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+        vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id=vocabulary_id,
+            defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0})
+        return Concept.objects.create(
+            concept_id=concept_id,
+            concept_name=f'Test {code}',
+            domain=Domain.objects.get(domain_id='Measurement'),
+            vocabulary=vocab,
+            concept_class=ConceptClass.objects.get(concept_class_id='Clinical Observation'),
+            standard_concept='S',
+            concept_code=code,
+            valid_start_date=date(1970, 1, 1),
+            valid_end_date=date(2099, 12, 31),
+            source=source,
+        )
+
+    def test_dry_run_writes_nothing(self):
+        from omop_core.models import Concept
+
+        self._concept(9001099, 'X-1')
+        call_command('backfill_concept_source', '--dry-run', verbosity=0)
+        self.assertIsNone(Concept.objects.get(concept_id=9001099).source)
+
+    def test_tags_each_category_of_local_row(self):
+        from omop_core.models import Concept
+
+        self._concept(9001099, 'X-1')                                  # seed mint range
+        self._concept(392021999, 'X-2', vocabulary_id='SNOMED')        # FHIR ingest block
+        self._concept(2_100_000_001, 'X-3', vocabulary_id='HemOnc')    # OHDSI custom range
+        self._concept(500001, 'X-4', vocabulary_id='LOCAL')            # local vocabulary
+        self._concept(500002, 'X-5', vocabulary_id='HK-Labs')          # HK-* vocabulary
+
+        call_command('backfill_concept_source', '--apply', verbosity=0)
+
+        for cid in (9001099, 392021999, 2_100_000_001, 500001, 500002):
+            self.assertEqual(
+                Concept.objects.get(concept_id=cid).source, 'HealthKey',
+                f'concept {cid} should have been tagged as locally minted')
+
+    def test_genuine_vocabulary_rows_are_left_alone(self):
+        """The overwhelming majority of rows are Athena content and must not be
+        touched — a predicate that swept them up would relabel 1.98M rows as
+        locally authored and destroy the column's meaning."""
+        from omop_core.models import Concept
+
+        genuine = self._concept(3025999, 'X-6', vocabulary_id='LOINC')
+        call_command('backfill_concept_source', '--apply', verbosity=0)
+        genuine.refresh_from_db()
+        self.assertIsNone(genuine.source)
+
+    def test_existing_source_values_are_not_overwritten(self):
+        from omop_core.models import Concept
+
+        self._concept(500003, 'X-7', vocabulary_id='HK-Labs', source='SomethingElse')
+        call_command('backfill_concept_source', '--apply', verbosity=0)
+        self.assertEqual(
+            Concept.objects.get(concept_id=500003).source, 'SomethingElse',
+            'the command must only fill NULLs, never relabel an existing value')
+
+    def test_rule_flag_limits_scope(self):
+        from omop_core.models import Concept
+
+        self._concept(9001099, 'X-1')                            # seed mint
+        self._concept(500001, 'X-4', vocabulary_id='LOCAL')      # local vocabulary
+
+        call_command('backfill_concept_source', '--apply', '--rule', 'seed_mint',
+                     verbosity=0)
+
+        self.assertEqual(Concept.objects.get(concept_id=9001099).source, 'HealthKey')
+        self.assertIsNone(Concept.objects.get(concept_id=500001).source)
+
+    def test_is_idempotent(self):
+        from omop_core.models import Concept
+
+        self._concept(9001099, 'X-1')
+        call_command('backfill_concept_source', '--apply', verbosity=0)
+        call_command('backfill_concept_source', '--apply', verbosity=0)
+        self.assertEqual(
+            Concept.objects.filter(concept_id=9001099, source='HealthKey').count(), 1)


### PR DESCRIPTION
Phase 1 of #415. Metadata-only: writes the `source` column and nothing else.

## Why

`Concept.source` records provenance — `NULL` = came from an external vocabulary release (Athena), `'HealthKey'` = authored or minted locally. Per the field's own definition that covers HK-* vocabularies, FHIR-upload quarantine rows, and HealthKey-curated loads.

The column was added after most rows existed and was never populated, so it claims a guarantee it does not provide. On staging: **19 of 1,979,422 rows carry it, while 224 are demonstrably local** — including all 71 rows in `HK-Labs`, a vocabulary that is HealthKey by name.

The concrete damage is to the vocabulary mirror: `snapshot/concept/?source=external` is meant to give consumers genuine vocabulary content and currently hands them 224 locally-invented concepts.

## What it does

`backfill_concept_source`, dry-run by default. Five rules, each separately reported so the dry run can be reviewed group by group rather than trusting one opaque predicate:

| Rule | Staging | Evidence |
|---|---|---|
| `hk_vocabulary` | 71 | `HK-*` vocabularies — deliberate HealthKey concepts |
| `local_vocabulary` | 39 | `LOCAL`, `sct`, `FHIR` — each vocabulary's own row declares itself `synthetic` / `local` |
| `seed_mint` | 18 | legacy `900xxxx` `seed_omop_concepts` range |
| `fhir_ingest_block` | 128 | contiguous `392021xxx` block, every row `valid_start 1970-01-01` |
| `ohdsi_custom_range` | 78 | `concept_id >= 2e9`, which Athena never allocates |

De-duplicated total: **224 rows**, spanning SNOMED 72, HK-Labs 71, LOCAL 28, LOINC 19, CVX 17, sct 11, HemOnc 6.

`sct` is the FHIR system-URI form of SNOMED (`http://snomed.info/sct`) — it only exists because something minted a concept from a FHIR `Coding` rather than resolving it. Athena's SNOMED rows use `vocabulary_id='SNOMED'`.

## The invariant this unlocks

The command also reports the set that matters for the rest of #415:

```sql
SELECT * FROM concept WHERE source='HealthKey' AND vocabulary_id NOT LIKE 'HK-%'
```

A locally-authored row in an **external** vocabulary is always wrong: it shadows a genuine concept and makes `concept_by_vocab`'s unordered `.first()` nondeterministic — the defect behind #413 and #415. After this backfill that set is a one-line query rather than the id-range guesswork this command has to use.

On staging it projects to **114 rows: SNOMED 72, LOINC 19, CVX 17, HemOnc 6.** That is the worklist for phase 2, sorted by the data instead of by heuristics.

**The dry run projects the state after the backfill, not before it.** Reporting only already-tagged rows would print "invariant holds" right up until the update made it false — the same preview-doesn't-look-forward flaw found in `remap_wearable_concepts`, deliberately not repeated.

## Tests

Six, covering each category of local row, that genuine vocabulary rows are left alone (a predicate that swept them up would relabel 1.98M rows and destroy the column's meaning), that existing `source` values are never overwritten, `--rule` scoping, and idempotency.

- Django: `Ran 1216 tests` — `OK (skipped=1)`
- pytest: 166 passed
- Frontend: unchanged, not touched by this PR

## Not in scope

Two findings from the same audit are split into **#427**: six drug concepts locally minted with the drug name as `concept_code` (1,200 `drug_exposure` rows, remappable via `Maps to`), and `concept_id = 0` — OMOP's universal "No matching concept" sentinel — being stored under `vocabulary_id='HK-Labs'`, `domain_id='Measurement'`, which misattributes ~20,800 unmapped rows across every domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
