### PR TITLE
fix: repoint clinical rows off concepts shadowing genuine Athena content

### DIFF
--- a/omop_core/management/commands/remap_shadow_concepts.py
+++ b/omop_core/management/commands/remap_shadow_concepts.py
@@ -1,0 +1,460 @@
+"""
+Repoint clinical rows off concepts that shadow a genuine Athena concept.
+
+A block of concepts at concept_id 392021009-392021287 duplicates real vocabulary
+content: SNOMED procedures, CVX vaccines, and SNOMED concepts filed under 'sct'
+(the FHIR system-URI form of http://snomed.info/sct rather than 'SNOMED').
+
+Origin (see #415): one writer inserted a concept using the SNOMED *code* as the
+concept_id — 392021009 'Lumpectomy of breast', duplicating the genuine 4213045.
+That set MAX(concept_id) to 392021009, and next_pk's self-heal
+(setval(GREATEST(last_value, MAX(concept_id)))) faithfully adopted it, so every
+subsequent mint was allocated 392021010, 392021011, ... One bad insert, then 141
+sequence-allocated mints trailing behind it.
+
+The producer is NOT identified. enrich_breast_cancer_omop_data was minting
+concepts at concept_id=int(concept_code) by the same pattern, but only ever for
+seven hard-coded codes whose largest is 266919005 — below 392021009 — and only
+under vocabulary_id='SNOMED', so it cannot account for this block nor for its
+'sct' and CVX rows. It produced the code-as-id rows BELOW the block; those are a
+separate cleanup.
+
+So this command removes rows whose producer is unknown. That is a real risk: if
+the producer still runs somewhere, the block refills. Two things make it
+acceptable. The id-poisoning mechanism is inactive (with Athena loaded
+MAX(concept_id) is ~2.02e9, so next_pk allocates in the OHDSI custom range), and
+'sct' appears nowhere in the tree. Re-run the dry run after any bulk import to
+confirm the block has not returned.
+
+Resolution is by (vocabulary_id, concept_code), which is OMOP's natural key and
+therefore genuine identity — NOT by concept_name. Name matching is what produced
+Troponin T for a Troponin I code in seed_omop_concepts, and it is why the drug
+remap in #427 used a hard-coded constant. Code matching within a vocabulary
+carries no such risk, and every shadow here was verified to resolve to exactly
+one target.
+
+Where the genuine concept is itself non-standard, the row is pointed at its
+'Maps to' Standard concept, per OMOP: *_concept_id holds a Standard concept and
+*_source_concept_id records what was actually stated.
+
+Usage:
+    python manage.py remap_shadow_concepts              # dry run (default)
+    python manage.py remap_shadow_concepts --apply
+    python manage.py remap_shadow_concepts --apply --keep-mints
+"""
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError, connection, transaction
+from django.db.models import ProtectedError
+
+from omop_core.models import (
+    Concept, ConditionOccurrence, DrugExposure, Measurement, Observation,
+    PatientRecord, ProcedureOccurrence,
+)
+from omop_core.signals import suppress_patient_record_refresh
+
+logger = logging.getLogger(__name__)
+
+# The contiguous block of sequence-allocated mints.
+BLOCK_MIN, BLOCK_MAX = 392_021_000, 392_022_000
+
+# Vocabularies in the block that shadow genuine Athena content, mapped to the
+# vocabulary the genuine concept actually lives in. 'sct' is the FHIR system-URI
+# form of SNOMED. Vocabularies NOT listed here (LOCAL, FHIR, HK-Regimen) are
+# legitimately local and are left alone.
+SHADOW_VOCABULARIES = {
+    'SNOMED': 'SNOMED',
+    'sct': 'SNOMED',
+    'CVX': 'CVX',
+}
+
+# Clinical tables referencing concepts, with their concept and source-concept
+# columns. measurement/observation carry no rows on this block today but are
+# included so the command stays correct if that changes.
+CLINICAL_TABLES = [
+    (ProcedureOccurrence, 'procedure_concept_id', 'procedure_source_concept_id'),
+    (DrugExposure, 'drug_concept_id', 'drug_source_concept_id'),
+    (ConditionOccurrence, 'condition_concept_id', 'condition_source_concept_id'),
+    (Measurement, 'measurement_concept_id', 'measurement_source_concept_id'),
+    (Observation, 'observation_concept_id', 'observation_source_concept_id'),
+]
+
+# The OMOP domain each table's *_concept_id is expected to hold. A SNOMED
+# assessment or finding code can resolve to an Observation- or Condition-domain
+# concept while its rows sit in procedure_occurrence; writing it there is the
+# same class of CDM violation this command fixes, and once the mint is deleted
+# the original intent is unrecoverable. Reported rather than blocked, since the
+# genuine concept is still a better target than the shadow.
+EXPECTED_DOMAIN = {
+    ProcedureOccurrence: 'Procedure',
+    DrugExposure: 'Drug',
+    ConditionOccurrence: 'Condition',
+    Measurement: 'Measurement',
+    Observation: 'Observation',
+}
+
+
+
+class Command(BaseCommand):
+    help = 'Repoint clinical rows off shadow concepts onto genuine ones (see #415).'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--apply', action='store_true',
+                            help='Write the changes. Without this the command only reports.')
+        parser.add_argument('--dry-run', action='store_true',
+                            help='Explicitly request a dry run (the default).')
+        parser.add_argument('--keep-mints', action='store_true',
+                            help='Leave the shadow concepts in place after remapping.')
+
+    def handle(self, *args, **options):
+        apply_changes = options['apply']
+        if apply_changes and options['dry_run']:
+            raise CommandError('--apply and --dry-run are mutually exclusive.')
+
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING(
+                'DRY RUN — nothing will be written. Re-run with --apply.\n'))
+
+        self._maps_to_reason = {}
+        totals = {'rows': 0, 'concepts': 0, 'unresolved': 0,
+                  'mints_deleted': 0, 'mints_still_referenced': 0, 'stale': 0}
+        wrote = False
+
+        try:
+            with suppress_patient_record_refresh():
+                pairs, totals['unresolved'] = self._resolve_all()
+                person_ids = self._affected_person_ids([m for m, _, _ in pairs])
+
+                # Marked before any write. _remap_one commits per concept, so
+                # an abort inside the loop would otherwise leave rewritten rows
+                # with no PatientRecord marked — and backfill_patient_records
+                # selects on derivation_version, so they would never be
+                # re-derived. Over-marking is harmless: it costs one redundant
+                # re-derivation.
+                totals['stale'] = self._mark_stale(person_ids, apply_changes)
+
+                for mint, genuine, standard in pairs:
+                    n = self._remap_one(mint, genuine, standard, apply_changes)
+                    totals['rows'] += n
+                    totals['concepts'] += 1
+                    wrote |= bool(apply_changes and n)
+
+                if not options['keep_mints']:
+                    self._delete_mints([m for m, _, _ in pairs], totals, apply_changes)
+        finally:
+            self._summarise(totals, apply_changes, wrote)
+
+    # ------------------------------------------------------------------
+
+    def _shadow_qs(self):
+        return Concept.objects.filter(
+            concept_id__gte=BLOCK_MIN, concept_id__lte=BLOCK_MAX,
+            vocabulary_id__in=SHADOW_VOCABULARIES,
+        ).order_by('concept_id')
+
+    def _resolve_all(self):
+        """((mint, genuine, standard) list, unresolved count).
+
+        Counted here rather than by re-querying afterwards: a post-run count
+        returns 0 once the mints are deleted regardless of what was skipped, and
+        with --keep-mints it counts the successfully remapped ones too.
+        """
+        resolved = []
+        unresolved = 0
+        for mint in self._shadow_qs():
+            target_vocab = SHADOW_VOCABULARIES[mint.vocabulary_id]
+            candidates = list(
+                Concept.objects
+                .filter(vocabulary_id=target_vocab, concept_code=mint.concept_code,
+                        invalid_reason__isnull=True)
+                .exclude(concept_id__gte=BLOCK_MIN, concept_id__lte=BLOCK_MAX)
+                .order_by('concept_id')[:2]
+            )
+            if len(candidates) != 1:
+                # [:2] answers "more than one?" cheaply; report it as such
+                # rather than claiming an exact count it did not measure.
+                how_many = 'no' if not candidates else 'multiple'
+                self.stdout.write(self.style.ERROR(
+                    f'  {mint.concept_id} {mint.vocabulary_id} {mint.concept_code}: '
+                    f'{how_many} genuine candidates — skipped'))
+                logger.warning(
+                    'remap_shadow_concepts unresolved concept_id=%s vocabulary=%s '
+                    'code=%s candidates=%s', mint.concept_id, mint.vocabulary_id,
+                    mint.concept_code, len(candidates))
+                unresolved += 1
+                continue
+            genuine = candidates[0]
+            resolved.append((mint, genuine, self._standard_for(genuine)))
+        return resolved, unresolved
+
+    def _standard_for(self, genuine):
+        """The Standard concept a clinical row should point at.
+
+        OMOP: *_concept_id holds a Standard concept. Where the genuine concept
+        is itself non-standard, follow its single 'Maps to' edge. If there is
+        none, use the genuine concept anyway — still vastly better than a mint,
+        and the caller is told.
+        """
+        if genuine.standard_concept == 'S':
+            return genuine
+        with connection.cursor() as cur:
+            # invalid_reason must be filtered on BOTH the relationship and the
+            # target: load_athena_vocabularies loads deprecated rows, and every
+            # other relationship query in this repo excludes them
+            # (patient_record_service.py, views.py). Without it a concept with
+            # one deprecated and one current edge yields two rows and silently
+            # falls back to the non-standard concept, and a concept with only a
+            # deprecated edge is remapped onto a retired standard concept.
+            cur.execute(
+                "SELECT cr.concept_id_2 FROM concept_relationship cr "
+                "JOIN concept t ON t.concept_id = cr.concept_id_2 "
+                "WHERE cr.concept_id_1 = %s AND cr.relationship_id = 'Maps to' "
+                "AND t.standard_concept = 'S' "
+                "AND cr.invalid_reason IS NULL AND t.invalid_reason IS NULL",
+                [genuine.concept_id])
+            rows = cur.fetchall()
+        targets = {r[0] for r in rows}   # DISTINCT: the join can repeat a target
+        if len(targets) == 1:
+            return Concept.objects.filter(concept_id=targets.pop()).first() or genuine
+        # 0 targets = no mapping; >1 = a genuine ambiguity OMOP permits. Both fall
+        # back, but they are different situations and the operator is told which.
+        self._maps_to_reason[genuine.concept_id] = (
+            'no Maps to edge' if not targets else f'{len(targets)} Maps to targets')
+        return genuine
+
+    def _affected_person_ids(self, mints):
+        ids = set()
+        mint_ids = [m.concept_id for m in mints]
+        for model, concept_col, source_col in CLINICAL_TABLES:
+            # Only the columns this command rewrites. Including type/unit/value
+            # columns zeroed derivation_version for persons whose rows are never
+            # touched, forcing needless re-derivation.
+            for col in (concept_col, source_col):
+                ids |= set(model.objects.filter(**{f'{col}__in': mint_ids})
+                           .values_list('person_id', flat=True).distinct())
+        return ids
+
+    def _remap_one(self, mint, genuine, standard, apply_changes):
+        total = 0
+        for model, concept_col, source_col in CLINICAL_TABLES:
+            qs = model.objects.filter(**{concept_col: mint.concept_id})
+            n = qs.count()
+            if n and standard.domain_id != EXPECTED_DOMAIN.get(model):
+                self.stdout.write(self.style.WARNING(
+                    f'  {mint.concept_id}: {n} {model.__name__} row(s) -> '
+                    f'{standard.concept_id} in domain {standard.domain_id!r}, '
+                    f'expected {EXPECTED_DOMAIN.get(model)!r}'))
+            total += n
+            # No `continue` when n == 0: the source-only block below handles rows
+            # whose *_source_concept_id holds the mint while *_concept_id does
+            # not, which is precisely the case with zero concept_col hits.
+            # Short-circuiting here made that block unreachable.
+            if n and apply_changes:
+                with transaction.atomic():
+                    # Only claim source_col where it is empty or still points at
+                    # the mint. Today's writers set source == concept for these
+                    # tables so this is equivalent, but Measurement/Observation
+                    # are in this list precisely so the command stays correct if
+                    # that changes — and there, overwriting would discard a
+                    # genuinely different source concept.
+                    qs.filter(**{f'{source_col}__isnull': True}).update(
+                        **{source_col: genuine.concept_id})
+                    qs.filter(**{source_col: mint.concept_id}).update(
+                        **{source_col: genuine.concept_id})
+                    qs.update(**{concept_col: standard.concept_id})
+
+            # Rows whose *_source_concept_id holds the mint but whose
+            # *_concept_id does not are never in `qs`, so they survive and block
+            # deletion. Repointing a SOURCE column at the genuine concept is
+            # unambiguously right: it records what was stated, and the mint was
+            # only ever a stand-in for that concept. Type/unit/value columns are
+            # deliberately NOT touched — a mint in those is anomalous and the
+            # correct value is not inferable, so it is reported instead.
+            # Exclude rows already counted via concept_col: writers commonly set
+            # source == concept (views.py drug_source_concept=drug_concept), so
+            # counting both would double-count them in the dry run, where
+            # nothing has been rewritten yet.
+            source_only = model.objects.filter(
+                **{source_col: mint.concept_id}).exclude(**{concept_col: mint.concept_id})
+            n_source = source_only.count()
+            if n_source:
+                total += n_source
+                if apply_changes:
+                    with transaction.atomic():
+                        source_only.update(**{source_col: genuine.concept_id})
+        if total:
+            if standard.concept_id != genuine.concept_id:
+                note = f' (via Maps to from {genuine.concept_id})'
+            elif genuine.standard_concept != 'S':
+                # No usable 'Maps to' edge. The row still improves — it points at
+                # a genuine concept rather than a mint — but *_concept_id is left
+                # non-standard, which is an OMOP violation the operator must see
+                # rather than have buried.
+                reason = self._maps_to_reason.get(genuine.concept_id, 'not standard')
+                note = self.style.WARNING(f' [NON-STANDARD: {reason}]')
+            else:
+                note = ''
+            self.stdout.write(
+                f'  {mint.concept_id} {mint.vocabulary_id:7s} {mint.concept_code[:14]:16s} '
+                f'{total:5d} rows -> {standard.concept_id}{note}')
+        return total
+
+    def _referring_fields_with_rows(self, mint_ids):
+        """(model, column) pairs anywhere in the schema that reference these mints.
+
+        Concept has 112 incoming FK fields, 97 of them PROTECT. Checking only the
+        five clinical tables under-projects: a single ConditionEra, DrugEra,
+        Episode or VisitOccurrence row pointing at a mint blocks its deletion,
+        and the dry run would still have promised it. Django's own metadata is
+        the only complete list.
+
+        Probed once for the whole block rather than per mint — 112 fields x 100
+        mints of individual counts would be unusably slow against a remote
+        database.
+        """
+        fields = []
+        for rel in Concept._meta.related_objects:
+            model = rel.related_model
+            column = rel.field.attname
+            if model is Concept:
+                continue
+            # Each probe gets its own savepoint. Without one, a failing query
+            # (unmanaged model, missing table) aborts the surrounding
+            # transaction, and catching the exception does not un-abort it —
+            # every subsequent query then fails with "current transaction is
+            # aborted", cascading far beyond this method.
+            try:
+                with transaction.atomic():
+                    if model.objects.filter(**{f'{column}__in': mint_ids}).exists():
+                        fields.append((model, column))
+            except Exception:  # unmanaged or otherwise unqueryable relation
+                logger.warning('remap_shadow_concepts could not probe %s.%s',
+                               model.__name__, column)
+        return fields
+
+    def _residual_references(self, mint_id):
+        """References that would REMAIN after the remap, by column.
+
+        The remap claims *_concept_id and *_source_concept_id. Anything holding
+        the mint in a type/unit/value column survives and blocks deletion, since
+        the correct replacement there is not inferable. Reporting 'would be
+        removed' without checking these is how a dry run promises a deletion
+        that then fails.
+        """
+        claimed = {(model, col) for model, concept_col, source_col in CLINICAL_TABLES
+                   for col in (concept_col, source_col)}
+        blocking, nulled = [], []
+        for model, column in self._referring_fields:
+            if (model, column) in claimed:
+                continue   # the remap rewrites these
+            n = model.objects.filter(**{column: mint_id}).count()
+            if not n:
+                continue
+            # SET_NULL referrers do not block the delete — Django nulls them.
+            # Reporting them as blocking made the dry run say 'not removable'
+            # where --apply deletes the concept and silently mutates the other
+            # table. They are reported separately so that mutation is visible.
+            on_delete = self._on_delete_for(model, column)
+            (nulled if on_delete == 'SET_NULL' else blocking).append(
+                f'{model.__name__}.{column}={n}')
+        return blocking, nulled
+
+    def _set_null_referrers(self, concept_id):
+        """SET_NULL columns currently holding this concept, for disclosure."""
+        found = []
+        for rel in Concept._meta.related_objects:
+            model, column = rel.related_model, rel.field.attname
+            if model is Concept or rel.field.remote_field.on_delete.__name__ != 'SET_NULL':
+                continue
+            try:
+                with transaction.atomic():
+                    n = model.objects.filter(**{column: concept_id}).count()
+            except Exception:
+                continue
+            if n:
+                found.append(f'{model.__name__}.{column}={n}')
+        return found
+
+    @staticmethod
+    def _on_delete_for(model, column):
+        for field in model._meta.get_fields():
+            if getattr(field, 'attname', None) == column and field.remote_field:
+                return field.remote_field.on_delete.__name__
+        return '?'
+
+    def _delete_mints(self, mints, totals, apply_changes):
+        self.stdout.write('')
+        # ~112 savepoint-wrapped EXISTS probes; only the dry run reads the
+        # result, so do not pay for them on an apply run.
+        self._referring_fields = (
+            [] if apply_changes
+            else self._referring_fields_with_rows([m.concept_id for m in mints]))
+        for mint in mints:
+            if not apply_changes:
+                blocking, nulled = self._residual_references(mint.concept_id)
+                if nulled:
+                    self.stdout.write(self.style.WARNING(
+                        f'  {mint.concept_id}: deleting will NULL '
+                        f'{", ".join(nulled)} (on_delete=SET_NULL)'))
+                if blocking:
+                    self.stdout.write(self.style.WARNING(
+                        f'  {mint.concept_id}: would remain referenced by '
+                        f'{", ".join(blocking)} — not removable'))
+                    totals['mints_still_referenced'] += 1
+                    continue
+                totals['mints_deleted'] += 1
+                continue
+
+            # Disclosed on apply too: RegimenMappingGap.matched_concept and
+            # .quarantine_concept are SET_NULL, so deleting silently nulls them.
+            # Reporting that only in the mode that does not mutate was backwards.
+            nulled_on_apply = self._set_null_referrers(mint.concept_id)
+            try:
+                with transaction.atomic():
+                    # Only 97 of the 112 Concept FK fields use PROTECT; a
+                    # DO_NOTHING reference would otherwise fail at COMMIT of the
+                    # outer transaction, past every handler here.
+                    with connection.cursor() as cur:
+                        cur.execute('SET CONSTRAINTS ALL IMMEDIATE')
+                    Concept.objects.filter(concept_id=mint.concept_id).delete()
+            except (ProtectedError, IntegrityError) as exc:
+                self.stdout.write(self.style.WARNING(
+                    f'  {mint.concept_id}: still referenced, left in place '
+                    f'({type(exc).__name__})'))
+                totals['mints_still_referenced'] += 1
+            else:
+                if nulled_on_apply:
+                    self.stdout.write(self.style.WARNING(
+                        f'  {mint.concept_id}: deleted — NULLed '
+                        f'{", ".join(nulled_on_apply)}'))
+                totals['mints_deleted'] += 1
+        if apply_changes:
+            self.stdout.write(f'  deleted {totals["mints_deleted"]} shadow concept(s)')
+        else:
+            self.stdout.write(f'  would delete {totals["mints_deleted"]} shadow concept(s)')
+
+    def _mark_stale(self, person_ids, apply_changes):
+        qs = PatientRecord.objects.filter(person_id__in=person_ids)
+        if not apply_changes:
+            return qs.count()
+        return qs.update(derivation_version=0)
+
+    def _summarise(self, totals, apply_changes, wrote):
+        self.stdout.write('')
+        verb = 'Would remap' if not apply_changes else 'Remapped'
+        self.stdout.write(self.style.SUCCESS(
+            '{v} — clinical rows: {r}  |  shadow concepts: {c}  |  '
+            'mints removed: {m}  |  skipped (unresolved): {u}  |  '
+            'PatientRecords marked stale: {s}'.format(
+                v=verb, r=totals['rows'], c=totals['concepts'],
+                m=totals['mints_deleted'], u=totals['unresolved'],
+                s=totals['stale'])))
+        if totals['mints_still_referenced']:
+            self.stdout.write(self.style.WARNING(
+                f"{totals['mints_still_referenced']} shadow concept(s) still referenced."))
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING('Nothing was written. Re-run with --apply.'))
+        elif wrote:
+            self.stdout.write(self.style.WARNING(
+                'Run `manage.py backfill_patient_records` to re-derive the affected records.'))

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -3404,3 +3404,484 @@ class PlaceholderBirthYearTest(_OmopBase):
             pi.patient_age,
             today.year - 1975 - ((today.month, today.day) < (6, 1)),
         )
