### PR TITLE
feat: bulk write endpoint for OMOP clinical rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -711,6 +711,32 @@ The FHIR upload endpoint in `patient_portal/api/views.py` (`upload_fhir_bundle`)
 
 ---
 
+## Bulk OMOP Row Writes
+
+The five OMOP clinical CRUD endpoints (`conditions`, `drug-exposures`, `measurements`,
+`observations`, `procedures`) accept a **JSON array** on POST for callers that have
+already parsed FHIR into OMOP rows. Single-dict POSTs are unchanged.
+
+Contract: `201` with `{"created": N, "ids": [...]}`, ids in request order. One
+transaction, all-or-nothing. One batch is one person (mixed-person → 400). Server
+assigns PKs via `next_pk_batch` (client-supplied PKs → 400). Per-index validation
+errors. Max 1,000 rows (`OMOP_BULK_MAX_ROWS`) → 413. Provenance comes from the
+`X-Provenance-Source` / `X-Provenance-User-Id` headers and applies to the whole
+batch; no source means no `ProvenanceRecord`, matching the single-row path.
+
+Two things to know before touching this code:
+
+- **`bulk_create` does not fire `post_save`**, so the `omop_core/signals.py` receivers
+  that rebuild `PatientRecord` do not run. The bulk path calls `refresh_patient_record`
+  explicitly, once per batch. Any new bulk write path must do the same, or it will land
+  rows that the read model never reflects.
+- **Query count must stay flat in batch size.** DRF resolves FKs with a per-row
+  `queryset.get(pk=...)`; `_prefetch_bulk_related` collapses that to one query per FK
+  column. `BulkOmopWriteTest` asserts this with `CaptureQueriesContext` at two batch
+  sizes — treat a failure there as a real regression, not a flaky threshold.
+
+---
+
 ## FHIR Bundle Generator Architecture
 
 `omop_core/management/commands/generate_fhir_bundle.py`:

--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -356,6 +356,16 @@ if DEBUG:
         'rest_framework.authentication.BasicAuthentication',
     ]
 
+# Pinned rather than inherited so the value is visible, but note the scope:
+# this bounds form/multipart bodies and anything read via HttpRequest.body. It
+# does NOT bound DRF JSON bodies — Request._load_stream hands JSONParser the raw
+# WSGI stream, bypassing HttpRequest.body entirely, which is the only place
+# Django enforces this. The bulk OMOP write endpoint therefore does its own
+# pre-parse CONTENT_LENGTH check (OMOP_BULK_MAX_BYTES in patient_portal/api/views.py).
+DATA_UPLOAD_MAX_MEMORY_SIZE = int(
+    os.environ.get('DATA_UPLOAD_MAX_MEMORY_SIZE', 2621440)
+)
+
 REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_AUTHENTICATION_CLASSES': _auth_classes,
@@ -377,6 +387,14 @@ REST_FRAMEWORK = {
         # a more generous bucket than the shared service-token /sync/ endpoint.
         'patient_sync': os.environ.get('PATIENT_SYNC_THROTTLE_RATE', '120/minute'),
         'patient_signup': '10/hour',
+        # OMOP clinical-row CRUD (conditions / drug-exposures / measurements /
+        # observations / procedures). These viewsets set throttle_scope='omop_write'
+        # and override throttle_classes, so this bucket REPLACES 'user' for them
+        # rather than stacking with it. The default matches the old 'user' rate, so
+        # behaviour is unchanged out of the box; raise it for bulk backfills, where
+        # 300/minute would otherwise become the new ceiling once per-row request
+        # overhead is gone.
+        'omop_write': os.environ.get('OMOP_WRITE_THROTTLE_RATE', '300/minute'),
     },
 }
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -4,6 +4,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.throttling import ScopedRateThrottle
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from patient_portal.models import Identity
 from django.contrib.auth import logout, login, authenticate
@@ -14,6 +15,7 @@ from django.utils.decorators import method_decorator
 from django.utils import timezone
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError as DjangoValidationError
 from omop_core.models import (
     Person, PatientRecord, Concept, ConceptClass, Domain, ProvenanceRecord, Vocabulary,
     ConditionOccurrence, DrugExposure, Measurement, MeasurementOwnership,
@@ -41,7 +43,7 @@ from omop_core.services.lot_inference_service import infer_lot_for_person
 from omop_core.services.omop_write_service import sync_to_omop
 from omop_core.services.episode_service import upsert_therapy_line_episode
 from omop_core.services.mappings import get_gender_concept, LAB_FIELD_TO_LOINC
-from omop_core.services.pk import next_pk
+from omop_core.services.pk import next_pk, next_pk_batch
 from omop_core.services.rxnav_service import resolve_drug as _rxnav_resolve_drug
 from omop_core.services.regimen_resolution import (
     get_or_create_quarantine_drug,
@@ -59,6 +61,7 @@ import csv
 import hashlib
 import json
 import logging
+import os
 import re
 from io import StringIO
 from .permissions import ScopedTokenPermission, PatientCrudPermission, PatientSelfScopePermission, PatientDeletePermission, get_request_org, is_service_token
@@ -142,16 +145,22 @@ class CurrentUserViewSet(viewsets.ViewSet):
         })
 
 def _extract_provenance(request):
