### PR TITLE
fix: correct concept 0 metadata and seed its prerequisites

### DIFF
--- a/omop_core/management/commands/seed_omop_concepts.py
+++ b/omop_core/management/commands/seed_omop_concepts.py
@@ -59,6 +59,15 @@ _VOCABULARIES = [
          vocabulary_reference='OMOP generated',
          vocabulary_version='v5',
          vocabulary_concept_id=0),
+    # OMOP's placeholder vocabulary. Required by concept 0 ('No matching
+    # concept') and by the generic-lab fallback 3000963. It was referenced by
+    # _CONCEPTS but never seeded, so seeding against an empty database raised
+    # IntegrityError — see conftest.py, which documents working around this.
+    dict(vocabulary_id='None',
+         vocabulary_name='OMOP Standardized Vocabularies',
+         vocabulary_reference='OMOP generated',
+         vocabulary_version='v5',
+         vocabulary_concept_id=0),
     dict(vocabulary_id='HemOnc',
          vocabulary_name='HemOnc',
          vocabulary_reference='https://hemonc.org',
@@ -87,6 +96,7 @@ _CONCEPT_CLASSES = [
     dict(concept_class_id='Treatment',           concept_class_name='Treatment',            concept_class_concept_id=0),
     dict(concept_class_id='Gender',              concept_class_name='Gender',               concept_class_concept_id=0),
     dict(concept_class_id='Regimen',             concept_class_name='Regimen',              concept_class_concept_id=0),
+    dict(concept_class_id='Undefined',           concept_class_name='Undefined',            concept_class_concept_id=0),
 ]
 
 
@@ -139,6 +149,19 @@ def _hk(offset, concept_name, domain_id, concept_class_id, concept_code):
 
 
 _CONCEPTS = [
+    # ------------------------------------------------------------------
+    # concept 0 — OMOP's universal "No matching concept" sentinel, written to
+    # any *_concept_id when source data cannot be mapped. It is domain-agnostic
+    # by design: on staging it is referenced by 12,352 observations, 8,131 drug
+    # exposures, 290 conditions and 14 measurements.
+    #
+    # It must NOT carry a real vocabulary or domain. Storing it as
+    # (HK-Labs, Measurement, Lab Test) — as one database had — makes every
+    # unmapped row of every domain look like a HealthKey lab test to any query
+    # that groups by vocabulary or domain. See #427.
+    # ------------------------------------------------------------------
+    _c(0, 'No matching concept', 'Metadata', 'None', 'Undefined', None, 'No matching concept'),
+
     # ------------------------------------------------------------------
     # Gender concepts — needed for Person.gender_concept FK.
     # ------------------------------------------------------------------

--- a/omop_core/migrations/0140_fix_concept_zero_metadata.py
+++ b/omop_core/migrations/0140_fix_concept_zero_metadata.py
@@ -1,0 +1,109 @@
+"""Correct concept 0 to the OMOP-specified "No matching concept" row.
+
+concept 0 is OMOP's universal sentinel, written to any `*_concept_id` when
+source data cannot be mapped. It is domain-agnostic by design.
+
+On staging it was stored as:
+
+    (0, 'No matching concept', Measurement, HK-Labs, Lab Test, NULL, '0', 'HealthKey')
+
+against the specification:
+
+    (0, 'No matching concept', Metadata, None, Undefined, NULL, 'No matching concept')
+
+Because it is referenced across every domain — 12,352 observations, 8,131 drug
+exposures, 290 conditions and 14 measurements — the wrong vocabulary and domain
+made ~20,800 unmapped rows of all kinds appear, to any query grouping by
+vocabulary or domain, as HealthKey lab tests. That directly caused a misreading
+during the #415 audit.
+
+`source='HealthKey'` was also wrong: concept 0 is standard OMOP content, not a
+local mint, so it polluted the `?source=external` vocabulary-mirror filter.
+
+Root cause: 0068_create_hk_labs_vocabulary creates concept 0 with
+(Measurement, HK-Labs, Lab Test) — it needed the sentinel for LOINC-unmatched
+measurements and borrowed the vocabulary it had just created.
+0077_seed_concept_zero then tried to seed the correct values, but with
+get_or_create, which no-ops when the row already exists. The correction was
+therefore written but never applied on any database that had run 0068.
+
+This migration uses save() on the existing row for exactly that reason.
+
+This is a metadata-only correction to a single row. It touches no clinical data
+and no foreign keys: every reference to concept 0 stays valid, because the
+concept_id does not change.
+
+Safe as an auto-applied migration (start.sh runs migrate on deploy) precisely
+because of that — unlike the bulk row rewrites in #413, which were deliberately
+kept as management commands.
+"""
+from django.db import migrations
+
+CONCEPT_ZERO = {
+    'concept_name': 'No matching concept',
+    'domain_id': 'Metadata',
+    'vocabulary_id': 'None',
+    'concept_class_id': 'Undefined',
+    'standard_concept': None,
+    'concept_code': 'No matching concept',
+    'source': None,
+}
+
+# Prerequisite rows for concept 0's foreign keys. get_or_create'd rather than
+# assumed: a database seeded only by seed_omop_concepts before this change has
+# no 'None' vocabulary and no 'Undefined' concept class.
+_VOCABULARY = ('None', 'OMOP Standardized Vocabularies', 'OMOP generated', 'v5')
+_DOMAIN = ('Metadata', 'Metadata')
+_CONCEPT_CLASS = ('Undefined', 'Undefined')
+
+
+def fix_concept_zero(apps, schema_editor):
+    Concept = apps.get_model('omop_core', 'Concept')
+    Vocabulary = apps.get_model('omop_core', 'Vocabulary')
+    Domain = apps.get_model('omop_core', 'Domain')
+    ConceptClass = apps.get_model('omop_core', 'ConceptClass')
+
+    concept = Concept.objects.filter(concept_id=0).first()
+    if concept is None:
+        # Nothing to correct. Do not create it here — seed_omop_concepts owns
+        # seeding, and a fresh database gets the correct row from there.
+        return
+
+    vid, vname, vref, vver = _VOCABULARY
+    Vocabulary.objects.get_or_create(
+        vocabulary_id=vid,
+        defaults={'vocabulary_name': vname, 'vocabulary_reference': vref,
+                  'vocabulary_version': vver, 'vocabulary_concept_id': 0},
+    )
+    did, dname = _DOMAIN
+    Domain.objects.get_or_create(
+        domain_id=did, defaults={'domain_name': dname, 'domain_concept_id': 0})
+    ccid, ccname = _CONCEPT_CLASS
+    ConceptClass.objects.get_or_create(
+        concept_class_id=ccid,
+        defaults={'concept_class_name': ccname, 'concept_class_concept_id': 0})
+
+    for field, value in CONCEPT_ZERO.items():
+        setattr(concept, field, value)
+    concept.save(update_fields=list(CONCEPT_ZERO))
+
+
+def reverse_noop(apps, schema_editor):
+    """Irreversible by design.
+
+    The previous values were themselves incorrect and varied by database — one
+    had (HK-Labs, Measurement, Lab Test), a freshly seeded one had no concept 0
+    at all. There is no single prior state to restore, and restoring a wrong one
+    would be worse than leaving the corrected row in place.
+    """
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('omop_core', '0139_patient_info_view_death_date'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_concept_zero, reverse_noop),
+    ]

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -2433,3 +2433,76 @@ class PurgeBrokenWearableRowsCommandTest(TestCase):
         self.assertEqual(
             PatientRecord.objects.get(person=self.person).derivation_version, 0,
             'affected PatientRecords must be re-derivable by the ordinary backfill')
+
+
+class ConceptZeroTest(TestCase):
+    """concept 0 is OMOP's universal 'No matching concept' sentinel (see #427).
+
+    It is written to any *_concept_id when source data cannot be mapped, so it
+    is domain-agnostic by design. One database had it stored as
+    (HK-Labs, Measurement, Lab Test), which made ~20,800 unmapped rows across
+    every domain look like HealthKey lab tests to any query grouping by
+    vocabulary or domain.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        call_command('seed_omop_concepts', verbosity=0)
+
+    def test_seeded_with_omop_specified_metadata(self):
+        from omop_core.models import Concept
+
+        c = Concept.objects.get(concept_id=0)
+        self.assertEqual(c.concept_name, 'No matching concept')
+        self.assertEqual(c.domain_id, 'Metadata',
+                         'concept 0 is domain-agnostic; a real domain misattributes '
+                         'every unmapped row of every other domain')
+        self.assertEqual(c.vocabulary_id, 'None')
+        self.assertEqual(c.concept_class_id, 'Undefined')
+        self.assertIsNone(c.standard_concept)
+
+    def test_not_marked_as_a_local_mint(self):
+        """concept 0 is standard OMOP content, not HealthKey-authored.
+
+        Tagging it 'HealthKey' pollutes the ?source=external vocabulary-mirror
+        filter in the opposite direction from the rest of #415.
+        """
+        from omop_core.models import Concept
+
+        self.assertIsNone(Concept.objects.get(concept_id=0).source)
+
+    def test_placeholder_vocabulary_and_class_are_seeded(self):
+        """seed_omop_concepts referenced vocabulary 'None' for the generic-lab
+        fallback but never seeded it, so seeding an empty database raised
+        IntegrityError — conftest.py documents working around exactly this."""
+        from omop_core.models import ConceptClass, Vocabulary
+
+        self.assertTrue(Vocabulary.objects.filter(vocabulary_id='None').exists())
+        self.assertTrue(ConceptClass.objects.filter(concept_class_id='Undefined').exists())
+
+    def test_migration_corrects_a_misfiled_concept_zero(self):
+        """Reproduces the staging state and asserts the migration logic fixes it."""
+        import importlib
+        # Module name starts with a digit, so it cannot be imported normally.
+        _0140 = importlib.import_module(
+            'omop_core.migrations.0140_fix_concept_zero_metadata')
+        from django.apps import apps as global_apps
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+
+        hk, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id='HK-Labs',
+            defaults={'vocabulary_name': 'HK-Labs', 'vocabulary_concept_id': 0})
+        c = Concept.objects.get(concept_id=0)
+        c.vocabulary = hk
+        c.domain = Domain.objects.get(domain_id='Measurement')
+        c.concept_class = ConceptClass.objects.get(concept_class_id='Lab Test')
+        c.source = 'HealthKey'
+        c.save()
+
+        _0140.fix_concept_zero(global_apps, None)
+
+        c.refresh_from_db()
+        self.assertEqual(c.domain_id, 'Metadata')
+        self.assertEqual(c.vocabulary_id, 'None')
+        self.assertEqual(c.concept_class_id, 'Undefined')
+        self.assertIsNone(c.source)


### PR DESCRIPTION
First half of #427. Single-row metadata correction, plus two seed rows that were referenced but never created.

## The defect

`concept 0` is OMOP's universal "No matching concept" sentinel, written to any `*_concept_id` when source data cannot be mapped. It is domain-agnostic by design. On staging it was stored as:

```
stored:    (0, 'No matching concept', Measurement, HK-Labs, Lab Test,  NULL, '0',                   'HealthKey')
OMOP spec: (0, 'No matching concept', Metadata,    None,    Undefined, NULL, 'No matching concept',  -)
```

It is referenced across every domain:

| Table | Rows on concept 0 |
|---|---|
| `observation` | 12,352 |
| `drug_exposure` | 8,131 |
| `condition_occurrence` | 290 |
| `measurement` | 14 |

So ~20,800 unmapped rows of all kinds appeared, to any query grouping by vocabulary or domain, as **HealthKey lab tests**. That is not hypothetical: during the #415 audit `drug_exposure` looked like it had 8,131 rows pointing at HK-Labs *drug* concepts, and it took a second look to find they were simply unmapped.

`source='HealthKey'` was wrong for the same reason — concept 0 is standard OMOP content, not a local mint, so it polluted the `?source=external` vocabulary-mirror filter in the opposite direction from the rest of #415.

## Root cause

`0068_create_hk_labs_vocabulary` creates concept 0 with `(Measurement, HK-Labs, Lab Test)`. It needed the sentinel to satisfy the FK for LOINC-unmatched measurements and borrowed the vocabulary it had just created.

`0077_seed_concept_zero` then tried to seed the **correct** values — `(Metadata, None, Undefined)` — but with `get_or_create`, which no-ops on an existing row. **The correction was written nine migrations later and silently never applied** on any database that had run 0068.

Migration `0140` uses `save()` for exactly that reason.

## Also fixed

`seed_omop_concepts` referenced two rows it never created:

- the **`None`** vocabulary, required by concept 0 and by the generic-lab fallback `3000963`
- the **`Undefined`** concept class

Seeding an empty database previously raised `IntegrityError` on `3000963`. `conftest.py` documents working around precisely this ("that command has its own pre-existing bug… so calling it against an empty DB raises an IntegrityError"), so the workaround can eventually go.

concept 0 is now seeded explicitly too, so a fresh database gets it right without depending on migration order.

## Why a migration rather than a management command

The bulk row rewrites in #413 were deliberately kept as commands because they rewrote ~127k clinical rows unattended on deploy. This is the opposite: one row, metadata only, no clinical data, no FK changes. Every existing reference to concept 0 stays valid because `concept_id` does not change. Safe to auto-apply.

The reverse is a documented no-op — the prior values were themselves wrong and varied by database, so there is no single correct state to restore.

## Tests

Four: seeded metadata matches the OMOP specification, concept 0 is not marked as a local mint, the placeholder vocabulary and concept class exist, and the migration corrects a database reproducing the staging state.

- Django: `Ran 1214 tests` — `OK (skipped=1)`
- pytest: 166 passed
- Verified on a freshly created database: migrate then seed yields `(0, 'No matching concept', 'Metadata', 'None', 'Undefined', None, None)`

## Remaining in #427

The six locally-minted drug concepts and their 1,200 `drug_exposure` rows, to be remapped via `Maps to` to Standard RxNorm concepts. Left separate deliberately: concept 0 was distorting the vocabulary-level queries needed to investigate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
