### PR TITLE
fix: repoint drug_exposure off locally-minted drug concepts

### DIFF
--- a/omop_core/management/commands/remap_local_drug_concepts.py
+++ b/omop_core/management/commands/remap_local_drug_concepts.py
@@ -1,0 +1,223 @@
+"""
+Repoint drug_exposure rows off locally-minted drug concepts onto Standard ones.
+
+Six drug concepts were minted locally instead of resolved against Athena. Their
+`concept_code` is the drug's *name* ("Olaparib") where real HemOnc drug codes are
+numeric ("366"), so something failed to resolve a drug and invented a concept
+from the display string.
+
+The clinical content is correct — the patient did receive the drug — but the
+representation severs it from the vocabulary. The genuine HemOnc concept for
+olaparib participates in 63 relationships ("Targeted therapy of" x24, brand
+names, FDA/EMA/PMDA indications); the mint participates in zero. A query for
+"patients on any PARP inhibitor" traverses concept_relationship from the
+Standard concept and finds nothing, because the exposures point at a row with no
+edges. The data is present but analytically invisible.
+
+The fix follows OMOP's own conventions:
+
+  drug_concept_id        -> the STANDARD concept (RxNorm / RxNorm Extension)
+  drug_source_concept_id -> the HemOnc concept, preserving what was recorded
+
+RxNorm is the standard vocabulary for the Drug domain, so the HemOnc drug
+concepts are standard_concept=NULL by design — they exist to be mapped onward.
+Pointing drug_concept_id at HemOnc would swap one non-standard concept for
+another.
+
+The mapping below is a reviewed constant, NOT resolved by name at runtime.
+Name matching is how seed_omop_concepts came to map LOINC 10839-9 (Troponin I)
+to a concept named Troponin T. Each Standard target here was taken from the
+vocabulary's own 'Maps to' edge, which is also what settles the "Ado-" question:
+HemOnc "Trastuzumab emtansine" maps to a Standard concept named
+"ado-Trastuzumab emtansine", so they are the same drug per the vocabulary rather
+than per a string comparison.
+
+Usage:
+    python manage.py remap_local_drug_concepts              # dry run (default)
+    python manage.py remap_local_drug_concepts --apply
+    python manage.py remap_local_drug_concepts --apply --keep-mints
+"""
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError, connection, transaction
+from django.db.models import ProtectedError
+
+from omop_core.models import Concept, DrugExposure, PatientRecord
+from omop_core.signals import suppress_patient_record_refresh
+
+logger = logging.getLogger(__name__)
+
+# (local mint, HemOnc source concept, Standard target). Verified against the
+# vocabulary: each Standard target is the 'Maps to' edge from the HemOnc concept,
+# and each HemOnc concept_code is numeric where the mint's is a drug name.
+#
+#   mint         HemOnc     Standard   drug
+DRUG_REMAP = [
+    (2006492703, 35802866, 902726),    # Ado-Trastuzumab Emtansine -> ado-Trastuzumab emtansine
+    (2012334076, 35803216, 45892579),  # Olaparib                  -> olaparib
+    (2018816589, 35803231, 45892075),  # Palbociclib               -> palbociclib
+    (2018910366, 35802975, 1310317),   # Cyclophosphamide          -> cyclophosphamide
+    (2019696819, 35803229, 1378382),   # Paclitaxel                -> paclitaxel
+    (2022763720, 42542260, 902724),    # Trastuzumab Deruxtecan    -> Fam-trastuzumab deruxtecan
+]
+
+MINT_IDS = [m for m, _, _ in DRUG_REMAP]
+
+
+class Command(BaseCommand):
+    help = 'Repoint drug_exposure off locally-minted drug concepts (see #427).'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--apply', action='store_true',
+            help='Write the changes. Without this the command only reports.')
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help='Explicitly request a dry run (the default).')
+        parser.add_argument(
+            '--keep-mints', action='store_true',
+            help='Leave the mint concepts in place after remapping.')
+
+    def handle(self, *args, **options):
+        apply_changes = options['apply']
+        if apply_changes and options['dry_run']:
+            raise CommandError('--apply and --dry-run are mutually exclusive.')
+
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING(
+                'DRY RUN — nothing will be written. Re-run with --apply.\n'))
+
+        totals = {'exposures': 0, 'mints_deleted': 0, 'mints_still_referenced': 0,
+                  'records_marked_stale': 0}
+        wrote_anything = False
+
+        try:
+            # drug_exposure changes below use queryset .update()/.delete(); the
+            # former sends no post_save at all, but deleting a concept could
+            # cascade elsewhere, and PatientRecord derivation is deferred to the
+            # backfill either way. Suppressing keeps that uniform and avoids the
+            # per-row refresh storm found in #413.
+            with suppress_patient_record_refresh():
+                person_ids = set(
+                    DrugExposure.objects.filter(drug_concept_id__in=MINT_IDS)
+                    .values_list('person_id', flat=True).distinct()
+                )
+                for mint_id, hemonc_id, standard_id in DRUG_REMAP:
+                    n = self._remap_one(mint_id, hemonc_id, standard_id, apply_changes)
+                    totals['exposures'] += n
+                    wrote_anything |= bool(apply_changes and n)
+
+                if not options['keep_mints']:
+                    self._delete_mints(totals, apply_changes)
+
+                totals['records_marked_stale'] = self._mark_stale(person_ids, apply_changes)
+        finally:
+            self._summarise(totals, apply_changes, wrote_anything)
+
+    # ------------------------------------------------------------------
+
+    def _remap_one(self, mint_id, hemonc_id, standard_id, apply_changes):
+        mint = Concept.objects.filter(concept_id=mint_id).first()
+        standard = Concept.objects.filter(concept_id=standard_id).first()
+        hemonc = Concept.objects.filter(concept_id=hemonc_id).first()
+
+        rows = DrugExposure.objects.filter(drug_concept_id=mint_id)
+        n = rows.count()
+        name = mint.concept_name if mint else f'(mint {mint_id} absent)'
+
+        if standard is None or hemonc is None:
+            self.stdout.write(self.style.ERROR(
+                f'  {name[:28]:30s} SKIPPED — target concept missing '
+                f'(standard={standard_id}, hemonc={hemonc_id}). '
+                f'Is the Athena vocabulary loaded?'))
+            return 0
+        if not n:
+            return 0
+
+        if standard.standard_concept != 'S':
+            self.stdout.write(self.style.ERROR(
+                f'  {name[:28]:30s} SKIPPED — target {standard_id} is not Standard '
+                f'(standard_concept={standard.standard_concept!r})'))
+            return 0
+
+        arrow = f'-> {standard_id} {standard.concept_name[:24]}'
+        if not apply_changes:
+            self.stdout.write(f'  {name[:28]:30s} {n:5d} rows {arrow}')
+            return n
+
+        with transaction.atomic():
+            rows.update(drug_concept_id=standard_id, drug_source_concept_id=hemonc_id)
+        self.stdout.write(f'  {name[:28]:30s} {n:5d} rows {arrow}')
+        return n
+
+    def _delete_mints(self, totals, apply_changes):
+        self.stdout.write('')
+        for mint_id in MINT_IDS:
+            mint = Concept.objects.filter(concept_id=mint_id).first()
+            if mint is None:
+                continue
+
+            if not apply_changes:
+                # Project the state AFTER the remap: the remap claims every
+                # drug_exposure row on this mint, so what matters is whether
+                # anything ELSE still points at it.
+                others = DrugExposure.objects.filter(
+                    drug_source_concept_id=mint_id).count()
+                if others:
+                    self.stdout.write(
+                        f'  mint {mint_id}: {others} row(s) would remain via '
+                        f'drug_source_concept_id — not removable')
+                    totals['mints_still_referenced'] += 1
+                else:
+                    self.stdout.write(f'  mint {mint_id}: would be removed')
+                    totals['mints_deleted'] += 1
+                continue
+
+            try:
+                with transaction.atomic():
+                    # Only 97 of the 112 FK fields pointing at Concept use
+                    # PROTECT; 13 use DO_NOTHING, whose violation would surface
+                    # at COMMIT of the outer transaction rather than here.
+                    with connection.cursor() as cur:
+                        cur.execute('SET CONSTRAINTS ALL IMMEDIATE')
+                    Concept.objects.filter(concept_id=mint_id).delete()
+            except (ProtectedError, IntegrityError) as exc:
+                self.stdout.write(self.style.WARNING(
+                    f'  mint {mint_id}: still referenced, left in place '
+                    f'({type(exc).__name__})'))
+                totals['mints_still_referenced'] += 1
+            else:
+                self.stdout.write(f'  mint {mint_id}: removed')
+                totals['mints_deleted'] += 1
+
+    def _mark_stale(self, person_ids, apply_changes):
+        """Force re-derivation of affected PatientRecords.
+
+        Therapy fields derive from drug_exposure, and queryset .update() sends
+        no signals, so nothing would otherwise notice the concepts changed.
+        Zeroing derivation_version puts these records in the ordinary
+        backfill_patient_records path rather than relying on --all.
+        """
+        qs = PatientRecord.objects.filter(person_id__in=person_ids)
+        if not apply_changes:
+            return qs.count()
+        return qs.update(derivation_version=0)
+
+    def _summarise(self, totals, apply_changes, wrote_anything):
+        self.stdout.write('')
+        verb = 'Would remap' if not apply_changes else 'Remapped'
+        self.stdout.write(self.style.SUCCESS(
+            '{v} — drug_exposure rows: {e}  |  mints removed: {m}  |  '
+            'PatientRecords marked stale: {s}'.format(
+                v=verb, e=totals['exposures'], m=totals['mints_deleted'],
+                s=totals['records_marked_stale'])))
+        if totals['mints_still_referenced']:
+            self.stdout.write(self.style.WARNING(
+                f"{totals['mints_still_referenced']} mint(s) still referenced and left in place."))
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING(
+                'Nothing was written. Re-run with --apply.'))
+        elif wrote_anything:
+            self.stdout.write(self.style.WARNING(
+                'Run `manage.py backfill_patient_records` to re-derive the affected records.'))

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -2603,3 +2603,142 @@ class BackfillConceptSourceCommandTest(TestCase):
         call_command('backfill_concept_source', '--apply', verbosity=0)
         self.assertEqual(
             Concept.objects.filter(concept_id=9001099, source='HealthKey').count(), 1)
