### PR TITLE
fix: serve SPA templates from the resolved frontend root

### DIFF
--- a/ctomop/frontend_paths.py
+++ b/ctomop/frontend_paths.py
@@ -1,0 +1,48 @@
+"""Resolution of the built-frontend directory.
+
+Two different frontend builds land in two different directories:
+
+| Build             | Command            | Output dir              | Image          |
+|-------------------|--------------------|-------------------------|----------------|
+| Standalone SPA    | `npm run build`    | `frontend/build`        | `Dockerfile`   |
+| Federation remote | `npm run build:remote` | `frontend/dist/remote` | `Dockerfile.gcp` |
+
+Both outputs contain the SPA shell (`index.html`) plus hashed assets, so both
+are simultaneously a WhiteNoise document root *and* a Django template dir — the
+catch-all route in ``ctomop.urls`` renders ``index.html`` as a template so that
+client-side deep links (``/patients/42``) return the shell.
+
+Those two consumers must resolve to the *same* directory. When they disagree,
+the failure is confusing: WhiteNoise serves ``/index.html`` and ``/assets/*``
+with a 200 while every SPA route 500s with ``TemplateDoesNotExist: index.html``.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+# Checked in priority order when WHITENOISE_ROOT is unset.
+_CANDIDATES = (
+    ('frontend', 'dist', 'remote'),
+    ('frontend', 'build'),
+)
+
+
+def resolve_frontend_root(base_dir: Path, whitenoise_root: str = '') -> Optional[Path]:
+    """Return the directory holding the built frontend, or None if there is none.
+
+    ``whitenoise_root`` is the raw ``WHITENOISE_ROOT`` environment value. When
+    set it wins outright and is *not* probed for existence — the Dockerfiles set
+    it to a path that exists in the final image, and failing loudly there beats
+    silently falling back to a stale directory.
+    """
+    if whitenoise_root:
+        return Path(whitenoise_root)
+
+    for parts in _CANDIDATES:
+        candidate = base_dir.joinpath(*parts)
+        # is_dir(), not exists(): a stray file at one of these paths must not be
+        # handed to the template loader or WhiteNoise as a document root.
+        if candidate.is_dir():
+            return candidate
+
+    return None

--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -15,11 +15,18 @@ from pathlib import Path
 import dj_database_url
 from dotenv import load_dotenv
 
+from ctomop.frontend_paths import resolve_frontend_root
+
 # Load environment variables from .env file (for local development)
 load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Directory holding the built frontend. Feeds BOTH the Django template loader
+# (for the SPA catch-all in ctomop.urls) and WhiteNoise (for index.html and the
+# hashed assets) — see ctomop/frontend_paths.py for why they must agree.
+FRONTEND_ROOT = resolve_frontend_root(BASE_DIR, os.environ.get('WHITENOISE_ROOT', ''))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-your-default-key-change-this')
@@ -166,7 +173,7 @@ ROOT_URLCONF = 'ctomop.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'frontend' / 'build'],
+        'DIRS': [FRONTEND_ROOT] if FRONTEND_ROOT else [],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -287,14 +294,8 @@ MEDIA_ROOT = BASE_DIR / 'media'
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-_whitenoise_root = os.environ.get('WHITENOISE_ROOT', '')
-if _whitenoise_root:
-    WHITENOISE_ROOT = Path(_whitenoise_root)
-else:
-    for _candidate in (BASE_DIR / 'frontend' / 'dist' / 'remote', BASE_DIR / 'frontend' / 'build'):
-        if _candidate.exists():
-            WHITENOISE_ROOT = _candidate
-            break
+if FRONTEND_ROOT:
+    WHITENOISE_ROOT = FRONTEND_ROOT
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/tests/test_frontend_paths.py
+++ b/tests/test_frontend_paths.py
@@ -1,0 +1,106 @@
+"""Regression tests for built-frontend directory resolution.
+
+Guards the staging outage where WHITENOISE_ROOT pointed at
+``frontend/dist/remote`` (the federation-remote build) while the Django template
+loader was hardcoded to ``frontend/build``. WhiteNoise served ``/index.html``
+and ``/assets/*`` with a 200 while every SPA route 500'd with
+``TemplateDoesNotExist: index.html``.
+"""
+
+from pathlib import Path
+
+import pytest
+from django.test import Client, override_settings
+
+from ctomop.frontend_paths import resolve_frontend_root
+
+
+class TestResolveFrontendRoot:
+    def test_env_value_wins_over_existing_directories(self, tmp_path):
+        """WHITENOISE_ROOT is authoritative — the Dockerfiles set it deliberately."""
+        (tmp_path / 'frontend' / 'build').mkdir(parents=True)
+        (tmp_path / 'frontend' / 'dist' / 'remote').mkdir(parents=True)
+
+        resolved = resolve_frontend_root(tmp_path, '/app/frontend/dist/remote')
+
+        assert resolved == Path('/app/frontend/dist/remote')
+
+    def test_env_value_is_not_probed_for_existence(self, tmp_path):
+        """Fail loudly on a bad WHITENOISE_ROOT rather than silently falling back."""
+        (tmp_path / 'frontend' / 'build').mkdir(parents=True)
+
+        resolved = resolve_frontend_root(tmp_path, '/nonexistent/path')
+
+        assert resolved == Path('/nonexistent/path')
+
+    def test_prefers_remote_build_when_both_exist(self, tmp_path):
+        (tmp_path / 'frontend' / 'build').mkdir(parents=True)
+        (tmp_path / 'frontend' / 'dist' / 'remote').mkdir(parents=True)
+
+        assert resolve_frontend_root(tmp_path) == tmp_path / 'frontend' / 'dist' / 'remote'
+
+    def test_falls_back_to_standalone_build(self, tmp_path):
+        """The Render deploy runs `npm run build`, which only produces frontend/build."""
+        (tmp_path / 'frontend' / 'build').mkdir(parents=True)
+
+        assert resolve_frontend_root(tmp_path) == tmp_path / 'frontend' / 'build'
+
+    def test_returns_none_when_frontend_is_not_built(self, tmp_path):
+        """A backend-only checkout must still import settings without blowing up."""
+        assert resolve_frontend_root(tmp_path) is None
+
+    def test_ignores_a_file_sitting_at_a_candidate_path(self, tmp_path):
+        """Only directories are valid document roots."""
+        (tmp_path / 'frontend').mkdir()
+        (tmp_path / 'frontend' / 'build').write_text('not a directory')
+
+        assert resolve_frontend_root(tmp_path) is None
+
+
+class TestTemplateAndStaticRootsAgree:
+    def test_settings_serve_templates_from_the_whitenoise_root(self, settings):
+        """The template dir and the static root must be the same directory.
+
+        Holds in both environments: a built checkout (CI images, Render, Cloud
+        Run) and a backend-only one where the frontend was never built.
+        """
+        if settings.FRONTEND_ROOT is None:
+            assert settings.TEMPLATES[0]['DIRS'] == []
+            assert not hasattr(settings, 'WHITENOISE_ROOT')
+            return
+
+        assert settings.TEMPLATES[0]['DIRS'] == [settings.FRONTEND_ROOT]
+        assert settings.WHITENOISE_ROOT == settings.FRONTEND_ROOT
+
+    @pytest.mark.parametrize('path', ['/', '/patients/42', '/settings'])
+    def test_spa_catch_all_renders_index_html(self, tmp_path, path):
+        """Deep links must return the SPA shell, not TemplateDoesNotExist."""
+        (tmp_path / 'index.html').write_text('<!doctype html><div id="root"></div>')
+
+        templates = [{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [tmp_path],
+            'APP_DIRS': True,
+            'OPTIONS': {'context_processors': []},
+        }]
+
+        with override_settings(TEMPLATES=templates):
+            response = Client().get(path)
+
+        assert response.status_code == 200
+        assert b'<div id="root">' in response.content
+
+    def test_spa_catch_all_500s_without_a_template_dir(self):
+        """Pins the actual failure mode, so the fix cannot silently regress."""
+        from django.template.exceptions import TemplateDoesNotExist
+
+        templates = [{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {'context_processors': []},
+        }]
+
+        with override_settings(TEMPLATES=templates):
+            with pytest.raises(TemplateDoesNotExist):
+                Client().get('/')


### PR DESCRIPTION
The staging Cloud Run deploy returned 500 TemplateDoesNotExist: index.html for every non-API route, while /index.html and /assets/* served 200.

TEMPLATES['DIRS'] was hardcoded to frontend/build. Dockerfile.gcp builds the federation remote into frontend/dist/remote and copies only that directory into the final image, so the template dir did not exist and the SPA catch-all in ctomop/urls.py could not resolve index.html. WHITENOISE_ROOT was made configurable in c2bbd95 but the template loader was never updated to match.

Resolve the built-frontend directory once and feed both consumers from it.