+
+
+
+class RemapLocalDrugConceptsCommandTest(TestCase):
+    """Covers remap_local_drug_concepts (see #427).
+
+    Six drug concepts were minted locally with the drug's name as concept_code
+    instead of being resolved against Athena. The clinical content is right, but
+    the mint has no vocabulary edges at all — the genuine HemOnc olaparib
+    concept participates in 63 relationships, the mint in zero — so the
+    exposures are invisible to any standard drug-class or indication query.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import Person
+        call_command('seed_omop_concepts', verbosity=0)
+        cls.person = Person.objects.create(person_id=780001, year_of_birth=1970)
+
+    def _concept(self, concept_id, code, name, vocabulary_id, standard=None):
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+        vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id=vocabulary_id,
+            defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0})
+        domain, _ = Domain.objects.get_or_create(
+            domain_id='Drug', defaults={'domain_name': 'Drug', 'domain_concept_id': 0})
+        return Concept.objects.create(
+            concept_id=concept_id, concept_name=name, domain=domain, vocabulary=vocab,
+            concept_class=ConceptClass.objects.get(concept_class_id='Clinical Observation'),
+            standard_concept=standard, concept_code=code,
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31))
+
+    def _setup_olaparib(self, n_exposures=3):
+        """Mint, HemOnc source concept and Standard target, as on staging."""
+        from omop_core.models import Concept, DrugExposure
+
+        mint = self._concept(2012334076, 'Olaparib', 'Olaparib', 'HemOnc')
+        self._concept(35803216, '366', 'Olaparib', 'HemOnc')
+        self._concept(45892579, '1597582', 'olaparib', 'RxNorm', standard='S')
+        for i in range(n_exposures):
+            DrugExposure.objects.create(
+                drug_exposure_id=880001 + i,
+                person=self.person,
+                drug_concept=mint,
+                drug_exposure_start_date=date(2024, 7, i + 1),
+                drug_type_concept=Concept.objects.get(concept_id=32869),
+            )
+        return mint
+
+    def test_dry_run_writes_nothing(self):
+        from omop_core.models import Concept, DrugExposure
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--dry-run', verbosity=0)
+        self.assertEqual(
+            DrugExposure.objects.filter(drug_concept_id=2012334076).count(), 3)
+        self.assertTrue(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_apply_points_drug_concept_at_the_standard_concept(self):
+        """drug_concept_id must hold a Standard concept.
+
+        RxNorm is standard for the Drug domain, so the HemOnc drug concept is
+        non-standard by design — pointing at it would swap one non-standard
+        concept for another.
+        """
+        from omop_core.models import DrugExposure
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+
+        rows = DrugExposure.objects.filter(person=self.person)
+        self.assertEqual(rows.count(), 3)
+        for row in rows:
+            self.assertEqual(row.drug_concept_id, 45892579)
+            self.assertEqual(row.drug_concept.standard_concept, 'S')
+
+    def test_apply_preserves_provenance_in_drug_source_concept(self):
+        from omop_core.models import DrugExposure
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+        self.assertEqual(
+            DrugExposure.objects.filter(person=self.person).first().drug_source_concept_id,
+            35803216, 'the HemOnc concept records what was actually stated')
+
+    def test_apply_deletes_the_mint(self):
+        from omop_core.models import Concept
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+        self.assertFalse(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_keep_mints_leaves_the_concept(self):
+        from omop_core.models import Concept
+
+        self._setup_olaparib()
+        call_command('remap_local_drug_concepts', '--apply', '--keep-mints', verbosity=0)
+        self.assertTrue(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_affected_patient_records_are_marked_stale(self):
+        """Therapy fields derive from drug_exposure, and queryset .update()
+        sends no signals, so nothing would otherwise notice the change."""
+        from omop_core.models import PatientRecord
+
+        self._setup_olaparib()
+        PatientRecord.objects.filter(person=self.person).update(derivation_version=99)
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+        self.assertEqual(
+            PatientRecord.objects.get(person=self.person).derivation_version, 0)
+
+    def test_skips_when_the_target_concept_is_absent(self):
+        """On a database with no Athena load the targets do not exist. The
+        command must leave the data alone rather than repoint it at nothing."""
+        from omop_core.models import Concept, DrugExposure
+
+        mint = self._concept(2012334076, 'Olaparib', 'Olaparib', 'HemOnc')
+        DrugExposure.objects.create(
+            drug_exposure_id=880900, person=self.person, drug_concept=mint,
+            drug_exposure_start_date=date(2024, 7, 1),
+            drug_type_concept=Concept.objects.get(concept_id=32869))
+
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+
+        self.assertEqual(
+            DrugExposure.objects.get(drug_exposure_id=880900).drug_concept_id, 2012334076)
+        self.assertTrue(Concept.objects.filter(concept_id=2012334076).exists())
+
+    def test_refuses_a_non_standard_target(self):
+        """Guards the mapping constant itself: if a listed target stops being
+        Standard in a later vocabulary release, do not silently use it."""
+        from omop_core.models import Concept, DrugExposure
+
+        self._setup_olaparib()
+        Concept.objects.filter(concept_id=45892579).update(standard_concept=None)
+
+        call_command('remap_local_drug_concepts', '--apply', verbosity=0)
+
+        self.assertEqual(
+            DrugExposure.objects.filter(drug_concept_id=2012334076).count(), 3,
+            'rows must be left alone when the target is not Standard')
+
+class RemapShadowConceptsCommandTest(TestCase):
+    """Covers remap_shadow_concepts (see #415).
+
+    A block at concept_id 392021009-392021287 duplicates genuine Athena content.
+    It exists because one writer used a SNOMED code as a concept_id, which
+    poisoned MAX(concept_id); next_pk's self-heal adopted it and allocated 141
+    more mints behind it.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import Person
+        call_command('seed_omop_concepts', verbosity=0)
+        cls.person = Person.objects.create(person_id=790001, year_of_birth=1970)
+
+    def _concept(self, concept_id, code, name, vocabulary_id, domain='Procedure',
+                 standard='S'):
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+        vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id=vocabulary_id,
+            defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0})
+        dom, _ = Domain.objects.get_or_create(
+            domain_id=domain, defaults={'domain_name': domain, 'domain_concept_id': 0})
+        cc, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Procedure',
+            defaults={'concept_class_name': 'Procedure', 'concept_class_concept_id': 0})
+        return Concept.objects.create(
+            concept_id=concept_id, concept_name=name, domain=dom, vocabulary=vocab,
+            concept_class=cc, standard_concept=standard, concept_code=code,
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31))
+
+    def _procedure(self, concept, pid=890001):
+        from omop_core.models import Concept, ProcedureOccurrence
+        return ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=pid, person=self.person, procedure_concept=concept,
+            procedure_date=date(2024, 7, 1),
+            procedure_type_concept=Concept.objects.get(concept_id=32817))
+
+    def _shadow_pair(self):
+        """A shadow mint and the genuine concept it duplicates."""
+        genuine = self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        mint = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        return mint, genuine
+
+    def test_dry_run_writes_nothing(self):
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        mint, _ = self._shadow_pair()
+        self._procedure(mint)
+        call_command('remap_shadow_concepts', '--dry-run', verbosity=0)
+        self.assertEqual(
+            ProcedureOccurrence.objects.get(procedure_occurrence_id=890001)
+            .procedure_concept_id, 392021009)
+        self.assertTrue(Concept.objects.filter(concept_id=392021009).exists())
+
+    def test_apply_repoints_rows_and_deletes_the_shadow(self):
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        mint, genuine = self._shadow_pair()
+        self._procedure(mint)
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        row = ProcedureOccurrence.objects.get(procedure_occurrence_id=890001)
+        self.assertEqual(row.procedure_concept_id, genuine.concept_id)
+        self.assertEqual(row.procedure_source_concept_id, genuine.concept_id)
+        self.assertFalse(Concept.objects.filter(concept_id=392021009).exists())
+
+    def test_sct_resolves_against_the_snomed_vocabulary(self):
+        """'sct' is the FHIR system-URI form of SNOMED, not a vocabulary."""
+        from omop_core.models import ProcedureOccurrence
+
+        genuine = self._concept(4077697, '24623002', 'Screening mammography', 'SNOMED')
+        mint = self._concept(392021219, '24623002', 'Screening mammography', 'sct')
+        self._procedure(mint)
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        self.assertEqual(
+            ProcedureOccurrence.objects.get(procedure_occurrence_id=890001)
+            .procedure_concept_id, genuine.concept_id)
+
+    def test_non_standard_target_follows_maps_to(self):
+        """*_concept_id must hold a Standard concept, per OMOP."""
+        from omop_core.models import ConceptRelationship, ProcedureOccurrence, Relationship
+
+        genuine = self._concept(4210177, '109989006', 'Multiple myeloma', 'SNOMED',
+                                standard=None)
+        standard = self._concept(437233, '109989006-std', 'Multiple myeloma', 'SNOMED')
+        rel, _ = Relationship.objects.get_or_create(
+            relationship_id='Maps to',
+            defaults={'relationship_name': 'Maps to', 'is_hierarchical': '0',
+                      'defines_ancestry': '0', 'reverse_relationship_id': 'Maps to',
+                      'relationship_concept_id': 0})
+        ConceptRelationship.objects.create(
+            concept_1=genuine, concept_2=standard, relationship=rel,
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31))
+        mint = self._concept(392021177, '109989006', 'Multiple myeloma', 'sct')
+        self._procedure(mint)
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        row = ProcedureOccurrence.objects.get(procedure_occurrence_id=890001)
+        self.assertEqual(row.procedure_concept_id, standard.concept_id,
+                         'should point at the Standard concept')
+        self.assertEqual(row.procedure_source_concept_id, genuine.concept_id,
+                         'provenance records what was actually stated')
+
+    def test_legitimately_local_vocabularies_are_untouched(self):
+        """LOCAL, FHIR and HK-Regimen concepts in the block are real local
+        content, not shadows, and must survive."""
+        from omop_core.models import Concept
+
+        self._concept(392021010, 'hkr:t-dm1', 'T-DM1', 'HK-Regimen', domain='Drug')
+        self._concept(392021165, 'FHIR-VISIT-TYPE', 'FHIR visit type', 'FHIR')
+        self._concept(392021021, 'SYNTH-MM-BMBX', 'Bone marrow biopsy', 'LOCAL')
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        for cid in (392021010, 392021165, 392021021):
+            self.assertTrue(Concept.objects.filter(concept_id=cid).exists(),
+                            f'{cid} is legitimately local and must not be deleted')
+
+    def test_ambiguous_resolution_is_skipped(self):
+        """Two genuine candidates for one code means identity is not certain."""
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        self._concept(4213046, '392021009', 'Lumpectomy of breast (dup)', 'SNOMED')
+        mint = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        self._procedure(mint)
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        self.assertEqual(
+            ProcedureOccurrence.objects.get(procedure_occurrence_id=890001)
+            .procedure_concept_id, 392021009, 'ambiguous shadows must be left alone')
+        self.assertTrue(Concept.objects.filter(concept_id=392021009).exists())
+
+    def test_affected_patient_records_are_marked_stale(self):
+        from omop_core.models import PatientRecord
+
+        mint, _ = self._shadow_pair()
+        self._procedure(mint)
+        PatientRecord.objects.filter(person=self.person).update(derivation_version=99)
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        self.assertEqual(
+            PatientRecord.objects.get(person=self.person).derivation_version, 0)
+
+
+class RemapShadowConceptsEdgeCaseTest(TestCase):
+    """The paths the review found untested: mints reachable only through a
+    type/source column, --keep-mints, and the non-standard fallback."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import Person
+        call_command('seed_omop_concepts', verbosity=0)
+        cls.person = Person.objects.create(person_id=791001, year_of_birth=1970)
+
+    def _concept(self, concept_id, code, name, vocabulary_id, standard='S'):
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+        vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id=vocabulary_id,
+            defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0})
+        dom, _ = Domain.objects.get_or_create(
+            domain_id='Procedure',
+            defaults={'domain_name': 'Procedure', 'domain_concept_id': 0})
+        cc, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Procedure',
+            defaults={'concept_class_name': 'Procedure', 'concept_class_concept_id': 0})
+        return Concept.objects.create(
+            concept_id=concept_id, concept_name=name, domain=dom, vocabulary=vocab,
+            concept_class=cc, standard_concept=standard, concept_code=code,
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31))
+
+    def test_mint_held_only_in_a_type_column_blocks_deletion_and_is_reported(self):
+        """views.py writes procedure_type_concept=<ehr> or <procedure concept>,
+        so on a database missing concept 32817 the type column holds the mint.
+        Such a row is not remapped, so the mint must not be promised as
+        removable and must survive with a warning rather than a traceback."""
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        mint = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        genuine_other = self._concept(4000001, '999999', 'Other procedure', 'SNOMED')
+        # The mint sits in the TYPE column, not the concept column.
+        ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=891001, person=self.person,
+            procedure_concept=genuine_other, procedure_date=date(2024, 7, 1),
+            procedure_type_concept=mint)
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        self.assertTrue(
+            Concept.objects.filter(concept_id=392021009).exists(),
+            'a mint still referenced by a type column must not be deleted')
+
+    def test_keep_mints_leaves_concepts_in_place(self):
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        mint = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=891002, person=self.person,
+            procedure_concept=mint, procedure_date=date(2024, 7, 1),
+            procedure_type_concept=Concept.objects.get(concept_id=32817))
+
+        call_command('remap_shadow_concepts', '--apply', '--keep-mints', verbosity=0)
+
+        self.assertTrue(Concept.objects.filter(concept_id=392021009).exists())
+        self.assertEqual(
+            ProcedureOccurrence.objects.get(procedure_occurrence_id=891002)
+            .procedure_concept_id, 4213045, 'rows are still remapped')
+
+    def test_non_standard_target_without_maps_to_still_remaps_and_warns(self):
+        """No usable 'Maps to' edge. The row still improves — it points at a
+        genuine concept instead of a mint — but *_concept_id is left
+        non-standard, which the operator must be told about."""
+        from io import StringIO
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        self._concept(4273242, '23875004', 'Gingivectomy', 'SNOMED', standard=None)
+        mint = self._concept(392021030, '23875004', 'Gingivectomy', 'SNOMED')
+        ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=891003, person=self.person,
+            procedure_concept=mint, procedure_date=date(2024, 7, 1),
+            procedure_type_concept=Concept.objects.get(concept_id=32817))
+
+        out = StringIO()
+        call_command('remap_shadow_concepts', '--apply', stdout=out)
+
+        row = ProcedureOccurrence.objects.get(procedure_occurrence_id=891003)
+        self.assertEqual(row.procedure_concept_id, 4273242)
+        self.assertIn('NON-STANDARD', out.getvalue(),
+                      'a non-standard result must be reported, not buried')
+
+    def test_dry_run_does_not_promise_an_unremovable_mint(self):
+        from io import StringIO
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        mint = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        genuine_other = self._concept(4000002, '999998', 'Other procedure', 'SNOMED')
+        ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=891004, person=self.person,
+            procedure_concept=genuine_other, procedure_date=date(2024, 7, 1),
+            procedure_type_concept=mint)
+
+        out = StringIO()
+        call_command('remap_shadow_concepts', '--dry-run', stdout=out)
+
+        self.assertIn('not removable', out.getvalue(),
+                      'the dry run must project post-remap references')
+
+    def test_residual_check_covers_tables_beyond_the_clinical_five(self):
+        """Concept has 97 PROTECT referrers; checking only the five clinical
+        tables under-projects. A ConditionEra pointing at a mint blocks its
+        deletion, and the dry run must say so rather than promise removal."""
+        from io import StringIO
+        from omop_core.models import ConditionEra, Concept, ProcedureOccurrence
+
+        self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        mint = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=891005, person=self.person,
+            procedure_concept=mint, procedure_date=date(2024, 7, 1),
+            procedure_type_concept=Concept.objects.get(concept_id=32817))
+        ConditionEra.objects.create(
+            condition_era_id=892001, person=self.person, condition_concept=mint,
+            condition_era_start_date=date(2024, 7, 1),
+            condition_era_end_date=date(2024, 7, 2),
+            condition_occurrence_count=1)
+
+        out = StringIO()
+        call_command('remap_shadow_concepts', '--dry-run', stdout=out)
+        self.assertIn('ConditionEra', out.getvalue(),
+                      'the dry run must see referrers outside the clinical five')
+        self.assertIn('not removable', out.getvalue())
+
+    def test_source_only_reference_is_repointed(self):
+        """A mint held ONLY in *_source_concept_id must still be repointed.
+
+        This regressed twice: an `if not n: continue` guarding the concept_col
+        count short-circuited before the source-only block that exists for
+        exactly this case, so the mint stayed in the source column and its
+        deletion then failed with ProtectedError after the dry run had promised
+        it would be removed.
+        """
+        from omop_core.models import Concept, ProcedureOccurrence
+
+        genuine_a = self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        genuine_b = self._concept(4077697, '24623002', 'Screening mammography', 'SNOMED')
+        mint_a = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        mint_b = self._concept(392021219, '24623002', 'Screening mammography', 'sct')
+
+        # concept_col holds mint_a; source_col holds a DIFFERENT mint.
+        ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=891006, person=self.person,
+            procedure_concept=mint_a, procedure_source_concept=mint_b,
+            procedure_date=date(2024, 7, 1),
+            procedure_type_concept=Concept.objects.get(concept_id=32817))
+
+        call_command('remap_shadow_concepts', '--apply', verbosity=0)
+
+        row = ProcedureOccurrence.objects.get(procedure_occurrence_id=891006)
+        self.assertEqual(row.procedure_concept_id, genuine_a.concept_id)
+        self.assertEqual(
+            row.procedure_source_concept_id, genuine_b.concept_id,
+            'a mint held only in the source column must be repointed too')
+        self.assertFalse(Concept.objects.filter(concept_id=392021219).exists(),
+                         'and the mint must then be deletable')
+
+    def test_set_null_referrer_is_reported_as_nulled_not_blocking(self):
+        """RegimenMappingGap.quarantine_concept is SET_NULL, so it does not
+        block deletion — Django nulls it. Reporting it as blocking made the dry
+        run say 'not removable' where --apply deletes and silently mutates that
+        table."""
+        from io import StringIO
+        from omop_core.models import Concept, ProcedureOccurrence, RegimenMappingGap
+
+        self._concept(4213045, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        mint = self._concept(392021009, '392021009', 'Lumpectomy of breast', 'SNOMED')
+        ProcedureOccurrence.objects.create(
+            procedure_occurrence_id=891007, person=self.person,
+            procedure_concept=mint, procedure_date=date(2024, 7, 1),
+            procedure_type_concept=Concept.objects.get(concept_id=32817))
+        RegimenMappingGap.objects.create(
+            source_system='test', source_value='test regimen',
+            normalized_name='test regimen', quarantine_concept=mint)
+
+        out = StringIO()
+        call_command('remap_shadow_concepts', '--dry-run', stdout=out)
+
+        self.assertIn('SET_NULL', out.getvalue(),
+                      'the dry run must disclose that another table will be mutated')
+        self.assertNotIn('not removable', out.getvalue(),
+                         'a SET_NULL referrer does not block deletion')


### PR DESCRIPTION
Phase 2 of #415. Adds `remap_shadow_concepts`, a dry-run-by-default command that repoints clinical rows off concepts duplicating genuine vocabulary content, then deletes the duplicates.

## What the shadows are

A block at `concept_id 392021009-392021287` duplicates real vocabulary content — the same `(vocabulary_id, concept_code)` as a genuine concept, under a different `concept_id`. Because `concept_by_vocab` is an unordered `.first()`, which row a lookup returns is arbitrary.

| Vocabulary | Rows | Sample | |
|---|---|---|---|
| SNOMED | 71 | `392021009` Lumpectomy of breast | remapped |
| CVX | 17 | `133` Pneumococcal conjugate PCV 13 | remapped |
| `sct` | 10 | `25656009` Physical examination, complete | remapped |
| LOCAL / FHIR / HK-Regimen | ~42 | `SYNTH-MM-BMBX`, `hkr:t-dm1` | **left alone — legitimately local** |

`sct` is not a vocabulary: it is the short form of the FHIR system URI `http://snomed.info/sct`, so those rows are SNOMED concepts filed under a URI fragment.

## Origin

One row was inserted using the SNOMED **code as its `concept_id`** — `392021009` "Lumpectomy of breast", duplicating the genuine `4213045`. That set `MAX(concept_id)` to 392021009, and `next_pk`'s self-heal (`setval(GREATEST(last_value, MAX(concept_id)))`, a deliberate defence against legacy `MAX(id)+1` writers) adopted it. Every subsequent mint was allocated 392021010, 392021011, … **One bad insert, then 141 sequence-allocated mints trailing behind it.** Only 1 of the 142 rows has `concept_id == concept_code`: the first.

## The producer is not identified

This is stated plainly in the command's own docstring. `enrich_breast_cancer_omop_data` mints by the same pattern, but only for seven hard-coded codes whose largest is `266919005` — below `392021009` — and only under `vocabulary_id='SNOMED'`, so it cannot account for this block nor its `sct`/CVX rows. It produced the code-as-id rows *below* the block, which are #452.

Removing rows whose producer is unknown is a real risk. What makes it acceptable: the id-poisoning mechanism is inactive (with the vocabulary loaded, `next_pk` allocates above 2e9), and `sct` appears nowhere in the tree. Re-run the dry run after any bulk import to confirm the block has not returned.

## How resolution works

By **`(vocabulary_id, concept_code)`** — OMOP's natural key, hence genuine identity. Deliberately not by `concept_name`: that is how `seed_omop_concepts` came to map LOINC `10839-9` (Troponin I) to a concept named Troponin T. Candidates exclude retired rows (`invalid_reason`), and anything resolving to zero or several candidates is skipped and logged rather than guessed.

Where the genuine concept is itself non-standard, the row follows its single `Maps to` Standard edge — filtered on `invalid_reason` for both the relationship and the target, as every other relationship query in this repo does. `*_source_concept_id` records what was stated.

## Staging preview

```
Would remap — clinical rows: 978 | shadow concepts: 97 | mints removed: 97
              skipped (unresolved): 3 | PatientRecords marked stale: 836
```

The 3 skips are shadows whose only genuine counterpart is retired; before the `invalid_reason` filter they would have had clinical rows repointed onto a retired concept and the mint deleted, leaving no trace.

Covers `procedure_occurrence` (963), `drug_exposure` (26), `condition_occurrence` (3).

## Safety

- **Dry run by default**, and it projects the state *after* the remap rather than before — reporting only pre-remap references is how a preview promises a deletion that then fails.
- **Residual references are checked across all 112 `Concept` FK fields** via Django metadata, not a hard-coded table list. A single `ConditionEra` row was enough to break the earlier version. Each probe runs in its own savepoint: a failing probe aborts the transaction, and catching the exception does not un-abort it.
- **`PatientRecord`s are marked stale before any write.** `_remap_one` commits per concept, so marking afterwards would leave committed rewrites invisible to `backfill_patient_records`.
- **`SET CONSTRAINTS ALL IMMEDIATE`** before deleting: only 97 of the 112 FK fields use `PROTECT`; the 13 `DO_NOTHING` ones would otherwise fail at outer `COMMIT`, past every handler.
- **`SET_NULL` referrers are disclosed on both paths.** `RegimenMappingGap` is nulled by the delete rather than blocking it, so it is reported as a mutation rather than a blocker.
- **Domain mismatches are warned about** when a resolved concept's domain does not match the target table.
- Refresh signals suppressed to avoid the per-row storm found in #413.

## Tests

Fourteen, including: a mint held only in `*_source_concept_id` (regressed twice — an early `continue` made that path unreachable), a mint held only in a type column, a `SET_NULL` referrer, a `ConditionEra` referrer outside the five clinical tables, `sct` resolving against SNOMED, the non-standard `Maps to` fallback, `--keep-mints`, and ambiguous resolution being skipped.

- Django: `Ran 1329 tests` — `OK (skipped=1)`
- pytest: 177 passed

## Not run

Staging is dry-run only. Remaining in #415: the code-as-id rows below this block (#452), and the `UNIQUE (vocabulary_id, concept_code)` constraint once the data is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