-    """Return (source, source_user_id, modification_reason) from headers or POST body."""
+    """Return (source, source_user_id, modification_reason) from headers or POST body.
+
+    A bulk POST body is a JSON *list*, which has no top-level provenance fields and
+    no ``.get()``. For those requests the headers are the only channel — per-row
+    provenance keys are deliberately out of scope, so a list body reads headers only.
+    """
+    body = request.data if isinstance(request.data, dict) else {}
     source = (
-        request.data.get('source')
+        body.get('source')
         or request.META.get('HTTP_X_PROVENANCE_SOURCE')
     )
     source_user_id = (
-        request.data.get('source_user_id')
+        body.get('source_user_id')
         or request.META.get('HTTP_X_PROVENANCE_USER_ID', '')
     )
-    modification_reason = request.data.get('modification_reason')
+    modification_reason = body.get('modification_reason')
     return source, source_user_id, modification_reason
 
 
@@ -4417,6 +4426,256 @@ class _OmopFilterMixin:
         return qs
 
 
+#: Maximum rows accepted in a single bulk POST body. Exceeding it is a 413 naming
+#: the limit rather than a timeout — callers chunk to this number.
+OMOP_BULK_MAX_ROWS = int(os.environ.get('OMOP_BULK_MAX_ROWS', 1000))
+
+#: Byte ceiling for a bulk body, checked against CONTENT_LENGTH *before* parsing.
+#: The row cap cannot serve as a memory guard: DRF's JSONParser reads the WSGI
+#: stream directly (Request._load_stream sets _stream to the raw HttpRequest),
+#: so it never touches HttpRequest.body — the only place Django enforces
+#: DATA_UPLOAD_MAX_MEMORY_SIZE. A 500 MB array would therefore be fully parsed
+#: into memory before the row count could reject it. 1,000 measurement rows is
+#: ~250 KB, so this leaves ample headroom.
+OMOP_BULK_MAX_BYTES = int(os.environ.get('OMOP_BULK_MAX_BYTES', 8 * 1024 * 1024))
+
+
+def _cached_pk_lookup(field, cache):
+    """Wrap a PrimaryKeyRelatedField's to_internal_value with a prefetched cache.
+
+    ``PrimaryKeyRelatedField.to_internal_value`` runs ``queryset.get(pk=...)`` per
+    row, so a 1,000-row batch with five FK columns costs 5,000 queries — the same
+    N+1 at the ORM layer that the endpoint exists to remove at the HTTP layer.
+    A cache miss falls through to the original implementation so that unknown or
+    malformed ids still raise DRF's own per-index validation error.
+    """
+    original = field.to_internal_value
+
+    def to_internal_value(data):
+        # bool subclasses int, so {1: obj}.get(True) is a HIT and would silently
+        # link the row to pk 1. DRF's own to_internal_value raises TypeError for
+        # bool before it reaches the queryset, yielding "Incorrect type. Expected
+        # pk value, received bool." — so deferring to it here is what produces the
+        # 400. Removing this guard turns a rejected row into a mis-linked one.
+        # Locked in by test_boolean_fk_is_rejected_not_silently_mislinked.
+        if isinstance(data, bool):
+            return original(data)
+        try:
+            hit = cache.get(data)
+        except TypeError:      # unhashable (dict/list) — let DRF report it
+            hit = None
+        return hit if hit is not None else original(data)
+
+    return to_internal_value
+
+
+def _prefetch_bulk_related(serializer, rows):
+    """Resolve every FK referenced anywhere in the batch in one query per model."""
+    from rest_framework.relations import PrimaryKeyRelatedField
+
+    for name, field in serializer.child.fields.items():
+        if not isinstance(field, PrimaryKeyRelatedField) or field.read_only:
+            continue
+        # Collect one value at a time rather than in a set comprehension: an
+        # unhashable id ({"person": {"id": 5}}) would raise TypeError out of the
+        # comprehension, escape as a 500, and lose the per-index 400 the
+        # single-row path gives for the same input. Skipping the value here
+        # leaves it out of the cache, so _cached_pk_lookup falls through to DRF
+        # and the offending row gets its normal validation error.
+        raw = set()
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            value = row.get(name)
+            if value is None:
+                continue
+            try:
+                raw.add(value)
+            except TypeError:
+                continue
+        if not raw:
+            continue
+        try:
+            objs = {obj.pk: obj for obj in field.get_queryset().filter(pk__in=raw)}
+        except (ValueError, TypeError, DjangoValidationError):
+            # Non-integer ids in the batch — skip the optimisation and let DRF
+            # produce the per-index error for the offending rows.
+            continue
+        if objs:
+            field.to_internal_value = _cached_pk_lookup(field, objs)
+
+
+class _OmopBulkCreateMixin:
+    """Accept a JSON *list* on POST and insert the rows in one batched transaction.
+
+    Motivation: consumers that have already parsed FHIR into OMOP-shaped rows were
+    writing one row per HTTP request (~1,900 requests for a single patient). This is
+    the batch entrance to the same fast internals ``fhir/sync.py::_bulk_insert``
+    uses — batched PK allocation plus ``bulk_create`` — without going through FHIR.
+
+    Semantics (summarised in CLAUDE.md, "Bulk OMOP Row Writes"):
+
+    * A single dict body is untouched and still goes through the normal DRF path.
+    * All-or-nothing: the whole batch shares one ``transaction.atomic()``.
+    * One batch is one person. Mixed-person batches are rejected with 400.
+    * Query count is bounded by a constant, not by the number of rows.
+    * ``bulk_create`` does not fire ``post_save``, so the ``omop_core.signals``
+      receivers that rebuild ``PatientRecord`` never run. The refresh is therefore
+      explicit here — once for the batch instead of once per row. ``?skip_refresh=true``
+      defers it for backfills that will run ``populate_patient_record`` afterwards.
+    """
+
+    def create(self, request, *args, **kwargs):
+        # Checked before request.data, which is what triggers parsing. Chunked
+        # uploads send no CONTENT_LENGTH; there is nothing to check pre-parse in
+        # that case, and the row cap still bounds what gets written.
+        try:
+            declared = int(request.META.get('CONTENT_LENGTH') or 0)
+        except (TypeError, ValueError):
+            declared = 0
+        if declared > OMOP_BULK_MAX_BYTES:
+            return Response(
+                {'detail': (
+                    f'Request body too large: {declared} bytes exceeds the maximum '
+                    f'of {OMOP_BULK_MAX_BYTES} bytes. Split the batch and retry.'
+                ), 'max_bytes': OMOP_BULK_MAX_BYTES},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+        if not isinstance(request.data, list):
+            return super().create(request, *args, **kwargs)
+        return self._bulk_create(request)
+
+    def _bulk_create(self, request):
+        from rest_framework.exceptions import PermissionDenied
+
+        rows = request.data
+        if len(rows) > OMOP_BULK_MAX_ROWS:
+            return Response(
+                {'detail': (
+                    f'Batch too large: {len(rows)} rows exceeds the maximum of '
+                    f'{OMOP_BULK_MAX_ROWS} rows per request. Split the batch and retry.'
+                ), 'max_rows': OMOP_BULK_MAX_ROWS},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+
+        model_name = self.serializer_class.Meta.model.__name__
+        pk_field, model_cls = _MODEL_PK_MAP[model_name]
+
+        # Client-supplied PKs would desynchronise the next_pk_batch accounting
+        # (some rows allocated, some not) — reject rather than half-honour them.
+        pk_errors = [
+            ({pk_field: ['Client-supplied primary keys are not allowed in a bulk '
+                         'request; ids are assigned by the server.']}
+             if isinstance(row, dict) and row.get(pk_field) is not None else {})
+            for row in rows
+        ]
+        if any(pk_errors):
+            return Response(pk_errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # many=True yields positionally-aligned per-index error dicts, so the
+        # operator can tell which of N rows to fix.
+        serializer = self.get_serializer(data=rows, many=True)
+        _prefetch_bulk_related(serializer, rows)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+
+        if not validated:
+            return Response({'created': 0, 'ids': []}, status=status.HTTP_201_CREATED)
+
+        # One batch is one person, by construction on the producer side.
+        people = {attrs.get('person') for attrs in validated}
+        if len(people) > 1:
+            return Response(
+                {'detail': (
+                    'A bulk request must contain rows for exactly one person; '
+                    f'found {len(people)} distinct person values. '
+                    'Split the batch by person and retry.'
+                )},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        person = people.pop()
+        if person is None:
+            return Response(
+                {'detail': 'person is required on every row of a bulk request.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Same authorization the single-row path applies in perform_create, run
+        # once for the batch's single person.
+        org = get_request_org(request)
+        if not is_service_token(request):
+            if org is not None:
+                existing_pi = PatientRecord.objects.filter(person=person).first()
+                if (existing_pi is not None
+                        and existing_pi.organization is not None
+                        and existing_pi.organization != org):
+                    raise PermissionDenied('Person does not belong to your organization.')
+            elif not getattr(request.user, 'is_staff', False):
+                from omop_core.authorization import can_write_patient
+                if not can_write_patient(request.user, person.person_id):
+                    raise PermissionDenied('Access denied.')
+
+        source, source_user_id, reason = _extract_provenance(request)
+        skip_refresh = str(
+            request.query_params.get('skip_refresh', 'false')
+        ).strip().lower() in ('1', 'true', 'yes')
+
+        from omop_core.signals import suppress_patient_record_refresh
+
+        with transaction.atomic():
+            # bulk_create does not fire post_save today, so the per-row refresh
+            # receivers would not run anyway. Suppressing explicitly is the
+            # documented house idiom for bulk writes (omop_core/signals.py) and
+            # keeps "one refresh per batch, never per row" true even if a future
+            # change introduces a per-row save() in here.
+            with suppress_patient_record_refresh():
+                ids = next_pk_batch(model_cls, pk_field, len(validated))
+                instances = []
+                for attrs, pk in zip(validated, ids):
+                    attrs = dict(attrs)
+                    attrs[pk_field] = pk
+                    instances.append(model_cls(**attrs))
+                model_cls.objects.bulk_create(instances)
+
+            # No source supplied means no ProvenanceRecord, matching the single-row
+            # path — inventing a source would make provenance unfalsifiable.
+            if source:
+                ct = ContentType.objects.get_for_model(model_cls)
+                ProvenanceRecord.objects.bulk_create([
+                    ProvenanceRecord(
+                        source=source,
+                        source_user_id=source_user_id or '',
+                        target_patient_id=str(person.person_id),
+                        modification_reason=reason,
+                        organization=org,
+                        content_type=ct,
+                        object_id=pk,
+                    )
+                    for pk in ids
+                ])
+
+            # Deliberately inside the transaction, and deliberately unguarded:
+            # a failing derivation rolls the rows back and 500s rather than
+            # leaving a landed batch with a stale read model, which is the
+            # silent-corruption case this endpoint exists to avoid.
+            #
+            # This is a considered divergence from the single-row path, where
+            # _refresh_for_instance swallows the same exception and logs a
+            # warning (omop_core/signals.py). There, one stale row is a small
+            # blast radius and failing the write would be disproportionate; here
+            # the caller is a pipeline that retries whole batches, so a loud
+            # rollback is both recoverable and the safer default. Callers who
+            # want the rows regardless can pass ?skip_refresh=true and derive
+            # separately.
+            if not skip_refresh:
+                refresh_patient_record(person)
+
+        return Response(
+            {'created': len(ids), 'ids': list(ids)},
+            status=status.HTTP_201_CREATED,
+        )
+
+
 class _ProvenanceMixin:
     """Record provenance on create/update when source headers/body fields are present."""
     def _prov(self, obj):
@@ -4496,26 +4755,32 @@ class _ProvenanceMixin:
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class ConditionOccurrenceViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class ConditionOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ConditionOccurrenceSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = ConditionOccurrence.objects.all()
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'omop_write'
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class DrugExposureViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class DrugExposureViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = DrugExposureSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = DrugExposure.objects.all()
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'omop_write'
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class MeasurementViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class MeasurementViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = MeasurementSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Measurement.objects.all()
     ordering_fields = ['measurement_date', 'measurement_id']
     ordering = ['-measurement_date']
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'omop_write'
 
     def get_queryset(self):
         qs = super().get_queryset()
@@ -4546,17 +4811,21 @@ class MeasurementViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewS
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class ObservationViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class ObservationViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ObservationSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Observation.objects.all()
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'omop_write'
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class ProcedureOccurrenceViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class ProcedureOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ProcedureOccurrenceSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = ProcedureOccurrence.objects.all()
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'omop_write'
 
 
 @method_decorator(csrf_exempt, name='dispatch')

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -15945,3 +15945,570 @@ class WearableUploadEndpointTest(TestCase):
             format='multipart',
         )
         self.assertIn(resp.status_code, [401, 403])
+
+
+# ---------------------------------------------------------------------------
+# Bulk OMOP row write endpoint
+# (contract summarised in CLAUDE.md, "Bulk OMOP Row Writes")
+# ---------------------------------------------------------------------------
+
+class BulkOmopWriteTest(TestCase):
+    """POST a JSON list to the five OMOP clinical CRUD endpoints.
+
+    Consumers that have already parsed FHIR into OMOP rows were writing one row
+    per HTTP request (~1,900 requests for a single patient). These cover the
+    batch entrance: one transaction, batched PK allocation, ordered ids back,
+    and — the part a naive bulk_create silently gets wrong — an explicit
+    PatientRecord refresh, since bulk_create does not fire post_save.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        _make_vocab_fixtures()
+        cls.person = Person.objects.create(person_id=31001)
+        cls.other_person = Person.objects.create(person_id=31002)
+        PatientRecord.objects.create(person=cls.person)
+        PatientRecord.objects.create(person=cls.other_person)
+
+        cls.m_concept = Concept.objects.get(concept_id=3000963)
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+        cls.drug_concept = Concept.objects.get(concept_id=19136160)
+
+        cls.service_identity = Identity.objects.get_or_create(
+            issuer='urn:service', sub='bulk-write-test',
+        )[0]
+        cls.service_identity.set_unusable_password()
+        cls.service_identity.save()
+
+    def setUp(self):
+        from django.core.cache import cache
+        # DRF throttle state lives in the cache and leaks between tests.
+        cache.clear()
+        self.client = APIClient()
+        self.client.force_authenticate(
+            user=self.service_identity, token="service-token"
+        )
+
+    def _rows(self, n, person=None, start_day=0):
+        person = person or self.person
+        base = date(2024, 1, 1)
+        return [
+            {
+                'person': person.person_id,
+                'measurement_concept': self.m_concept.concept_id,
+                'measurement_date': (
+                    base + timedelta(days=start_day + i)).isoformat(),
+                'measurement_type_concept': self.type_concept.concept_id,
+                'value_as_number': 5.0 + i,
+                'measurement_source_value': f'LOCAL-{i}',
+            }
+            for i in range(n)
+        ]
+
+    # --- happy path -------------------------------------------------------
+
+    def test_bulk_post_creates_all_rows_and_returns_ordered_ids(self):
+        """A JSON array creates every row and returns ids in request order."""
+        resp = self.client.post('/api/v1/measurements/', self._rows(3), format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(resp.data['created'], 3)
+        ids = resp.data['ids']
+        self.assertEqual(len(ids), 3)
+        self.assertEqual(len(set(ids)), 3)
+
+        # Ids are positionally aligned with the request rows.
+        for i, mid in enumerate(ids):
+            m = Measurement.objects.get(measurement_id=mid)
+            self.assertEqual(m.measurement_source_value, f'LOCAL-{i}')
+            self.assertEqual(m.person_id, self.person.person_id)
+
+    def test_single_dict_post_still_works(self):
+        """The existing single-row form is unchanged by the list support."""
+        resp = self.client.post('/api/v1/measurements/', {
+            'person': self.person.person_id,
+            'measurement_concept': self.m_concept.concept_id,
+            'measurement_date': '2024-03-01',
+            'measurement_type_concept': self.type_concept.concept_id,
+        }, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        # Single-row responses still serialize the full row, not {created, ids}.
+        self.assertIn('measurement_id', resp.data)
+        self.assertNotIn('created', resp.data)
+
+    def test_bulk_post_works_on_legacy_prefix_too(self):
+        """Extending create() exposes the array form on /api/ as well as /api/v1/."""
+        resp = self.client.post('/api/measurements/', self._rows(2), format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(resp.data['created'], 2)
+
+    def test_all_five_resource_types_accept_a_batch(self):
+        """conditions, drug-exposures, measurements, observations, procedures."""
+        cases = [
+            ('conditions', 'condition_occurrence_id', ConditionOccurrence, {
+                'condition_concept': self.m_concept.concept_id,
+                'condition_start_date': '2024-01-01',
+                'condition_type_concept': self.type_concept.concept_id,
+            }),
+            ('drug-exposures', 'drug_exposure_id', DrugExposure, {
+                'drug_concept': self.drug_concept.concept_id,
+                'drug_exposure_start_date': '2024-01-01',
+                'drug_type_concept': self.type_concept.concept_id,
+            }),
+            ('measurements', 'measurement_id', Measurement, {
+                'measurement_concept': self.m_concept.concept_id,
+                'measurement_date': '2024-01-01',
+                'measurement_type_concept': self.type_concept.concept_id,
+            }),
+            ('observations', 'observation_id', Observation, {
+                'observation_concept': self.m_concept.concept_id,
+                'observation_date': '2024-01-01',
+                'observation_type_concept': self.type_concept.concept_id,
+            }),
+            ('procedures', 'procedure_occurrence_id', ProcedureOccurrence, {
+                'procedure_concept': self.m_concept.concept_id,
+                'procedure_date': '2024-01-01',
+                'procedure_type_concept': self.type_concept.concept_id,
+            }),
+        ]
+        for route, pk_field, model, fields in cases:
+            with self.subTest(route=route):
+                rows = [dict(fields, person=self.person.person_id) for _ in range(2)]
+                resp = self.client.post(
+                    f'/api/v1/{route}/', rows, format='json')
+                self.assertEqual(
+                    resp.status_code, status.HTTP_201_CREATED,
+                    f'{route}: {resp.data}')
+                self.assertEqual(resp.data['created'], 2)
+                self.assertEqual(
+                    model.objects.filter(
+                        **{f'{pk_field}__in': resp.data['ids']}).count(), 2)
+
+    def test_empty_list_is_a_noop(self):
+        resp = self.client.post('/api/v1/measurements/', [], format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(resp.data, {'created': 0, 'ids': []})
+
+    # --- query count ------------------------------------------------------
+
+    def _post_query_count(self, n, start_day, query=''):
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.post(
+                f'/api/v1/measurements/{query}',
+                self._rows(n, start_day=start_day), format='json')
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+            self.assertEqual(resp.data['created'], n)
+        return len(ctx)
+
+    def test_bulk_write_query_count_does_not_scale_with_batch_size(self):
+        """Mirrors test_batched_ingest_does_not_scale_queries_with_bundle_size.
+
+        Measures the write path (skip_refresh=true) so the assertion is about
+        insert behaviour alone: batched PK allocation, one bulk_create, and FK
+        resolution prefetched per column instead of per row. Warmup first so
+        ContentType and other process-level caches are not counted.
+
+        The refresh is excluded deliberately — refresh_patient_record is O(the
+        person's accumulated data) by nature, so it cannot be constant, and
+        covering it here would measure the derivation pipeline rather than this
+        endpoint. test_bulk_write_is_far_cheaper_than_per_row_posts covers the
+        end-to-end cost with the refresh on.
+        """
+        self.client.post(
+            '/api/v1/measurements/?skip_refresh=true',
+            self._rows(1), format='json')
+
+        q_small = self._post_query_count(5, 100, '?skip_refresh=true')
+        q_large = self._post_query_count(40, 200, '?skip_refresh=true')
+        self.assertLess(
+            q_large - q_small, 10,
+            f'query count scaled with batch size: {q_small} queries for 5 rows, '
+            f'{q_large} for 40. Bulk path is falling back to per-row work.')
+
+    def test_bulk_write_is_far_cheaper_than_per_row_posts(self):
+        """End-to-end, refresh included: one batch beats N single-row POSTs.
+
+        This is the claim the endpoint is justified by, so assert it rather than
+        assuming it follows from the write-path test above.
+        """
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
+        n = 20
+        self.client.post('/api/v1/measurements/', self._rows(1), format='json')
+
+        with CaptureQueriesContext(connection) as bulk_ctx:
+            resp = self.client.post(
+                '/api/v1/measurements/', self._rows(n, start_day=100),
+                format='json')
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+
+        with CaptureQueriesContext(connection) as row_ctx:
+            for row in self._rows(n, person=self.other_person, start_day=200):
+                r = self.client.post('/api/v1/measurements/', row, format='json')
+                self.assertEqual(r.status_code, status.HTTP_201_CREATED, r.data)
+
+        self.assertLess(
+            len(bulk_ctx), len(row_ctx),
+            f'bulk write ({len(bulk_ctx)} queries) was not cheaper than '
+            f'{n} single-row POSTs ({len(row_ctx)} queries)')
+
+    # --- transaction / validation ----------------------------------------
+
+    def test_invalid_row_rolls_back_whole_batch_with_per_index_errors(self):
+        """One bad row fails the batch; errors are positionally aligned."""
+        before = Measurement.objects.filter(person=self.person).count()
+        rows = self._rows(3)
+        del rows[1]['measurement_date']
+
+        resp = self.client.post('/api/v1/measurements/', rows, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(resp.data), 3)
+        self.assertEqual(resp.data[0], {})
+        self.assertIn('measurement_date', resp.data[1])
+        self.assertEqual(resp.data[2], {})
+        self.assertEqual(
+            Measurement.objects.filter(person=self.person).count(), before,
+            'a partial batch landed — the whole batch must roll back')
+
+    def test_client_supplied_pk_is_rejected(self):
+        rows = self._rows(2)
+        rows[1]['measurement_id'] = 999999
+        resp = self.client.post('/api/v1/measurements/', rows, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data[0], {})
+        self.assertIn('measurement_id', resp.data[1])
+        self.assertFalse(Measurement.objects.filter(measurement_id=999999).exists())
+
+    def test_mixed_person_batch_is_rejected(self):
+        """One batch is one person; a mixed batch is a client bug, not a merge."""
+        rows = self._rows(2) + self._rows(1, person=self.other_person, start_day=5)
+        before = Measurement.objects.count()
+        resp = self.client.post('/api/v1/measurements/', rows, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('one person', resp.data['detail'])
+        self.assertEqual(Measurement.objects.count(), before)
+
+    # --- limits -----------------------------------------------------------
+
+    def test_over_limit_batch_returns_413_naming_the_maximum(self):
+        from patient_portal.api.views import OMOP_BULK_MAX_ROWS
+        rows = [self._rows(1)[0]] * (OMOP_BULK_MAX_ROWS + 1)
+        before = Measurement.objects.count()
+        resp = self.client.post('/api/v1/measurements/', rows, format='json')
+        self.assertEqual(
+            resp.status_code, status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+        self.assertEqual(resp.data['max_rows'], OMOP_BULK_MAX_ROWS)
+        self.assertIn(str(OMOP_BULK_MAX_ROWS), resp.data['detail'])
+        self.assertEqual(Measurement.objects.count(), before)
+
+    def test_batch_at_exactly_the_limit_is_accepted(self):
+        from patient_portal.api.views import OMOP_BULK_MAX_ROWS
+        rows = self._rows(1) * OMOP_BULK_MAX_ROWS
+        resp = self.client.post(
+            '/api/v1/measurements/?skip_refresh=true', rows, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(resp.data['created'], OMOP_BULK_MAX_ROWS)
+
+    # --- provenance -------------------------------------------------------
+
+    def test_provenance_row_per_created_row_when_source_supplied(self):
+        from omop_core.models import ProvenanceRecord
+        from django.contrib.contenttypes.models import ContentType
+
+        resp = self.client.post(
+            '/api/v1/measurements/', self._rows(4), format='json',
+            HTTP_X_PROVENANCE_SOURCE='EHR_SYNC',
+            HTTP_X_PROVENANCE_USER_ID='etl-run-7',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        ct = ContentType.objects.get_for_model(Measurement)
+        prov = ProvenanceRecord.objects.filter(
+            content_type=ct, object_id__in=resp.data['ids'])
+        self.assertEqual(prov.count(), 4)
+        self.assertEqual({p.source for p in prov}, {'EHR_SYNC'})
+        self.assertEqual({p.source_user_id for p in prov}, {'etl-run-7'})
+        self.assertEqual(
+            {p.target_patient_id for p in prov}, {str(self.person.person_id)})
+
+    def test_no_source_means_no_provenance_rows(self):
+        """Matches single-row behavior — an invented source is unfalsifiable."""
+        from omop_core.models import ProvenanceRecord
+        from django.contrib.contenttypes.models import ContentType
+
+        resp = self.client.post('/api/v1/measurements/', self._rows(3), format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        ct = ContentType.objects.get_for_model(Measurement)
+        self.assertEqual(
+            ProvenanceRecord.objects.filter(
+                content_type=ct, object_id__in=resp.data['ids']).count(),
+            0)
+
+    # --- PatientRecord refresh -------------------------------------------
+
+    def test_bulk_write_refreshes_patient_record_by_default(self):
+        """bulk_create skips post_save, so the refresh must be explicit.
+
+        Without it the rows land but the read model stays stale — invisible to
+        the frontend and to /api/patient-records/.
+        """
+        derived_before = PatientRecord.objects.get(
+            person=self.person).derived_at
+
+        resp = self.client.post('/api/v1/measurements/', self._rows(3), format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+
+        pr = PatientRecord.objects.get(person=self.person)
+        self.assertIsNotNone(
+            pr.derived_at,
+            'PatientRecord was never refreshed after the bulk write')
+        self.assertNotEqual(
+            pr.derived_at, derived_before,
+            'PatientRecord.derived_at did not advance — the read model is stale')
+
+    def _count_refreshes(self, n, query='', start_day=0):
+        """Return how many times refresh_patient_record runs for one bulk POST.
+
+        views.py binds the symbol at module load; omop_core/signals.py imports it
+        lazily inside _refresh_for_instance. Patch both so signal-triggered
+        refreshes are counted too, not just the explicit end-of-batch one.
+        """
+        from unittest import mock
+        from omop_core.services import patient_record_service as prs
+
+        real = prs.refresh_patient_record
+        calls = []
+
+        def counting(person, *a, **kw):
+            calls.append(getattr(person, 'person_id', person))
+            return real(person, *a, **kw)
+
+        with mock.patch('patient_portal.api.views.refresh_patient_record', counting), \
+             mock.patch.object(prs, 'refresh_patient_record', counting):
+            resp = self.client.post(
+                f'/api/v1/measurements/{query}',
+                self._rows(n, start_day=start_day), format='json')
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        return calls
+
+    def test_refresh_runs_once_per_batch_never_per_row(self):
+        """The derivation pipeline must fire once for the batch, not per row.
+
+        refresh_patient_record rebuilds the whole PatientRecord from the person's
+        OMOP data, so a per-row call is what made the single-row path take ~65
+        minutes for one patient. Assert the count is exactly 1 and independent of
+        batch size — measured for real, since the guarantee currently rests on
+        bulk_create not emitting post_save.
+        """
+        for n in (1, 5, 40):
+            with self.subTest(rows=n):
+                calls = self._count_refreshes(n, start_day=n * 3)
+                self.assertEqual(
+                    len(calls), 1,
+                    f'{n}-row batch triggered {len(calls)} refreshes; expected '
+                    f'exactly 1. A per-row refresh has crept back in.')
+                self.assertEqual(calls, [self.person.person_id])
+
+    def test_skip_refresh_true_runs_no_refresh_at_all(self):
+        self.assertEqual(
+            self._count_refreshes(20, '?skip_refresh=true', start_day=500), [])
+
+    def test_skip_refresh_true_defers_the_refresh(self):
+        derived_before = PatientRecord.objects.get(person=self.person).derived_at
+        resp = self.client.post(
+            '/api/v1/measurements/?skip_refresh=true',
+            self._rows(3), format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(Measurement.objects.filter(person=self.person).count(), 3)
+        self.assertEqual(
+            PatientRecord.objects.get(person=self.person).derived_at,
+            derived_before,
+            'skip_refresh=true still refreshed the PatientRecord')
+
+    # --- auth -------------------------------------------------------------
+
+    def test_bulk_write_requires_authentication(self):
+        anon = APIClient()
+        resp = anon.post('/api/v1/measurements/', self._rows(2), format='json')
+        self.assertIn(resp.status_code, [401, 403])
+        self.assertEqual(Measurement.objects.filter(person=self.person).count(), 0)
+
+    def test_boolean_fk_is_rejected_not_silently_mislinked(self):
+        """A JSON boolean FK must 400, never resolve to pk=1.
+
+        bool subclasses int, so the prefetch cache built in _prefetch_bulk_related
+        would return the pk-1 object for `True` — {1: obj}.get(True) is a hit.
+        DRF's own to_internal_value guards against this (it raises TypeError for
+        bool before hitting the queryset), so _cached_pk_lookup must route bools
+        to the original implementation rather than answering from the cache.
+
+        Verified counterfactually: with the bool guard removed this POST returns
+        201 and silently attaches the measurement to person 1.
+        """
+        p1 = Person.objects.create(person_id=1)
+        PatientRecord.objects.create(person=p1)
+
+        row = self._rows(1)[0]
+        row['person'] = True
+        resp = self.client.post('/api/v1/measurements/', [row], format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.data)
+        self.assertIn('person', resp.data[0])
+        self.assertEqual(
+            Measurement.objects.filter(person_id=1).count(), 0,
+            'a boolean FK silently resolved to person_id=1')
+
+    def test_boolean_fk_bulk_matches_single_row_behavior(self):
+        """The bulk path must not be more permissive than the single-row path."""
+        p1 = Person.objects.create(person_id=1)
+        PatientRecord.objects.create(person=p1)
+
+        row = self._rows(1)[0]
+        row['person'] = True
+        single = self.client.post('/api/v1/measurements/', dict(row), format='json')
+        bulk = self.client.post('/api/v1/measurements/', [dict(row)], format='json')
+
+        self.assertEqual(single.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(bulk.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            str(single.data['person'][0]), str(bulk.data[0]['person'][0]),
+            'bulk and single-row disagree on how a boolean FK is reported')
+
+    def test_unhashable_fk_value_errors_per_index_not_500(self):
+        """A dict/list FK id must 400 like the single-row path, not blow up.
+
+        _prefetch_bulk_related builds a set of candidate ids; adding an
+        unhashable value raised TypeError straight out of the comprehension,
+        which DRF does not catch — so the batch 500'd where a single-row POST of
+        the same body returns a clean 400.
+        """
+        for bad in ({'id': 5}, [5], {'nested': {'deep': 1}}):
+            with self.subTest(value=bad):
+                row = self._rows(1)[0]
+                row['person'] = bad
+                resp = self.client.post(
+                    '/api/v1/measurements/', [row], format='json')
+                self.assertEqual(
+                    resp.status_code, status.HTTP_400_BAD_REQUEST, resp.data)
+                self.assertIn('person', resp.data[0])
+
+    def test_unhashable_fk_matches_single_row_status(self):
+        """Bulk must not be worse than single-row for the same malformed body."""
+        row = self._rows(1)[0]
+        row['person'] = {'id': 5}
+        single = self.client.post('/api/v1/measurements/', dict(row), format='json')
+        bulk = self.client.post('/api/v1/measurements/', [dict(row)], format='json')
+        self.assertEqual(single.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(bulk.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_one_bad_fk_does_not_stop_the_others_prefetching(self):
+        """An unhashable id is skipped for caching, not fatal to the batch.
+
+        The valid rows must still validate normally; only the bad row errors.
+        """
+        rows = self._rows(3)
+        rows[1]['person'] = {'id': 5}
+        resp = self.client.post('/api/v1/measurements/', rows, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data[0], {})
+        self.assertIn('person', resp.data[1])
+        self.assertEqual(resp.data[2], {})
+
+    def test_oversized_body_rejected_before_parsing(self):
+        """CONTENT_LENGTH over the byte ceiling returns 413 pre-parse.
+
+        The row cap alone is not a memory guard: DRF's JSONParser reads the WSGI
+        stream directly and never touches HttpRequest.body, so
+        DATA_UPLOAD_MAX_MEMORY_SIZE does not bound a JSON array. Without this
+        check a huge body is fully parsed before the row count can reject it.
+        """
+        from patient_portal.api.views import OMOP_BULK_MAX_BYTES
+
+        resp = self.client.post(
+            '/api/v1/measurements/', self._rows(1), format='json',
+            CONTENT_LENGTH=str(OMOP_BULK_MAX_BYTES + 1))
+        self.assertEqual(
+            resp.status_code, status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, resp.data)
+        self.assertEqual(resp.data['max_bytes'], OMOP_BULK_MAX_BYTES)
+
+    def test_normal_sized_body_is_unaffected_by_the_byte_ceiling(self):
+        resp = self.client.post(
+            '/api/v1/measurements/?skip_refresh=true',
+            self._rows(50), format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(resp.data['created'], 50)
+
+    def test_unknown_fk_id_still_errors_per_index(self):
+        """A cache miss must fall through to DRF's own per-index error."""
+        rows = self._rows(2)
+        rows[1]['measurement_concept'] = 987654321   # no such concept
+        resp = self.client.post('/api/v1/measurements/', rows, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data[0], {})
+        self.assertIn('measurement_concept', resp.data[1])
+
+    def _org_client(self, org, label):
+        """An OAuth2 write-token client scoped to `org`."""
+        from oauth2_provider.models import AccessToken, Application
+        from omop_core.models import ApplicationOrganization
+        from django.utils import timezone as tz
+        import datetime
+
+        user = Identity.objects.create_user(email=f'svc_{label}@test.com', password='x')
+        app = Application.objects.create(
+            name=f'{label} App',
+            client_id=f'{label}-client',
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            user=user,
+        )
+        ApplicationOrganization.objects.create(application=app, organization=org)
+        token = AccessToken.objects.create(
+            user=user, application=app, token=f'{label}-write-token',
+            expires=tz.now() + datetime.timedelta(hours=1),
+            scope='patient/*.write',
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {token.token}')
+        return client
+
+    def test_bulk_write_rejects_cross_org_person(self):
+        """The bulk path re-implements perform_create's org check — prove it runs.
+
+        A batch is authorized once for its single person rather than per row, so
+        this is genuinely separate code from the single-row path and needs its
+        own coverage: an org token must not write to another org's patient.
+        """
+        from omop_core.models import Organization
+
+        org_a = Organization.objects.create(name='Bulk Org A', slug='bulk-org-a')
+        org_b = Organization.objects.create(name='Bulk Org B', slug='bulk-org-b')
+        pr = PatientRecord.objects.get(person=self.person)
+        pr.organization = org_b
+        pr.save()
+
+        before = Measurement.objects.filter(person=self.person).count()
+        resp = self._org_client(org_a, 'bulk-a').post(
+            '/api/v1/measurements/', self._rows(3), format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.data)
+        self.assertEqual(
+            Measurement.objects.filter(person=self.person).count(), before,
+            'cross-org bulk write landed rows')
+
+    def test_bulk_write_allows_same_org_person(self):
+        """The counterpart — the org check must not reject a legitimate write."""
+        from omop_core.models import Organization
+
+        org = Organization.objects.create(name='Bulk Org C', slug='bulk-org-c')
+        pr = PatientRecord.objects.get(person=self.person)
+        pr.organization = org
+        pr.save()
+
+        resp = self._org_client(org, 'bulk-c').post(
+            '/api/v1/measurements/', self._rows(3), format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(resp.data['created'], 3)


### PR DESCRIPTION
The five OMOP clinical CRUD endpoints (conditions, drug-exposures, measurements, observations, procedures) now accept a JSON array on POST, returning {"created": N, "ids": [...]} with ids in request order. Single-dict POSTs are unchanged. Available on both /api/ and /api/v1/.

Consumers that have already parsed FHIR into OMOP rows were writing one row per HTTP request — ~1,892 requests and ~65 minutes for a single patient. This gives them a batch entrance to the same internals fhir/sync.py::_bulk_insert uses, without routing normalized data back through FHIR.

Semantics: all-or-nothing per request; one batch is one person (mixed-person batches are rejected with 400); server-assigned PKs via next_pk_batch; per-index validation errors; 1,000-row limit returning 413; unchanged auth, re-applied once for the batch's single person.

Two things a naive bulk_create gets wrong, both covered by tests:

- bulk_create does not fire post_save, so the omop_core/signals.py receivers that rebuild PatientRecord never run. The refresh is explicit here, once per batch, inside the transaction. Without it the rows land but the read model stays stale — invisible to the frontend and /api/patient-records/. ?skip_refresh=true defers it for backfills.
- DRF resolves FKs with a per-row queryset.get(pk=...), which reintroduces the N+1 at the ORM layer. _prefetch_bulk_related collapses it to one query per FK column: the write path is a flat 15 queries at 5, 40, and 200 rows.

Provenance travels in X-Provenance-Source / X-Provenance-User-Id headers and applies to the whole batch; no source means no ProvenanceRecord, matching single-row behavior rather than inventing an unfalsifiable default. _extract_provenance is guarded against a list body, which has no .get().

Also gives the five viewsets an env-tunable 'omop_write' throttle scope (OMOP_WRITE_THROTTLE_RATE, default 300/minute — the previous effective rate). Without it the 300/minute 'user' bucket becomes the new ceiling for a ~4,100 patient backfill once per-row request overhead is gone. DATA_UPLOAD_MAX_MEMORY_SIZE is pinned explicitly rather than inherited from Django's default by accident.