+
+
+class RemapLocalDrugConceptsCommandTest(TestCase):
+    """Covers remap_local_drug_concepts (see #427).
+
+    Six drug concepts were minted locally with the drug's name as concept_code
+    instead of being resolved against Athena. The clinical content is right, but
+    the mint has no vocabulary edges at all — the genuine HemOnc olaparib
+    concept participates in 63 relationships, the mint in zero — so the
+    exposures are invisible to any standard drug-class or indication query.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import Person
+        call_command('seed_omop_concepts', verbosity=0)
+        cls.person = Person.objects.create(person_id=780001, year_of_birth=1970)
+
+    def _concept(self, concept_id, code, name, vocabulary_id, standard=None):
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+        vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id=vocabulary_id,
+            defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0})
+        domain, _ = Domain.objects.get_or_create(
+            domain_id='Drug', defaults={'domain_name': 'Drug', 'domain_concept_id': 0})
+        return Concept.objects.create(
+            concept_id=concept_id, concept_name=name, domain=domain, vocabulary=vocab,
+            concept_class=ConceptClass.objects.get(concept_class_id='Clinical Observation'),
+            standard_concept=standard, concept_code=code,
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31))
+
+    def _setup_olaparib(self, n_exposures=3):
+        """Mint, HemOnc source concept and Standard target, as on staging."""
+        from omop_core.models import Concept, DrugExposure
+
+        mint = self._concept(2012334076, 'Olaparib', 'Olaparib', 'HemOnc')
+        self._concept(35803216, '366', 'Olaparib', 'HemOnc')
+        self._concept(45892579, '1597582', 'olaparib', 'RxNorm', standard='S')
+        for i in range(n_exposures):
+            DrugExposure.objects.create(
+                drug_exposure_id=880001 + i,
+                person=self.person,
+                drug_concept=mint,
+                drug_exposure_start_date=date(2024, 7, i + 1),
+                drug_type_concept=Concept.objects.get(concept_id=32869),
+            )
+        return mint
+
+    def test_dry_run_writes_nothing(self):
+        from omop_core.models import Concept, DrugExposure
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--dry-run', verbosity=0)
+        self.assertEqual(
+            DrugExposure.objects.filter(drug_concept_id=2012334076).count(), 3)
+        self.assertTrue(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_apply_points_drug_concept_at_the_standard_concept(self):
+        """drug_concept_id must hold a Standard concept.
+
+        RxNorm is standard for the Drug domain, so the HemOnc drug concept is
+        non-standard by design — pointing at it would swap one non-standard
+        concept for another.
+        """
+        from omop_core.models import DrugExposure
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+
+        rows = DrugExposure.objects.filter(person=self.person)
+        self.assertEqual(rows.count(), 3)
+        for row in rows:
+            self.assertEqual(row.drug_concept_id, 45892579)
+            self.assertEqual(row.drug_concept.standard_concept, 'S')
+
+    def test_apply_preserves_provenance_in_drug_source_concept(self):
+        from omop_core.models import DrugExposure
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+        self.assertEqual(
+            DrugExposure.objects.filter(person=self.person).first().drug_source_concept_id,
+            35803216, 'the HemOnc concept records what was actually stated')
+
+    def test_apply_deletes_the_mint(self):
+        from omop_core.models import Concept
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+        self.assertFalse(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_keep_mints_leaves_the_concept(self):
+        from omop_core.models import Concept
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', '--keep-mints', verbosity=0)
+        self.assertTrue(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_affected_patient_records_are_marked_stale(self):
+        """Therapy fields derive from drug_exposure, and queryset .update()
+        sends no signals, so nothing would otherwise notice the change."""
+        from omop_core.models import PatientRecord
+
+        self._setup_olaparib()
+        PatientRecord.objects.filter(person=self.person).update(derivation_version=99)
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+        self.assertEqual(
+            PatientRecord.objects.get(person=self.person).derivation_version, 0)
+
+    def test_skips_when_the_target_concept_is_absent(self):
+        """On a database with no Athena load the targets do not exist. The
+        command must leave the data alone rather than repoint it at nothing."""
+        from omop_core.models import Concept, DrugExposure
+
+        mint = self._concept(2012334076, 'Olaparib', 'Olaparib', 'HemOnc')
+        DrugExposure.objects.create(
+            drug_exposure_id=880900, person=self.person, drug_concept=mint,
+            drug_exposure_start_date=date(2024, 7, 1),
+            drug_type_concept=Concept.objects.get(concept_id=32869))
+
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+
+        self.assertEqual(
+            DrugExposure.objects.get(drug_exposure_id=880900).drug_concept_id, 2012334076)
+        self.assertTrue(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_refuses_a_non_standard_target(self):
+        """Guards the mapping constant itself: if a listed target stops being
+        Standard in a later vocabulary release, do not silently use it."""
+        from omop_core.models import Concept, DrugExposure
+
+        self._setup_olaparib()
+        Concept.objects.filter(concept_id=45892579).update(standard_concept=None)
+
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+
+        self.assertEqual(
+            DrugExposure.objects.filter(drug_concept_id=2012334076).count(), 3,
+            'rows must be left alone when the target is not Standard')


### PR DESCRIPTION
Second half of #427, after #429 fixed concept 0.

## The defect

Six drug concepts were minted locally instead of resolved against Athena. Their `concept_code` is the drug's **name** where real HemOnc drug codes are numeric:

```
mint 2012334076   vocabulary=HemOnc   concept_code='Olaparib'   <- invented
     35803216     vocabulary=HemOnc   concept_code='366'        <- genuine
```

**The clinical content is correct.** The patient did receive olaparib, and the name says so. What is wrong is the representation, and the cost is severance from the vocabulary graph:

| Concept | `concept_relationship` edges | `drug_exposure` rows |
|---|---|---|
| mint `2012334076` "Olaparib" | **0** | 56 |
| genuine `35803216` HemOnc `366` | **63** | 0 |

The genuine concept participates in `Targeted therapy of` ×24, `Has brand name` ×13, `Has FDA indication`, `Has EMA indication`, `Has PMDA indication`. A query for "patients on any PARP inhibitor", or any drug-class or indication rollup, traverses `concept_relationship` from the Standard concept and finds nothing — the exposures hang off a row with no edges. **1,200 rows on staging are present but analytically invisible.**

## The fix

Follows OMOP's own conventions rather than swapping one non-standard concept for another:

```
drug_concept_id        -> the STANDARD RxNorm concept
drug_source_concept_id -> the HemOnc concept, preserving what was stated
```

RxNorm is the standard vocabulary for the Drug domain, so the HemOnc *drug* concepts are `standard_concept=NULL` by design — they exist to be mapped onward. Pointing `drug_concept_id` at HemOnc would leave it non-standard.

| Mint | Rows | Standard target |
|---|---|---|
| Ado-Trastuzumab Emtansine | 67 | `902726` ado-Trastuzumab emtansine |
| Olaparib | 56 | `45892579` olaparib |
| Palbociclib | 91 | `45892075` palbociclib |
| Cyclophosphamide | 406 | `1310317` cyclophosphamide |
| Paclitaxel | 405 | `1378382` paclitaxel |
| Trastuzumab Deruxtecan | 175 | `902724` Fam-trastuzumab deruxtecan |

**The mapping is a reviewed constant, not resolved by name at runtime.** Name matching is how `seed_omop_concepts` came to map LOINC `10839-9` (Troponin I) to a concept named Troponin T. Each Standard target was taken from the vocabulary's own `Maps to` edge — which is also what settles the "Ado-" question: HemOnc "Trastuzumab emtansine" maps to a Standard concept named "ado-Trastuzumab emtansine", so they are the same drug per the vocabulary rather than per a string comparison.

## Safety

- **Dry run by default.** Staging preview: 1,200 rows, 6 mints removable, 798 PatientRecords affected.
- **`derivation_version` reset** on affected records — therapy fields derive from `drug_exposure`, and queryset `.update()` sends no signals, so nothing would otherwise notice.
- **`SET CONSTRAINTS ALL IMMEDIATE`** before deleting a mint, because only 97 of the 112 FK fields pointing at `Concept` use `PROTECT`; the 13 `DO_NOTHING` ones would otherwise fail at outer COMMIT, past every handler.
- **Refuses a non-Standard target**, guarding the constant against a future vocabulary release changing one.
- **Leaves data alone where Athena is not loaded** rather than repointing it at a missing concept.

## Tests

Eight, covering the dry run, Standard-concept targeting, provenance in `drug_source_concept_id`, mint deletion, `--keep-mints`, stale marking, the no-Athena case, and the non-Standard-target guard.

- Django: `Ran 1228 tests` — `OK (skipped=1)`
- pytest: 177 passed

## Not run yet

Staging is dry-run only so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
