### PR TITLE
docs: correct wearable OMOP mapping doc and add device-agnostic article

### DIFF
--- a/docs/decision-ready-wearables.md
+++ b/docs/decision-ready-wearables.md
@@ -1,0 +1,492 @@
+# Decision-Ready Wearables: One Clinical Layer Across Every Device
+
+*How PROMOP normalizes consumer wearable data into OMOP CDM v5.4 and LOINC, and why that
+normalization is what turns a step count into something a clinician, a trial coordinator, or a
+model can actually act on.*
+
+> **On scope.** The architecture described here is device-agnostic by construction. Apple Health
+> and Garmin are the two adapters implemented in the codebase today, so they are what this article
+> uses for concrete examples — real HealthKit identifiers, real FIT message names, real concept
+> ids. Fitbit, Whoop, and Oura are planned and fit the same three-layer model without changing
+> anything below the parser boundary. The section
+> [Beyond Apple and Garmin](#beyond-apple-and-garmin-what-a-new-device-actually-costs) sets out
+> precisely what a new device adds and what it doesn't.
+
+---
+
+## The problem is not the data. It's that every vendor has its own of everything.
+
+An Apple Watch, a Garmin Fenix, a Fitbit Charge, a Whoop strap, and an Oura ring all measure
+resting heart rate. They all do it reasonably well. What they do not do is agree on how to say so.
+
+Apple exports an XML record typed `HKQuantityTypeIdentifierRestingHeartRate`. Garmin writes a
+binary FIT file containing a `monitoring_hr_data` message with a `resting_heart_rate` field — and
+on devices that don't emit that message at all, nothing, just an all-day stream of
+`monitoring.heart_rate` samples from which resting HR has to be inferred. Fitbit, Whoop, and Oura
+each serve their own JSON from their own OAuth-gated REST API, with their own field names, their
+own units, and their own opinion about what "daily" means.
+
+None of these identifiers is a clinical vocabulary term. They are product API surfaces, versioned
+on vendor timelines, describing vendor features. `HKQuantityTypeIdentifierAppleExerciseTime` is
+not a concept in any terminology a research warehouse, a trial protocol, or a decision-support
+rule has ever heard of.
+
+The tempting shortcut is to store the vendor payload as-is and sort it out at query time. That
+choice does not remove the problem; it moves it, and multiplies it. Every consumer downstream —
+the eligibility screen, the deterioration alert, the cohort extract — now has to know every
+vendor's vocabulary, unit conventions, aggregation rules, and edge cases. Add a device and every
+one of those consumers changes. Five vendors is not five integrations; it's five integrations
+times every query you will ever write. The vendors' schemas become your schema, and you inherit
+all of their churn.
+
+PROMOP takes the opposite approach: **normalize once, at the edge, into a real clinical
+vocabulary. Nothing downstream ever learns what a `HKQuantityType` is.**
+
+---
+
+## Three layers, one contract
+
+```mermaid
+flowchart TB
+    A["Apple Health<br/>export.zip"] --> AP["parse_apple_health_export<br/><i>_APPLE_TYPE_MAP</i>"]
+    G["Garmin<br/>.fit"] --> GP["parse_garmin_fit<br/><i>FIT message handlers</i>"]
+    F["Fitbit / Whoop / Oura<br/><i>OAuth REST JSON</i>"] -.-> FP["adapter per vendor<br/><i>planned</i>"]
+    AP --> WS["<b>WearableSample</b><br/>(metric_key, date, value)"]
+    GP --> WS
+    FP -.-> WS
+    WS --> C["Concept resolution<br/><i>(vocabulary_id, concept_code)</i><br/>13 LOINC + 4 HK-Wearable"]
+    C --> M["OMOP <b>measurement</b><br/>13 metrics"]
+    C --> O["OMOP <b>observation</b><br/>4 metrics"]
+    M --> PR["<b>PatientRecord</b><br/>21 flat 30-day columns"]
+    O --> PR
+    PR --> D1["Standard of care"]
+    PR --> D2["Trial matching"]
+    PR --> D3["Analytics & models"]
+
+    classDef planned stroke-dasharray:5 5
+    class F,FP planned
+```
+
+**Layer 1 — device adapters.** One adapter per vendor, one output type for all of them.
+`WearableSample` is a three-field tuple: `(metric_key, date, value)`. That is the entire contract
+between the device world and everything else. Vendor vocabulary does not cross this boundary.
+
+The seventeen canonical metric keys are the vocabulary the rest of the system speaks: `steps`,
+`resting_hr`, `hrv_sdnn`, `spo2`, `respiratory_rate`, `sleep_duration`, `vo2_max`, and so on.
+When Apple emits `HKQuantityTypeIdentifierRestingHeartRate` and Garmin emits
+`monitoring_hr_data.resting_heart_rate`, both become `resting_hr` — and from that point they are
+indistinguishable. A Fitbit adapter reading `restingHeartRate` from an activity-heart response, or
+an Oura adapter reading a nightly `lowest_heart_rate`, joins the same key and becomes equally
+indistinguishable. **The same metric is stored identically no matter which device produced it:
+same concept, same units, same table.** A query for resting heart rate never has to know what the
+patient is wearing.
+
+Every parser also collapses to one value per metric per calendar day before returning, using the
+same sum-vs-mean rule. Cumulative quantities (steps, active minutes, sleep, distance, flights,
+energy) are summed; rates and percentages (HR, SpO2, HRV, respiratory rate, walking speed, VO2
+max, body mass) are averaged. The rule is applied identically in every adapter, which is what
+makes a Garmin patient's step count and an Apple patient's step count the same kind of number —
+and what a Fitbit or Oura adapter has to honor to make theirs the same kind too.
+
+**Layer 2 — OMOP `measurement` and `observation`, keyed by LOINC.** Each canonical metric maps to
+exactly one controlled-vocabulary concept. This is the join point between the two adapters, and
+the point at which the data acquires clinical meaning rather than just clinical-adjacent
+plausibility.
+
+**Layer 3 — the `PatientRecord` projection.** Twenty-one flat, pre-aggregated 30-day summary
+columns derived from the OMOP rows. This is the surface that decisions actually read.
+
+---
+
+## Layer 2: the mapping that carries the meaning
+
+Seventeen metrics, thirteen of which have a genuine LOINC code:
+
+| Metric | LOINC | Concept | OMOP table | Unit | Daily aggregation |
+|---|---|---|---|---|---|
+| `steps` | 55423-8 | Number of steps in unspecified time Pedometer | `observation` | `/d` | sum |
+| `active_minutes` | 55411-3 | Exercise duration | `observation` | `min` | sum |
+| `sleep_duration` | 93832-4 | Sleep duration | `observation` | `h` | sum |
+| `flights_climbed` | 100304-5 | Flights climbed [#] Reporting Period | `observation` | `{flights}` | sum |
+| `resting_hr` | 40443-4 | Heart rate --resting | `measurement` | `/min` | mean |
+| `hrv_sdnn` | 80404-7 | R-R interval SD (heart rate variability) | `measurement` | `ms` | mean |
+| `spo2` | 59408-5 | Oxygen saturation in arterial blood by pulse oximetry | `measurement` | `%` | mean |
+| `respiratory_rate` | 9279-1 | Respiratory rate | `measurement` | `/min` | mean |
+| `vo2_max` | 94122-9 | Oxygen consumption (VO2)/body weight | `measurement` | `mL/kg/min` | mean |
+| `distance` | 41953-1 | Walking distance 24 hour Calculated | `measurement` | `km` | sum |
+| `walking_speed` | 41957-2 | Walking speed 24 hour mean Calculated | `measurement` | `km/hr` | mean |
+| `active_energy` | 93819-1 | Calories burned in unspecified time --during activity | `measurement` | `kcal` | sum |
+| `body_mass` | 29463-7 | Body weight | `measurement` | `kg` | mean |
+
+The full table — including every Apple HealthKit type identifier and every Garmin FIT
+message/field that feeds each row — is in
+[wearable-omop-mapping.md](wearable-omop-mapping.md).
+
+### The four metrics LOINC doesn't have
+
+Consumer wearables measure some things clinical terminology has never needed a code for. LOINC
+has no concept for walking step length, walking double-support percentage, heart rate during
+walking, or basal energy expenditure in kcal/day.
+
+The wrong answer is to find the nearest-looking code and use it. The right answer is to mint
+locally — under strict quarantine, so a local concept can never be mistaken for a standard one:
+
+- a dedicated `HK-Wearable` vocabulary, never `LOINC`
+- `source='HealthKey'` on every row, so consumers mirroring the vocabulary tables can filter local
+  content with a single predicate
+- `HK-*`-shaped concept codes
+- `concept_id >= 2,000,000,000` — the range OHDSI reserves for locally-authored concepts, where
+  Athena never allocates
+
+The four mints are allocated contiguously from 2,029,606,350, continuing the project's existing
+`HK-Labs` block. They are visibly, structurally local. Nothing about them can pass for a
+vocabulary release row.
+
+### Why "we mapped it to LOINC" is not the same as "we mapped it correctly"
+
+This is the part that is easy to claim and hard to do, so it is worth being specific about how
+PROMOP got it wrong first.
+
+An earlier version of this mapping table had seventeen codes that all looked like LOINC. Four of
+them resolved, against a full Athena vocabulary load, to entirely unrelated concepts:
+
+| Metric | Code used | What that code actually is |
+|---|---|---|
+| `walking_speed` | 41909-3 | **Deprecated Body mass index (BMI)** |
+| `walking_hr_avg` | 89270-3 | **Body mass index (BMI) [Ratio] Estimated** |
+| `basal_energy` | 41982-0 | **Percentage of body fat Measured** |
+| `active_energy` | 55424-6 | Calories burned — *Pedometer*, an approximate match |
+
+Three more — for step length, double support, and flights climbed — were not valid LOINC at all;
+they simply did not exist in the release.
+
+This is worse than dropping the data. A row with a wrong concept id looks completely valid. Any
+query trusting `measurement_concept_id` — which is to say, any correct OMOP query — reads walking
+speed as BMI and basal energy as body fat percentage, and reports a plausible number.
+
+The fix was not just corrected codes. It was a rule: **every code is verified against Athena's
+`concept_name` before it enters the map, and a metric with no faithful code is minted locally
+rather than approximated.** Six of the seventeen entries changed as a result — four to correct
+codes, three to `HK-Wearable` mints, one (`flights_climbed`) to a code that actually exists.
+
+A companion cleanup command, `purge_broken_wearable_rows`, removes rows written under the old
+mapping. It deletes rather than migrates, on the reasoning that wearable rows are uniquely
+reproducible — re-uploading the device export regenerates them correctly — while a cross-table
+migration silently drops columns that cannot be recovered.
+
+The consistency claim in this article rests entirely on that discipline. Two devices agreeing on
+a code that means the wrong thing is not interoperability.
+
+### Routing follows the vocabulary, not our opinion
+
+Four metrics — steps, active minutes, sleep duration, flights climbed — resolve to
+**Observation-domain** concepts and are written to `observation`. The other thirteen are
+Measurement-domain and go to `measurement`.
+
+The write path does not hard-code that list. It reads `concept.domain_id` at runtime, so routing
+stays correct automatically if a code ever changes. This matters more than it sounds: OMOP's rule
+is that a concept's domain determines its table, and violating it is exactly the kind of local
+shortcut that passes every internal test and then fails Achilles/DQD domain checks the first time
+the data reaches a research warehouse.
+
+The read path is built to be indifferent to the split — it merges `measurement` and `observation`
+rows into a single index keyed by concept code, so a metric reads the same way regardless of which
+table its domain routed it to. Consumers never encode the split either.
+
+### What else happens at write time
+
+Three things that make the OMOP layer trustworthy rather than merely populated:
+
+**Artifact filtering.** Readings outside physiologic bounds are discarded *before* the row is
+created — SpO2 outside 70–100%, resting HR outside 20–300 bpm, HRV outside 1–300 ms. Rejected
+readings are never persisted, so the OMOP tables hold only plausible values. The same bounds are
+applied again on read, so rows written before a bound was tightened cannot leak into a summary.
+
+**Idempotent ingestion.** Dedup is on `(metric_key, date, value)`, checked against whichever table
+the concept's domain routes to. Re-uploading an overlapping export is safe — a patient syncing
+monthly does not accumulate duplicate days.
+
+**Loud failure on unmapped metrics.** If a concept cannot be resolved, the upload logs a warning
+naming the affected metrics and returns `unmapped_samples` and `unmapped_metrics` in the HTTP
+response. Previously it skipped silently, which meant a database missing nine wearable concepts
+returned HTTP 200 with a success count and discarded most of the upload — indistinguishable from
+"the device exported no data."
+
+---
+
+## Beyond Apple and Garmin: what a new device actually costs
+
+Apple and Garmin are the two adapters that exist today. Fitbit, Whoop, and Oura are planned, and
+the reason they are a small piece of work rather than a large one is that the boundary was drawn
+in the right place.
+
+### Transport differs. The contract doesn't.
+
+Apple and Garmin arrive as **file uploads** — an `export.zip` the patient generates from the
+Health app, a `.fit` file pulled from Garmin Connect or a USB-mounted watch. Fitbit, Whoop, and
+Oura are **OAuth-gated cloud APIs**: the patient authorizes once, and the server pulls JSON on a
+schedule.
+
+That is a genuine architectural difference, and it is worth being precise about where it lands.
+It changes how bytes arrive — token storage, refresh handling, scheduled pulls, rate limits,
+revocation — and it changes nothing at all about what an adapter emits. `WearableSample` is
+`(metric_key, date, value)`. It has no opinion about whether those values came out of a zip
+archive or an HTTP response.
+
+So the cloud-API work is real work, but it sits *above* the parser boundary and is shared across
+all three vendors rather than duplicated per vendor. Below the boundary — concepts, tables,
+artifact bounds, aggregation, projection, every downstream query — nothing changes.
+
+### The metrics line up
+
+The canonical metric set was derived from what wearables actually measure, not from what Apple
+and Garmin happen to call things, so the overlap with the other three vendors is high:
+
+| Canonical metric | Fitbit | Whoop | Oura |
+|---|---|---|---|
+| `steps` | ✓ | limited — not a historical Whoop capability | ✓ |
+| `active_minutes` | ✓ (active-zone minutes) | ✓ (strain/activity durations) | ✓ |
+| `resting_hr` | ✓ | ✓ | ✓ (nightly lowest HR) |
+| `hrv_sdnn` | ✓ **but RMSSD** — see below | ✓ **but RMSSD** | ✓ **but RMSSD** |
+| `spo2` | ✓ | ✓ | ✓ |
+| `respiratory_rate` | ✓ | ✓ | ✓ |
+| `sleep_duration` | ✓ | ✓ | ✓ |
+| `active_energy` / `basal_energy` | ✓ | ✓ | ✓ |
+| `distance` | ✓ | — | ✓ (equivalent walking distance) |
+| `flights_climbed` | ✓ | — | — |
+| `vo2_max` | ✓ (cardio fitness score) | — | — |
+| `body_mass` | ✓ (Aria scale) | — | — |
+| `walking_speed`, `walking_step_length`, `walking_double_support_pct`, `walking_hr_avg` | — | — | — |
+
+> This table is a planning sketch of vendor *capability*, not a verified field map. Exact endpoint
+> and field names must be confirmed against each vendor's current API documentation when its
+> adapter is written — which is the same rule already applied to every LOINC code in this system.
+
+Two things fall out of it. First, the four Apple-only gait metrics stay Apple-only: a ring and a
+strap have no way to measure step length or double-support percentage, and no other vendor should
+be mapped onto those concepts to make a column look populated. Second, several vendors will leave
+metrics null — which is not a defect but the exact situation `wearable_coverage_ratio_30d` exists
+to make legible. A Whoop-only patient with no step data is a patient the eligibility screen can
+correctly decline to evaluate on step count, rather than one it silently scores as sedentary.
+
+### HRV is where a careless adapter would repeat the original bug
+
+This is the sharpest example of why the discipline in the previous section matters, and it is
+worth dwelling on because it is so easy to get wrong.
+
+"HRV in milliseconds" is not one measurement. **SDNN** is the standard deviation of the full
+R-R interval series; **RMSSD** is the root mean square of successive differences. They are
+different statistics over the same signal, they respond to different physiology, and they produce
+different numbers from identical data. LOINC 80404-7 — the code this system uses for `hrv_sdnn` —
+is specifically the standard-deviation form.
+
+Apple's identifier is unambiguous: `HKQuantityTypeIdentifierHeartRateVariabilitySDNN`. Fitbit,
+Whoop, and Oura all report RMSSD-derived values. Filing an RMSSD number under the SDNN code
+because both are "HRV in ms" would be precisely the failure this system already made once, when
+walking speed went into a BMI concept: a row that looks entirely valid, that any correct OMOP
+query will read confidently, and that means something other than what it says.
+
+The correct handling is a second canonical metric with its own concept — resolved against Athena
+at implementation time, not aliased onto 80404-7 — and a `PatientRecord` column that does not
+average the two together. That is more work than one adapter line. It is also the difference
+between an interoperability layer and a pile of numbers that share a unit.
+
+> **This applies to code already shipped.** Garmin's HRV Status is documented by Garmin as
+> RMSSD-based, and the existing adapter files `hrv_status_summary.weekly_average` under
+> `hrv_sdnn`. That mapping needs verification before any further HRV work — it may already be the
+> same conflation. Tracked as
+> [#438](https://github.com/healthkey-ai/promop/issues/438), and as Gap G in
+> [wearable-omop-mapping.md](wearable-omop-mapping.md).
+
+### What a new adapter actually changes
+
+Concretely, adding Fitbit touches:
+
+- **a new parser module** emitting `WearableSample` — the substantive work
+- **the `device_type` allow-list** in `upload_wearable`, currently the literal tuple
+  `('garmin', 'apple')`, plus the per-device file-extension validation and parser dispatch beside
+  it — for a cloud vendor, a sync entry point alongside the upload one
+- **the frontend's `detectDeviceType`** and its upload-history label, which today is a two-way
+  ternary that would render any third device as "Apple"
+- **new canonical metrics**, only if the vendor measures something the seventeen don't cover
+  (readiness scores, skin temperature) — each needing a verified concept or a quarantined
+  `HK-Wearable` mint
+
+And it changes none of: the concept map for existing metrics, the domain routing, the artifact
+bounds, the dedup rule, the aggregation logic, the twenty-one `PatientRecord` columns, the trial
+eligibility query, the care-alert thresholds, or any model feature. That asymmetry is the whole
+return on drawing the boundary at three fields.
+
+---
+
+## Layer 3: from OMOP rows to a decision surface
+
+A trial screening query against raw OMOP has to touch, per patient: seventeen metrics × up to
+thirty days × two tables, joined to `concept`, filtered by code, aggregated, and windowed. Per
+patient. For every criterion, in every screen.
+
+So PROMOP materializes the answer. `_get_wearable_data` derives twenty-one flat columns on
+`PatientRecord`, refreshed automatically whenever the underlying OMOP rows change:
+
+| Column | Derivation |
+|---|---|
+| `median_daily_steps_30d` | median of daily step totals |
+| `active_minutes_per_day_30d` | mean of daily active-minute totals |
+| `activity_trend_30d` | first vs. second half of window: `improving` / `stable` / `declining` / `insufficient_data` |
+| `resting_heart_rate_avg_30d` | mean of daily means |
+| `hrv_sdnn_avg_30d` | mean of daily means |
+| `oxygen_saturation_min_30d` | **minimum** valid reading in window |
+| `oxygen_saturation_avg_30d` | mean of daily means |
+| `respiratory_rate_avg_30d` | mean of daily means |
+| `sleep_duration_hours_avg_30d` | mean nightly total |
+| `vo2_max_avg_30d`, `walking_speed_avg_30d`, `distance_km_per_day_30d`, … | 12 further metric summaries |
+| `wearable_last_sync_at` | anchor date of the window |
+| `wearable_coverage_ratio_30d` | valid days ÷ 30 |
+
+Three design decisions in that table are worth pulling out.
+
+**The window anchors on data, not on today.** The 30-day window ends at the most recent day with
+at least seven valid days behind it — not at the current date. A patient who stopped syncing three
+weeks ago yields a summary describing the period they actually wore the device, timestamped
+honestly in `wearable_last_sync_at`, rather than a window that is 70% empty.
+
+**SpO2 is summarized by minimum, not mean.** One reading of 87% is clinically significant in a way
+that a 30-day average of 96% will never reveal. The aggregation function is a clinical judgment,
+not a default.
+
+**Insufficient data is a value, not a null.** `activity_trend_30d` requires seven valid days in
+*each* half of the window and reports `insufficient_data` when it can't. A consumer can
+distinguish "this patient is stable" from "we don't know," which a null cannot express.
+
+### What the projection buys
+
+Against the documented benchmark procedure — a 20-criterion trial eligibility pull, and a full
+`PatientRecord` derivation across all 19 sections:
+
+| Path | Reads from | Relative speedup |
+|---|---|---|
+| 20-criterion trial eligibility row | `PatientRecord` vs. raw OMOP subqueries | **~6.9×** |
+| Full patient record derivation | `PatientRecord` vs. live OMOP derivation | **~46.8×** |
+
+Absolute latencies are hardware- and cache-dependent; the reproducible result is the ratio. The
+full-derivation gap is larger because nineteen sections × multiple queries each compounds the OMOP
+overhead, while the `PatientRecord` read cost is essentially flat regardless of how many fields
+are requested.
+
+The projection is a cache, and it is treated as one: derived columns are read-only over the API,
+written only by the refresh service, so a client cannot PATCH a summary into disagreement with the
+OMOP rows it claims to summarize. (Eleven of the twenty-one columns added most recently still need
+to be added to that read-only list — see Gap E in the mapping document.) The OMOP tables remain
+the system of record. Delete every `PatientRecord` row and the entire projection rebuilds.
+
+---
+
+## Why this is decision-ready
+
+"Decision-ready" is a specific claim: that a consumer can read a value, know what it means, know
+how much to trust it, and act — without knowing anything about the device that produced it.
+
+### Standard of care
+
+Functional decline is one of the strongest signals in oncology, and one of the worst-captured.
+ECOG performance status is assessed at clinic visits, by different clinicians, on a five-point
+scale, weeks apart. Between visits there is nothing.
+
+`median_daily_steps_30d` and `activity_trend_30d` are a continuous, objective proxy measured every
+day the patient wears the device. `activity_trend_30d = 'declining'` on a patient two cycles into
+treatment is a supportive-care conversation that would otherwise have waited for the next visit.
+
+The other summaries map to specific surveillance questions: rising `resting_heart_rate_avg_30d`
+with falling `hrv_sdnn_avg_30d` is a recognized deconditioning and cardiotoxicity pattern relevant
+to anthracycline and HER2-directed therapy. `oxygen_saturation_min_30d < 90` is a pulmonary flag.
+`respiratory_rate_avg_30d` supports infection and pneumonitis escalation.
+
+None of these are diagnoses, and the architecture doesn't pretend otherwise — but they are
+*inputs*, available continuously, in units a protocol can be written against.
+
+### Trial matching
+
+Eligibility criteria are written in clinical language: performance status, cardiopulmonary
+reserve, activity limitation. Screening against raw wearable time series is expensive enough that
+in practice it doesn't happen, so wearable data is simply excluded from pre-screening.
+
+A flat, LOINC-anchored, vendor-neutral projection makes the criterion a column read. And because
+the normalization happened at ingestion, one screening query covers an entire mixed cohort —
+Apple, Garmin, and every vendor added later, screened by identical logic, with no per-vendor
+branch and no vendor covariate. A screening query written today does not change when Fitbit,
+Whoop, and Oura patients start appearing in the cohort.
+
+`wearable_coverage_ratio_30d` is what makes this defensible rather than merely fast. A coordinator
+screening on `median_daily_steps_30d > 4000` can require `wearable_coverage_ratio_30d >= 0.5`
+alongside it, and know the difference between a patient who walks 4,000 steps a day and a patient
+who wore the watch twice.
+
+### Analytics and predictive models
+
+Feature engineering over wearable data is normally a per-vendor ETL problem. Here it isn't: the
+features are already canonical, already unit-normalized, already artifact-filtered, and already
+windowed. A cohort assembled from `PatientRecord` mixes device populations without a vendor
+indicator variable — because device identity was resolved away three layers earlier.
+
+Coverage ratio doubles as a missingness feature, which matters more than it looks: wearable
+adherence is itself correlated with function and with outcome, so a model that treats "no data" as
+"missing at random" is making an assumption the coverage column lets it stop making.
+
+And because the OMOP layer underneath is CDM v5.4-conformant with real LOINC concepts, the same
+cohort exports to an OHDSI research warehouse without a translation step. That is the deeper
+payoff of doing Layer 2 properly: the analytics story isn't PROMOP-specific.
+
+---
+
+## Knowing what you don't have
+
+An honest data layer is measured by what it refuses to assert. This one:
+
+- **discards implausible readings** before they're persisted, and again on read
+- **requires seven valid days** before emitting any 30-day summary column
+- **publishes its own coverage** as a first-class column rather than making consumers infer it
+- **anchors windows to real data**, and timestamps the anchor
+- **distinguishes "insufficient data" from "stable"** with a sentinel value rather than a null
+- **reports unmapped metrics** in the upload response instead of returning a success count
+
+The known limitations are documented rather than papered over. `unit_concept_id` is not yet
+populated (only `unit_source_value`), which standard OMOP consumers read. The measurement type
+concept currently in use resolves to "Survey," which a wearable reading is not. Six metrics are
+Apple-only because the Garmin adapter has no source for them yet — a Garmin patient has permanent
+nulls in six columns. Storage is at daily grain with no `measurement_datetime`, so nocturnal SpO2
+desaturation and circadian HR analyses are out of reach today.
+
+All six are tracked as numbered gaps with proposed fixes in
+[wearable-omop-mapping.md](wearable-omop-mapping.md). A gap you've written down is a roadmap item.
+A gap you haven't is a bug someone else will find in your data.
+
+---
+
+## The shape of the argument
+
+Consumer wearables produce genuinely useful clinical signal in a format no clinical system can
+consume. The instinct is to build vendor integrations. The better move is to build one
+normalization boundary and put every vendor behind it.
+
+PROMOP's boundary is three fields wide — `(metric_key, date, value)` — and everything past it is
+OMOP CDM v5.4 with LOINC concepts, artifact bounds, domain-correct routing, and a flat projection
+with published coverage. Apple and Garmin are behind it today; Fitbit, Whoop, and Oura are the
+next three, and adding each one means writing one adapter. Nothing else in the system changes:
+not the concepts, not the tables, not the projection, not the trial query, not the model features.
+
+The one thing that does not get easier with each vendor is the part that never was easy — deciding
+what a vendor's number actually means before assigning it a concept. That work is per-metric and
+irreducible, and HRV is the standing proof of it.
+
+That is the whole point. Interoperability isn't achieved by supporting many formats. It's achieved
+by having one, and being rigorous about what it means.
+
+---
+
+## Further reading
+
+- [wearable-omop-mapping.md](wearable-omop-mapping.md) — the complete mapping table, Apple and
+  Garmin source fields, artifact bounds, row shape, and open gaps
+- [concept-mapping.md](concept-mapping.md) — general LOINC/SNOMED/HemOnc → OMOP concept resolution
+- [reproducing-benchmark-results.md](reproducing-benchmark-results.md) — benchmark methodology
+- [OMOP2PatientInfo.md](../OMOP2PatientInfo.md) — the full OMOP → `PatientRecord` derivation

--- a/docs/wearable-omop-mapping.md
+++ b/docs/wearable-omop-mapping.md
@@ -5,8 +5,8 @@ How Apple Watch and Garmin metrics are normalized into OMOP CDM v5.4 `measuremen
 
 Companion documents:
 - [concept-mapping.md](concept-mapping.md) — general LOINC/SNOMED/HemOnc → OMOP concept resolution
-- [apple-wearable-patientinfo-fields.md](apple-wearable-patientinfo-fields.md) — the derived
-  `PatientRecord` summary columns that sit *above* this layer
+- [apple-wearable-patientinfo-fields.md](apple-wearable-patientinfo-fields.md) — the original
+  issue proposing the derived `PatientRecord` summary columns that sit *above* this layer
 
 ---
 
@@ -19,9 +19,9 @@ type identifiers; Garmin exports FIT message/field pairs. Both are translated to
 ```
 Apple export.zip ──► parse_apple_health_export ──┐
                      (_APPLE_TYPE_MAP)           │
-                                                 ├──► WearableSample ──► one LOINC ──► Measurement
-Garmin .fit ────────► parse_garmin_fit ──────────┘   (metric_key,        concept        or Observation
-                     (FIT message handlers)           date, value)
+                                                 ├──► WearableSample ──► one concept ──► Measurement
+Garmin .fit ────────► parse_garmin_fit ──────────┘   (metric_key,       (LOINC or       or Observation
+                     (FIT message handlers)           date, value)       HK-Wearable)    (by domain_id)
 ```
 
 `WearableSample` (`omop_core/services/wearable_parsers.py:18`) is the normalization contract —
@@ -30,54 +30,133 @@ identically no matter which device produced it**: same concept, same units, same
 for resting heart rate never has to know whether the patient wears an Apple Watch or a Fenix.
 
 Both parsers reduce to **one value per metric per calendar day** before returning. Cumulative
-metrics (steps, distance, energy, flights, active minutes, sleep) are summed across the day;
-rates and percentages (HR, SpO2, HRV, respiratory rate, speed, step length, double support,
-VO2 max, body mass) are averaged. See `wearable_parsers.py:328` (Garmin) and `:489` (Apple).
+metrics (steps, active minutes, sleep, distance, flights, active energy, basal energy) are summed
+across the day; rates and percentages (HR, SpO2, HRV, respiratory rate, walking speed, step
+length, double support, walking HR, VO2 max, body mass) are averaged. The two parsers share the
+same sum-vs-mean list, at `wearable_parsers.py:328` (Garmin) and `:489` (Apple) — a metric added
+to one must be added to the other.
 
 ---
 
 ## The normalization table
 
-The canonical registry is `WEARABLE_LOINC` in `omop_core/services/mappings.py:91`. One row per
-metric key; the LOINC code is the join point between the two device adapters.
+The canonical registry is `WEARABLE_CONCEPT_CODE` (`omop_core/services/mappings.py:99`). One row
+per metric key; the concept code is the join point between the two device adapters.
 
-| Metric key | LOINC | OMOP table | UCUM unit | Daily agg | Apple HealthKit type | Garmin FIT source |
-|---|---|---|---|---|---|---|
-| `steps` | 55423-8 | measurement | `/d` | sum | `HKQuantityTypeIdentifierStepCount` | `monitoring.steps` → `.cycles`; fallback `session.total_steps`/`total_cycles` |
-| `active_minutes` | 77592-4 | measurement | `min` | sum | `HKQuantityTypeIdentifierAppleExerciseTime` | `monitoring.active_time` ÷ 60; `session.total_timer_time` ÷ 60 |
-| `resting_hr` | 40443-4 | measurement | `/min` | mean | `HKQuantityTypeIdentifierRestingHeartRate` (or derived, below) | `monitoring_hr_data.resting_heart_rate` (or derived, below) |
-| `hrv_sdnn` | 80404-7 | measurement | `ms` | mean | `HKQuantityTypeIdentifierHeartRateVariabilitySDNN` | `hrv_status_summary.weekly_average`/`last_night_average`; `hrv_value.value`; legacy `hrv.sdnn` |
-| `spo2` | 59408-5 | measurement | `%` | mean | `HKQuantityTypeIdentifierOxygenSaturation` | `spo2_data.reading_spo2`; fallback `session.saturated_hemoglobin_percent` |
-| `respiratory_rate` | 9279-1 | measurement | `/min` | mean | `HKQuantityTypeIdentifierRespiratoryRate` | `respiration_rate.respiration_rate`; fallback `session.avg_respiration_rate` |
-| `sleep_duration` | 93832-4 | **observation** | `h` | sum | `HKCategoryTypeIdentifierSleepAnalysis` (asleep spans only) | `sleep_level` timestamp spans; fallback `sleep_data.total_timer_time` ÷ 3600 |
-| `vo2_max` | 94122-9 | measurement | `mL/kg/min` | mean | `HKQuantityTypeIdentifierVO2Max` | `session.enhanced_max_oxygen_consumption` → `vo2_max` |
-| `distance` | 41953-1 | measurement | `km` | sum | `HKQuantityTypeIdentifierDistanceWalkingRunning` | `monitoring.distance` ÷ 1000; `session.total_distance` ÷ 1000 |
-| `walking_speed` | 41909-3 | measurement | `km/hr` | mean | `HKQuantityTypeIdentifierWalkingSpeed` | *(no source — see gaps)* |
-| `walking_step_length` | 96341-8 | measurement | `cm` | mean | `HKQuantityTypeIdentifierWalkingStepLength` | *(no source)* |
-| `walking_double_support_pct` | 96343-4 | measurement | `%` | mean | `HKQuantityTypeIdentifierWalkingDoubleSupportPercentage` | *(no source)* |
-| `walking_hr_avg` | 89270-3 | measurement | `/min` | mean | `HKQuantityTypeIdentifierWalkingHeartRateAverage` | *(no source)* |
-| `flights_climbed` | 96340-0 | measurement | `{flights}` | sum | `HKQuantityTypeIdentifierFlightsClimbed` | *(no source)* |
-| `active_energy` | 55424-6 | measurement | `kcal` | sum | `HKQuantityTypeIdentifierActiveEnergyBurned` | `monitoring.active_calories`; `session.total_calories` |
-| `basal_energy` | 41982-0 | measurement | `kcal` | sum | `HKQuantityTypeIdentifierBasalEnergyBurned` | `monitoring_info.resting_metabolic_rate` |
-| `body_mass` | 29463-7 | measurement | `kg` | mean | `HKQuantityTypeIdentifierBodyMass` | *(no source)* |
+Despite most entries being LOINC, **this map is not LOINC-only** — four metrics have no LOINC
+equivalent and are minted locally under the `HK-Wearable` vocabulary. Concept resolution is
+therefore scoped by `(vocabulary_id, concept_code)` via `WEARABLE_CONCEPT_VOCAB`
+(`mappings.py:122`); a bare `concept_code` is ambiguous, since 852 codes are reused across
+vocabularies.
 
-> ⚠️ **The codes above document what the code does today, not what is correct.** Four resolve to
-> unrelated concepts and three are not valid LOINC at all — see Gap 1 and Gap 1b. Do not copy
-> `walking_speed`, `walking_hr_avg`, `basal_energy`, `flights_climbed`, `walking_step_length`, or
-> `walking_double_support_pct` from this table into new work.
+| Metric key | Code | Vocab | Seeded concept_id | OMOP table | UCUM unit | Daily agg | Apple HealthKit type | Garmin FIT source |
+|---|---|---|---|---|---|---|---|---|
+| `steps` | 55423-8 | LOINC | 40758552 | **observation** | `/d` | sum | `HKQuantityTypeIdentifierStepCount` | `monitoring.steps` → `.cycles` (max — cumulative counter); fallback `session.total_steps`/`total_cycles` |
+| `active_minutes` | 55411-3 | LOINC | 40758540 | **observation** | `min` | sum | `HKQuantityTypeIdentifierAppleExerciseTime` | `monitoring.active_time` ÷ 60; `session.total_timer_time` ÷ 60 |
+| `resting_hr` | 40443-4 | LOINC | 3040891 | measurement | `/min` | mean | `HKQuantityTypeIdentifierRestingHeartRate` (or derived, below) | `monitoring_hr_data.resting_heart_rate` (or derived, below) |
+| `hrv_sdnn` | 80404-7 | LOINC | 21491502 | measurement | `ms` | mean | `HKQuantityTypeIdentifierHeartRateVariabilitySDNN` | `hrv_status_summary.weekly_average`/`last_night_average`; `hrv_value.value`; legacy `hrv.weekly_average`/`sdnn` |
+| `spo2` | 59408-5 | LOINC | 40762499 | measurement | `%` | mean | `HKQuantityTypeIdentifierOxygenSaturation` | `spo2_data.reading_spo2`; fallback `session.saturated_hemoglobin_percent` |
+| `respiratory_rate` | 9279-1 | LOINC | 3024171 | measurement | `/min` | mean | `HKQuantityTypeIdentifierRespiratoryRate` | `respiration_rate.respiration_rate`; fallback `session.avg_respiration_rate` |
+| `sleep_duration` | 93832-4 | LOINC | 1002368 | **observation** | `h` | sum | `HKCategoryTypeIdentifierSleepAnalysis` (asleep spans only) | `sleep_level` timestamp spans; fallback `sleep_data.total_timer_time` ÷ 3600 |
+| `vo2_max` | 94122-9 | LOINC | 1002246 | measurement | `mL/kg/min` | mean | `HKQuantityTypeIdentifierVO2Max` | `session.enhanced_max_oxygen_consumption` → `vo2_max` |
+| `distance` | 41953-1 | LOINC | 3031111 | measurement | `km` | sum | `HKQuantityTypeIdentifierDistanceWalkingRunning` | `monitoring.distance` ÷ 1000; `session.total_distance` ÷ 1000 |
+| `walking_speed` | 41957-2 | LOINC | 3032289 | measurement | `km/hr` | mean | `HKQuantityTypeIdentifierWalkingSpeed` | *(no source — see Gap A)* |
+| `walking_step_length` | HK-WEAR-STEP-LENGTH | **HK-Wearable** | 2029606350 | measurement | `cm` | mean | `HKQuantityTypeIdentifierWalkingStepLength` | *(no source)* |
+| `walking_double_support_pct` | HK-WEAR-DBL-SUPPORT | **HK-Wearable** | 2029606351 | measurement | `%` | mean | `HKQuantityTypeIdentifierWalkingDoubleSupportPercentage` | *(no source)* |
+| `walking_hr_avg` | HK-WEAR-WALK-HR | **HK-Wearable** | 2029606352 | measurement | `/min` | mean | `HKQuantityTypeIdentifierWalkingHeartRateAverage` | *(no source — see Gap A)* |
+| `flights_climbed` | 100304-5 | LOINC | 1761351 | **observation** | `{flights}` | sum | `HKQuantityTypeIdentifierFlightsClimbed` | *(no source — see Gap A)* |
+| `active_energy` | 93819-1 | LOINC | 1001786 | measurement | `kcal` | sum | `HKQuantityTypeIdentifierActiveEnergyBurned` | `monitoring.active_calories`; `session.total_calories` |
+| `basal_energy` | HK-WEAR-BASAL-ENERGY | **HK-Wearable** | 2029606353 | measurement | `kcal` | sum | `HKQuantityTypeIdentifierBasalEnergyBurned` | `monitoring_info.resting_metabolic_rate` |
+| `body_mass` | 29463-7 | LOINC | 3025315 | measurement | `kg` | mean | `HKQuantityTypeIdentifierBodyMass` | *(no source — see Gap A)* |
 
-### Why one metric lands in `observation` and the rest in `measurement`
+Every code here has been verified against Athena to resolve to a concept whose `concept_name`
+matches the metric. Do not add an entry without doing the same check — four codes in the original
+version of this map resolved to BMI and body-fat-percentage concepts, and three were not valid
+LOINC at all. That defect is fixed; the section below explains the rules that keep it fixed.
 
-`sleep_duration` is written to `observation`; everything else to `measurement`
-(`patient_portal/api/views.py:3677`). The split is defensible under OMOP conventions — sleep
-duration is a derived interval describing a state rather than a quantified specimen or
-instrument reading — but it is applied inconsistently today (see Gap 2).
+`spo2` (59408-5 / 40762499) and `body_mass` (29463-7 / 3025315) are seeded in the **vitals** block
+of `seed_omop_concepts`, not the wearable block. They must not be seeded twice — a second row for
+the same `(vocabulary_id, concept_code)` is exactly the duplication the seeding rules exist to
+prevent.
 
-Arguments could be made for moving `active_minutes`, `flights_climbed`, and `steps` to
-`observation` on the same reasoning. The recommendation here is the opposite: **keep everything
-in `measurement` except sleep**, because every non-sleep metric is a numeric quantity with a
-UCUM unit and benefits from `measurement`'s `unit_concept_id`, `range_low`/`range_high`, and
-`operator_concept_id` columns, none of which exist on `observation`.
+### Table routing is by `domain_id`, not by a hard-coded metric list
+
+Four metrics — `steps`, `active_minutes`, `sleep_duration`, `flights_climbed` — resolve to
+**Observation-domain** concepts and are therefore written to `observation`. The other thirteen go
+to `measurement`.
+
+The write path does not hard-code that split. It reads `concept.domain_id` at runtime
+(`patient_portal/api/views.py:3672`), so routing stays correct automatically if a code changes.
+`WEARABLE_OBSERVATION_METRICS` (`mappings.py:131`) mirrors the same four keys, but exists only for
+tests and fixtures — it is not consulted by the runtime writer.
+
+This follows OMOP's own rule: a concept's `domain_id` determines its table. Arguments could be
+made on clinical grounds for placing step counts in `measurement` — every non-sleep metric is a
+numeric quantity with a UCUM unit, and `measurement` alone offers `unit_concept_id`,
+`range_low`/`range_high`, and `operator_concept_id`. But the CDM does not leave that to local
+judgement, and following the vocabulary's domain is what keeps the data passing Achilles/DQD
+domain checks.
+
+The read path is built to be indifferent to the split: `_get_wearable_data` merges `measurement`
+and `observation` rows into a single index keyed by concept code
+(`patient_record_service.py:2547`), so a metric reads the same way regardless of which table its
+domain routed it to.
+
+---
+
+## Local concept minting rules
+
+Where a metric has no LOINC, the local mint **must** follow the project's quarantine convention
+(`omop_core/models.py:566`) — and all four wearable mints do:
+
+- `vocabulary_id='HK-Wearable'` (declared in `seed_omop_concepts._VOCABULARIES`)
+- `source='HealthKey'`
+- an `HK-*`-shaped `concept_code`
+- `concept_id >= 2,000,000,000` — OHDSI reserves that range for locally-authored concepts, and
+  Athena never allocates there
+
+The four ids are allocated contiguously from `_HK_WEARABLE_ID_BASE = 2_029_606_350`
+(`seed_omop_concepts.py:140`), continuing the existing `HK-Labs` block. New wearable mints should
+continue upward from there.
+
+**Never mint a real LOINC code under `vocabulary_id='LOINC'`.** Doing so creates a duplicate
+`(vocabulary_id, concept_code)` pair, and `concept_by_vocab` resolves duplicates arbitrarily
+(`concept_cache.py:39` — `.first()` with no ordering). This is the defect tracked in **#415**.
+
+For codes that Athena *does* own, the rule is:
+
+> **Seed the genuine Athena `concept_id`. Never invent a new one for a code Athena already owns.**
+
+`seed_omop_concepts` applies rows with `get_or_create(concept_id=..., defaults=row)` — keyed on
+`concept_id`. A row seeded with the real id is therefore *created* on a bare database and
+*matches the existing row* on an Athena-loaded one. No duplicate can arise, on any environment, by
+construction. These rows are genuine external concepts, so `source` correctly stays NULL.
+
+Local dev and test databases have no Athena load, so these concepts must be seeded for ingestion
+to work there at all.
+
+### Cleaning up rows written under the old mapping
+
+Six retired `900xxxx` mints (`steps` 9001019 through `sleep_duration` 9001024) were used before
+this mapping was corrected. Rows written under them, and rows carrying a code the old mapping used
+wrongly, are removed by:
+
+```bash
+python manage.py purge_broken_wearable_rows              # dry run (default)
+python manage.py purge_broken_wearable_rows --apply
+python manage.py purge_broken_wearable_rows --apply --keep-mints
+```
+
+The command **deletes rather than migrates**, because wearable rows are reproducible — re-uploading
+the device export regenerates them correctly under the corrected mapping. An earlier
+`remap_wearable_concepts` tried to move rows across tables and silently dropped
+`measurement_datetime`, `is_erroneous`, provider, visit, and the source/unit/value concept columns
+in the process.
+
+It deliberately does **not** match `body_mass` (29463-7) or `spo2` (59408-5) by code: both codes
+were always correct, and both are also written by the vitals and FHIR ingestion paths, so matching
+them would delete non-wearable clinical data. Rows for those two metrics are removed only when
+they sit on a retired mint, which is unambiguous.
 
 ---
 
@@ -92,9 +171,9 @@ that day's all-day heart-rate samples as the proxy (`wearable_parsers.py:310` fo
 `:473` for Apple). The absolute minimum is too noisy; the mean is inflated by activity.
 
 Garmin skips the estimate on any date that already has a `monitoring_hr_data.resting_heart_rate`
-value; Apple only runs the fallback when the export contains **no** `RestingHeartRate` records at
+value. Apple only runs the fallback when the export contains **no** `RestingHeartRate` records at
 all — a coarser condition, so an export with sparse resting-HR coverage gets no fill-in on the
-missing days.
+missing days. Apple additionally requires ≥ 5 heart-rate readings on a day before estimating.
 
 **Sleep duration — span reconstruction.** Apple sums `HKCategoryTypeIdentifierSleepAnalysis`
 records whose value contains `asleep`, discarding `InBed`. Garmin sorts `sleep_level` entries by
@@ -105,9 +184,11 @@ each span at 4h to filter recording gaps. Both attribute the night to the **star
 
 ## Artifact filtering
 
-Values outside `WEARABLE_ARTIFACT_BOUNDS` (`mappings.py:112`) are discarded *before* the OMOP
-row is created (`views.py:3666`) — rejected readings are never persisted, so the OMOP tables
-hold only physiologically plausible values.
+Values outside `WEARABLE_ARTIFACT_BOUNDS` (`mappings.py:136`) are discarded *before* the OMOP
+row is created (`views.py:3710`) — rejected readings are never persisted, so the OMOP tables
+hold only physiologically plausible values. The same bounds are applied again on the read path
+(`patient_record_service.py:2564`), so rows written before a bound was tightened cannot leak into
+a summary.
 
 | Metric | Lower | Upper | Metric | Lower | Upper |
 |---|---|---|---|---|---|
@@ -125,186 +206,106 @@ hold only physiologically plausible values.
 
 ## Row shape written today
 
-Per `views.py:3679` (observation) and `:3711` (measurement):
+Per `views.py:3725` (observation) and `:3738` (measurement):
 
 | Column | Value | Notes |
 |---|---|---|
-| `person_id` | uploading patient's Person | |
-| `measurement_concept_id` / `observation_concept_id` | LOINC concept via `_cc_by_loinc()` | **skipped entirely if unresolved** |
-| `measurement_date` / `observation_date` | sample date | date only; no `_datetime` |
-| `*_type_concept_id` | 32883, falling back to 32856 | see Gap 4 |
+| `person_id` | uploading patient's Person | resolved from `request.user` via `PatientUser` |
+| `measurement_concept_id` / `observation_concept_id` | concept via `_cc_by_vocab(vocab, code)` | skipped if unresolved, but **logged and counted** |
+| `measurement_date` / `observation_date` | sample date | date only; no `_datetime` — Gap D |
+| `*_type_concept_id` | 32883, falling back to 32856 | both wrong — Gap C |
 | `value_as_number` | daily aggregate, rounded to 2dp | |
-| `*_source_value` | the LOINC code string | lets `_get_wearable_data` match rows whose concept FK is null |
-| `unit_source_value` | UCUM string from the table above | `unit_concept_id` **not set** — Gap 3 |
+| `*_source_value` | the concept code string | lets `_get_wearable_data` match rows whose concept FK is null |
+| `unit_source_value` | UCUM string from the table above | `unit_concept_id` **not set** — Gap B |
 
-Dedup is `(metric_key, date, round(value, 2))` against existing rows (`views.py:3671`), so
-re-uploading an overlapping export is safe. Rows carry `_skip_patient_record_refresh = True` and
-`refresh_patient_record(person)` is called once after the bulk insert.
+Unresolvable concepts are reported rather than dropped silently: `upload_wearable` logs a WARNING
+at `views.py:3629` naming the affected metrics, and the HTTP response carries `unmapped_samples`
+and `unmapped_metrics` alongside `samples_created` and `duplicates_skipped`. A missing concept is
+therefore distinguishable from "the device exported no data for this metric" — previously the two
+were identical, and every local dev database silently discarded nine metrics while returning
+HTTP 200 with a success count.
 
-The read path (`patient_record_service._get_wearable_data`, `:2473`) matches on **either**
-`measurement_concept__concept_code` **or** `measurement_source_value`, then requires
-`WEARABLE_MIN_VALID_DAYS` (7) distinct valid days before emitting a `PatientRecord` column.
+Dedup is `(metric_key, date, round(value, 2))` against existing rows (`views.py:3715`), reading
+whichever table the concept's domain routes it to, so re-uploading an overlapping export is safe.
+Rows carry `_skip_patient_record_refresh = True` and `refresh_patient_record(person)` is called
+once after the bulk insert. Each upload is recorded in `WearableUpload` for patient-visible
+history.
+
+---
+
+## The `PatientRecord` projection above this layer
+
+`_get_wearable_data` (`patient_record_service.py:2484`) turns the daily OMOP rows into 21 flat
+30-day summary columns on `PatientRecord` (`models.py:2420-2440`). The rules:
+
+- **Row matching** is on **either** `*_concept__concept_code` **or** `*_source_value`, so a row
+  whose concept FK is null or unmapped is still read.
+- **Recency window.** Only rows from the last 90 days are considered; if none exist, the query
+  re-runs unbounded so historical or synthetic data still produces a summary.
+- **Anchor date.** The window is the 30 days ending at the most recent day that has at least
+  `WEARABLE_MIN_VALID_DAYS` (7) valid days behind it. If no such day exists, the latest valid day
+  is used. `wearable_last_sync_at` records the anchor.
+- **Coverage.** `wearable_coverage_ratio_30d` is the union of valid days across all metrics ÷ 30,
+  so a consumer can judge whether the other 19 columns are trustworthy.
+- **Aggregation.** Median for steps; mean of daily means for rates; mean of daily totals for
+  cumulative metrics; `min` for `oxygen_saturation_min_30d`, since one low SpO2 reading is
+  clinically significant in a way an average is not.
+- **Trend.** `activity_trend_30d` compares the mean daily steps of the window's first and second
+  halves, requiring ≥ 7 valid days in *each* half; ≥ +10% is `improving`, ≤ −10% is `declining`,
+  otherwise `stable`. It defaults to `insufficient_data` rather than null.
 
 ---
 
 ## Gaps and proposed work
 
-> **Environments audited.** All findings below were verified against **staging**
+> **Environments.** Concept resolution claims here were verified against **staging**
 > (`ctomop_dev`, `promop-staging.onrender.com`, full Athena load: 1,979,424 concepts /
 > 277,790 LOINC rows) and against local `promop_dev` (partial `seed_omop_concepts` set only).
-> Staging is the reference environment for this work. Production trails the `dev` branch by a
-> long way and is reconciled by a separate `dev` → `main` merge; it is out of scope here and is
-> not a prerequisite for any fix below.
+> Staging is the reference environment for this work.
 >
 > Note that CLAUDE.md's Database Selection table is stale: it references a `STAGING_DATABASE_URL`
 > that is not defined in `.env`, and a production host that does not match the one `DATABASE_URL`
 > actually points at — which is staging (`ctomop_dev`).
 
-### Gap 1 — four LOINC codes resolve to unrelated concepts (blocking)
+### Gap A — Garmin has no adapter for six metrics
 
-Where a full Athena vocabulary is loaded, 14 of 17 codes resolve — but four resolve to the
-**wrong concept**, so wearable data is filed under unrelated clinical meanings:
+`walking_speed`, `walking_step_length`, `walking_double_support_pct`, `walking_hr_avg`,
+`flights_climbed`, and `body_mass` are Apple-only today. The normalization design is sound — these
+are canonical metrics with a concept and a unit — but Garmin contributes nothing, so a Garmin-only
+patient has permanent nulls in six `PatientRecord` columns.
 
-| Metric | Code in `WEARABLE_LOINC` | What it actually is |
-|---|---|---|
-| `walking_speed` | 41909-3 | **Deprecated Body mass index (BMI)** — also `standard_concept=None` |
-| `walking_hr_avg` | 89270-3 | **Body mass index (BMI) [Ratio] Estimated** |
-| `basal_energy` | 41982-0 | **Percentage of body fat Measured** |
-| `active_energy` | 55424-6 | Calories burned in unspecified time **Pedometer** — approximate |
+FIT sources exist for four of them and should be added to `parse_garmin_fit`:
 
-This is worse than dropping the data: the rows look valid, and any query trusting
-`measurement_concept_id` reads walking speed and basal energy as BMI and body fat.
-
-Verified replacements: `walking_speed` → **41957-2** (Walking speed 24 hour mean Calculated,
-std=S) — same 419xx family as `distance` 41953-1, which is correct, suggesting a mis-picked
-neighbour; `flights_climbed` → **100304-5** (Flights climbed [#] Reporting Period, std=S).
-For `basal_energy` the only candidate is 50042-1 "Basal metabolic rate **index**", which may not
-be kcal/day — review before adopting.
-
-### Gap 1b — three codes are not valid LOINC, and minting must be quarantined
-
-`96340-0`, `96341-8`, `96343-4` do not exist in the loaded release. This is not a vocabulary
-vintage problem — 111 concepts in the `963xx` range are present, and searching LOINC for
-`step length` or `double support` returns nothing at all.
-
-Where a metric has no LOINC, the local mint **must** follow the project's quarantine convention
-(`omop_core/models.py:566`): `source='HealthKey'`, in an `HK-*` vocabulary, with an `HK-*`-shaped
-`concept_code`. A new `HK-Wearable` vocabulary is the right home for `walking_step_length`,
-`walking_double_support_pct`, and `walking_hr_avg`.
-
-**Never mint a real LOINC code under `vocabulary_id='LOINC'`.** Doing so creates a duplicate
-`(vocabulary_id, concept_code)` pair, and `concept_by_loinc` resolves duplicates arbitrarily
-(`concept_cache.py:39`, `.first()` with no ordering). All six existing wearable mints
-(9001019–9001024) already collide with genuine Athena concepts this way, and all 24 `900xxxx`
-mints are written `source=NULL` because `seed_omop_concepts._c()` has no `source` parameter.
-Tracked separately in **#415** — 115 duplicate pairs table-wide.
-
-### How to seed wearable concepts correctly
-
-Local dev and test databases have no Athena load, so the concepts must be seeded for ingestion to
-work there at all. The rule that keeps that safe:
-
-> **Seed the genuine Athena `concept_id`. Never invent a new one for a code Athena already owns.**
-
-`seed_omop_concepts` applies rows with `get_or_create(concept_id=..., defaults=row)` — keyed on
-`concept_id`. So a row seeded with the real id is *created* on a bare database and *matches the
-existing row* on an Athena-loaded one. No duplicate can arise, on any environment, by
-construction. These rows are genuine external concepts, so `source` correctly stays NULL.
-
-Minting a fresh `900xxxx` id for the same code is what produces the duplicate pair and the
-arbitrary resolution described in #415.
-
-| Metrics | Action |
+| Metric | Candidate FIT source |
 |---|---|
-| The 11 codes that are already correct | Seed the real Athena concept_id |
-| `walking_speed`, `flights_climbed` | Correct the code first (41957-2, 100304-5), then seed the real id |
-| `basal_energy` | Resolve the correct code first — 41982-0 is body-fat-percentage |
-| `walking_step_length`, `walking_double_support_pct`, `walking_hr_avg` | No LOINC exists — mint in `HK-Wearable`, `source='HealthKey'`, `HK-*` concept_code, **concept_id ≥ 2e9** |
-| Existing 9001019–9001024 | Retire; remap dependent `measurement`/`observation` FKs to the Athena ids |
+| `flights_climbed` | `monitoring.ascent` / `total_ascent` (metres → flights, ÷ ~3.05 m) |
+| `walking_speed` | `session.avg_speed` / `enhanced_avg_speed` on walk-type sessions (m/s → km/hr) |
+| `walking_hr_avg` | `session.avg_heart_rate` filtered to walking sport type |
+| `body_mass` | `weight_scale.weight` (Garmin Index scale) or `user_profile.weight` |
 
-This also requires adding a `source` parameter to `_c()` (`seed_omop_concepts.py:94`), which
-currently cannot express `'HealthKey'` at all.
+`walking_step_length` and `walking_double_support_pct` have no FIT equivalent — Garmin's Running
+Dynamics reports ground contact time and vertical oscillation, which are not the same
+measurements and should **not** be mapped onto these concepts. Leave them Apple-only.
 
-#### Minted concept_ids must sit in the OHDSI custom range
-
-OHDSI reserves **`concept_id >= 2,000,000,000`** for locally-authored concepts; Athena never
-allocates there. This repo already follows the convention for `HK-Labs`, but not for the
-`900xxxx` seed mints.
-
-Staging allocation:
-
-| Range | Rows | Note |
-|---|---|---|
-| 2,006,492,703 – 2,022,763,720 | 6 | HemOnc, `source=NULL` — local rows in an external vocabulary |
-| 2,029,606,278 | 1 | LOINC, `source=NULL` — same anti-pattern |
-| 2,029,606,279 – 2,029,606,349 | 71 | `HK-Labs` — the contiguous local block |
-| — | — | global max `concept_id` = **2,029,606,349** |
-
-**New `HK-Wearable` concepts should be allocated from 2,029,606,350 upward**, continuing the
-`HK-Labs` block.
-
-The `900xxxx` range is unsafe: non-mint concept_ids in staging span `0 → 2,029,606,349`, so
-`900xxxx` falls inside the space Athena actually uses. Those ids risk a primary-key collision on
-a future vocabulary load, independently of the `(vocabulary_id, concept_code)` duplication.
-
-All **24** `900xxxx` mints are `vocabulary_id='LOINC'`. Six are the wearable concepts retired
-above; the remaining 18 (labs, GFR, electrolytes) carry the same defect and need the same
-treatment — seed the genuine Athena id where one exists, otherwise relocate above 2e9 under an
-`HK-*` vocabulary. Out of scope for the wearable work, but tracked in #415.
-
-Relocation is not an `UPDATE` of `concept_id`: it is the primary key, referenced by
-`measurement`, `observation`, and other FKs. Retiring a mint means inserting/resolving the
-replacement, remapping every referencing row, then deleting the old concept.
-
-**Guard to add:** a test asserting that every concept with `source='HealthKey'` has
-`concept_id >= 2e9` and lives in an `HK-*` vocabulary — and conversely that no row in an
-externally-loaded vocabulary carries `source='HealthKey'`.
-
-### Gap 1c — unresolvable concepts are skipped silently
-
-`views.py:3661`:
-
-```python
-concept = loinc_concepts.get(sample.metric_key)
-if concept is None:
-    continue
-```
-
-No log, no counter. On a database seeded only by `seed_omop_concepts` — which is every local dev
-and test database — nine metrics have no concept at all and are discarded while the upload still
-returns HTTP 200 with a success count. The failure is indistinguishable from "the device
-exported no data". This should log at WARNING and return an `unmapped_metrics` count.
-
-### Gap 2 — `sleep_duration` domain contradicts its write target
-
-Seeded as `domain_id='Measurement'` (`seed_omop_concepts.py:275`) but written to `observation`
-(`views.py:3677`). OMOP convention is that a concept's `domain_id` determines its table, so this
-row violates the CDM's own routing rule and will fail Achilles/DQD domain checks.
-
-Genuine Athena 93832-4 (concept_id 1002368) carries `domain_id='Observation'`, which **confirms
-the write target is correct and the local seed is the wrong side**. Seeding the real concept_id
-per the recipe above fixes this automatically — the hand-written `Measurement` domain disappears
-along with the mint.
-
-### Gap 3 — `unit_concept_id` is never populated
+### Gap B — `unit_concept_id` is never populated
 
 Only `unit_source_value` is set. Standard OMOP consumers, and any downstream ETL to a research
 warehouse, read `unit_concept_id`.
 
-**Proposed:** add a `WEARABLE_UNIT_CONCEPT` dict in `mappings.py` beside `WEARABLE_LOINC`,
+**Proposed:** add a `WEARABLE_UNIT_CONCEPT` dict in `mappings.py` beside `WEARABLE_CONCEPT_CODE`,
 resolve it once at upload, and set `unit_concept_id`. The UCUM strings needing a concept are
 `%`, `/min`, `ms`, `kcal`, `kg`, `min`, `h`, `km`, `cm`, `km/hr`, `mL/kg/min`, `/d`, and
 `{flights}`.
 
-Every one of these must be looked up in Athena rather than hard-coded from memory. The UCUM
-units are not currently loaded in `promop_dev` — the standard unit vocabulary is absent from the
+Every one of these must be looked up in Athena rather than hard-coded from memory. The UCUM units
+are not currently loaded in `promop_dev` — the standard unit vocabulary is absent from the
 partial Athena load — so this work depends on `load_athena_vocabularies` having been run with
 the unit domain included. Confirm each id against the loaded `concept` table before writing it
 into `mappings.py`.
 
-### Gap 4 — type concept 32883 is unverified
+### Gap C — type concept 32883 is wrong
 
-`views.py:3625` uses concept 32883 with a comment reading "wearable device = 32883 / Patient
+`views.py:3635` uses concept 32883 with a comment reading "wearable device = 32883 / Patient
 self-report", falling back to 32856. Both are wrong:
 
 | Concept | Actual `concept_name` (staging) |
@@ -316,52 +317,126 @@ A wearable reading is neither a survey response nor a laboratory result. Worse, 
 from any database seeded only by `seed_omop_concepts` (verified on `promop_dev`), so the fallback
 fires there and wearable rows are typed `Lab` outright.
 
-**Proposed:** identify the correct device/EHR-derived type concept in Athena, seed it by its real
-concept_id, and drop the silent fallback in favour of an explicit failure — mislabelling
+**Proposed:** identify the correct device/patient-generated type concept in Athena, seed it by its
+real concept_id, and drop the silent fallback in favour of an explicit failure — mislabelling
 provenance is worse than refusing to write.
 
-### Gap 5 — Garmin has no adapter for six metrics
-
-`walking_speed`, `walking_step_length`, `walking_double_support_pct`, `walking_hr_avg`,
-`flights_climbed`, and `body_mass` are Apple-only today. The normalization design is sound —
-these are canonical metrics with a LOINC and a unit — but Garmin currently contributes nothing,
-so a Garmin-only patient has permanent nulls in six columns.
-
-FIT sources exist for at least four and should be added to `parse_garmin_fit`:
-
-| Metric | Candidate FIT source |
-|---|---|
-| `flights_climbed` | `monitoring.ascent` / `total_ascent` (metres → flights, ÷ ~3.05 m) |
-| `walking_speed` | `session.avg_speed` / `enhanced_avg_speed` on walk-type sessions (m/s → km/hr) |
-| `walking_hr_avg` | `session.avg_heart_rate` filtered to walking sport type |
-| `body_mass` | `weight_scale.weight` (Garmin Index scale) or `user_profile.weight` |
-
-`walking_step_length` and `walking_double_support_pct` have no FIT equivalent — Garmin's Running
-Dynamics reports ground contact time and vertical oscillation, which are not the same
-measurements and should **not** be mapped onto these LOINCs. Leave them Apple-only.
-
-### Gap 6 — daily-total units are dimensionally loose
-
-`distance` is stored as `km` and `steps` as `/d`, but both values are daily totals. `distance`
-should arguably be `km/d` to match. This affects nothing today because every consumer reads
-`WEARABLE_LOINC` and knows the semantics, but it will confuse any external OMOP consumer.
-
-### Gap 7 — no `measurement_datetime`, provider, or visit
+### Gap D — no `measurement_datetime`, provider, or visit
 
 Only the date is stored. For sub-daily analyses (nocturnal SpO2 desaturation, circadian HR) the
 current model cannot support the query. Deferred deliberately — the daily grain is what the
 30-day `PatientRecord` summaries need — but noted so the limitation is not rediscovered later.
 
+### Gap E — eleven derived `PatientRecord` columns are client-writable
+
+`PatientRecordSerializer.read_only_fields` (`patient_portal/api/serializers.py:276`) protects the
+original ten wearable columns, with the comment "Wearable summaries are written by the device-sync
+service, never by the client API." The eleven columns added since were never added to that list:
+
+`oxygen_saturation_avg_30d`, `vo2_max_avg_30d`, `distance_km_per_day_30d`,
+`walking_speed_avg_30d`, `walking_step_length_avg_30d`, `walking_double_support_pct_avg_30d`,
+`walking_hr_avg_30d`, `flights_climbed_per_day_30d`, `active_energy_per_day_30d`,
+`basal_energy_per_day_30d`, `body_mass_avg_30d`.
+
+A client can PATCH any of them, and the value survives until the next `refresh_patient_record`
+overwrites it — so a derived column can disagree with the OMOP rows it claims to summarize, for an
+unbounded window. Add all eleven to `read_only_fields`, and add a test asserting that every
+`*_30d` column and every `wearable_*` column on `PatientRecord` is read-only, so the next column
+added cannot repeat the omission.
+
+### Gap F — daily-total units are dimensionally loose
+
+`distance` is stored as `km` and `steps` as `/d`, but both values are daily totals. `distance`
+should arguably be `km/d` to match. This affects nothing today because every consumer reads
+`WEARABLE_CONCEPT_CODE` and knows the semantics, but it will confuse any external OMOP consumer.
+
+### Gap G — `hrv_sdnn` may be conflating SDNN and RMSSD (#438)
+
+LOINC 80404-7 is *R-R interval.standard deviation* — specifically **SDNN**. Apple's source
+identifier is unambiguously SDNN (`HKQuantityTypeIdentifierHeartRateVariabilitySDNN`), so that
+side of the map is sound.
+
+The Garmin side is not verified. `parse_garmin_fit` files
+`hrv_status_summary.weekly_average`/`last_night_average` (`wearable_parsers.py:231`) and the
+legacy `hrv` message (`:277`) under `hrv_sdnn`, and names the local variable `sdnn`. But Garmin's
+HRV Status feature is documented by Garmin as **RMSSD**-based. RMSSD and SDNN are different
+statistics over the same R-R series; they are not interchangeable and produce different values
+from identical input.
+
+If that is right, Garmin HRV rows are filed under a concept that means something else — the same
+class of defect as the original `walking_speed`→BMI mapping, and equally invisible to any query
+that trusts `measurement_concept_id`.
+
+**Before any further HRV work:**
+
+1. Confirm what `hrv_status_summary` actually reports, against Garmin's FIT SDK / HRV Status
+   documentation. `hrv_value.value` (5-minute readings, `:242`) needs the same check separately —
+   it may not be the same statistic as the summary messages.
+2. If it is RMSSD, add a second canonical metric (`hrv_rmssd`) with its own verified Athena
+   concept, repoint the Garmin adapter at it, and give it its own `PatientRecord` column. Do not
+   alias it onto 80404-7, and do not average the two into one summary.
+3. Existing Garmin-sourced `hrv_sdnn` rows would need the `purge_broken_wearable_rows` treatment —
+   delete and re-upload, since the corrected value is reproducible from the export.
+
+This gap becomes blocking as soon as a Fitbit, Whoop, or Oura adapter is written: all three report
+RMSSD-derived HRV, so a `hrv_rmssd` concept is needed regardless, and resolving it correctly for
+those vendors settles Garmin at the same time.
+
+---
+
+## Adding a new device adapter
+
+The parser boundary is what keeps a new vendor cheap. An adapter's only obligation is to emit
+`WearableSample(metric_key, date, value)` tuples using the existing canonical metric keys, at one
+value per metric per calendar day, in the units given in the normalization table.
+
+Everything below that boundary — concept resolution, domain routing, artifact bounds, dedup,
+`PatientRecord` aggregation — is vendor-independent and must not be touched to accommodate a
+device.
+
+What a new vendor does touch:
+
+| Layer | Change |
+|---|---|
+| `wearable_parsers.py` | The new parser. Reuse the shared sum-vs-mean list (`:328`, `:489`) — don't invent a third copy. |
+| `views.py:3568` | `device_type` allow-list, currently the literal `('garmin', 'apple')` |
+| `views.py:3578-3581` | Per-device file-extension validation |
+| `views.py:3604` | Parser dispatch, plus the error-message ternary at `:3612` |
+| `WearableTab.tsx:56` | `detectDeviceType`, and the upload-history label at `:364` — a two-way ternary that renders any third device as "Apple" |
+| `mappings.py` | Only if the vendor measures something the 17 canonical metrics don't cover |
+
+`WearableUpload.device_type` is `max_length=10`, which accommodates `fitbit`, `whoop`, and `oura`
+without a migration.
+
+**Cloud-API vendors need a sync path, not an upload path.** Apple and Garmin arrive as file
+uploads; Fitbit, Whoop, and Oura are OAuth-gated REST APIs requiring token storage, refresh
+handling, and scheduled pulls. That work sits *above* the parser boundary and is shared across
+those vendors rather than duplicated per vendor — `upload_wearable`'s `request.FILES` handling is
+the wrong entry point for them, but everything from `WearableSample` onward is reused unchanged.
+
+**Do not map a vendor field onto a concept it doesn't mean** to make a column look populated. The
+gait metrics (`walking_step_length`, `walking_double_support_pct`, `walking_speed`,
+`walking_hr_avg`) have no equivalent on a ring or a chest strap, and Garmin's Running Dynamics
+measures different quantities entirely (see Gap A). A null is correct;
+`wearable_coverage_ratio_30d` exists so consumers can tell the difference between "no data" and
+"low values". See Gap G for the HRV version of this trap, which is subtler and already live.
+
 ---
 
 ## Adding a new wearable metric
 
-1. `mappings.py` — add to `WEARABLE_LOINC` and `WEARABLE_ARTIFACT_BOUNDS`.
-2. `seed_omop_concepts.py` — seed the LOINC concept, **or ingestion silently no-ops** (Gap 1).
+1. `mappings.py` — add to `WEARABLE_CONCEPT_CODE` and `WEARABLE_ARTIFACT_BOUNDS`. If the concept
+   is Observation-domain, add it to `WEARABLE_OBSERVATION_METRICS` too (fixtures/tests only —
+   the runtime writer reads `domain_id`).
+2. `seed_omop_concepts.py` — seed the concept, **or ingestion discards the metric** (it will be
+   logged and counted, but no row is written). Seed the genuine Athena `concept_id` if the code
+   exists there; otherwise mint via `_hk()` under `HK-Wearable`.
 3. `wearable_parsers.py` — add the Apple `_APPLE_TYPE_MAP` entry and the Garmin FIT handler;
-   add the key to the sum-vs-mean list at `:328` and `:489` if it is cumulative.
+   add the key to the sum-vs-mean list at `:328` **and** `:489` if it is cumulative.
 4. `views.py` — add the `unit_map` entry in `upload_wearable`.
-5. `patient_record_service.py` — add the 30-day aggregation.
+5. `patient_record_service.py` — add the 30-day aggregation in `_get_wearable_data`, including the
+   `_metric_daily` call, the `_within_window` call, and both `all_valid_days` unions.
 6. `models.py` + migration — add the `PatientRecord` column.
-7. `frontend/src/types/patient.ts` + `WearableTab.tsx` — expose it.
-8. Tests at every layer, per CLAUDE.md.
+7. `serializers.py` — add the column to `read_only_fields` (see Gap E).
+8. `frontend/src/types/patient.ts` + `WearableTab.tsx` — expose it.
+9. Tests at every layer, per CLAUDE.md.


### PR DESCRIPTION
## Summary

Docs only — no code or behaviour changes.

**`wearable-omop-mapping.md` had drifted badly from the code.** It documented four LOINC codes resolving to BMI/body-fat concepts and three codes that are not valid LOINC as *current behaviour*, behind a warning banner telling readers not to copy them. All of that was fixed by #413. A reader following the doc would have been misled about what the system does today.

**`decision-ready-wearables.md` is new** — an article on the three-layer wearable architecture and why it makes the data usable for care decisions, trial matching, and analytics.

## Corrections to `wearable-omop-mapping.md`

| Documented as | Actual current state |
|---|---|
| 4 codes resolving to BMI / body-fat concepts | Fixed — `walking_speed`→41957-2, `active_energy`→93819-1, `walking_hr_avg` + `basal_energy`→`HK-Wearable` mints |
| 3 codes not valid LOINC | Fixed — minted under `HK-Wearable`, `source='HealthKey'`, ids from 2,029,606,350 |
| `active_minutes` = 77592-4 | Actually 55411-3 |
| Unresolved concepts skipped silently | Logged, and returned as `unmapped_samples` / `unmapped_metrics` |
| Only `sleep_duration` in `observation` | Four metrics are Observation-domain; routing reads `concept.domain_id` at runtime |

Also added: the seeded `concept_id` for every metric, the `PatientRecord` projection rules, the `purge_broken_wearable_rows` cleanup path, and an **"Adding a new device adapter"** section covering the parser-boundary contract and the vendor-coupled touch points. Surviving gaps renumbered A–F. Every `file:line` citation re-verified against the current source.

## Two new gaps found while verifying

**Gap E — eleven derived `PatientRecord` columns are client-writable.** `PatientRecordSerializer.read_only_fields` protects the original ten wearable columns with the comment *"written by the device-sync service, never by the client API"*, but was never updated for the eleven added since: `oxygen_saturation_avg_30d`, `vo2_max_avg_30d`, `distance_km_per_day_30d`, all five `walking_*`, `flights_climbed_per_day_30d`, both energy columns, and `body_mass_avg_30d`. A client can PATCH any of them and the value survives until the next `refresh_patient_record`. Not yet filed as an issue.

**Gap G — HRV may conflate SDNN and RMSSD (#438).** LOINC 80404-7 is specifically SDNN. Apple's identifier is unambiguously SDNN; Garmin documents HRV Status as RMSSD-based, and the adapter files it under `hrv_sdnn`. If confirmed, same class of defect as the `walking_speed`→BMI mapping. Blocking for any Fitbit/Whoop/Oura adapter, since all three report RMSSD.

## The article

`decision-ready-wearables.md` covers device adapters → LOINC-anchored OMOP rows → the flat `PatientRecord` projection, then the three consumers (standard of care, trial matching, analytics).

Written **device-agnostically**: Apple and Garmin supply the concrete examples because they are what is implemented, with Fitbit, Whoop and Oura covered as planned adapters that fit the same model without changing anything below the parser boundary. It uses the pre-#413 wrong-concept bug as the centrepiece of the interoperability argument — two devices agreeing on a code that means the wrong thing is not interoperability — and closes on the open gaps rather than claiming completeness.

## Testing

Not run. The diff touches zero code files; both changed paths are markdown under `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
