### PR TITLE
fix: stop enrichment minting concepts at concept_id=int(code)

### DIFF
--- a/omop_core/management/commands/enrich_breast_cancer_omop_data.py
+++ b/omop_core/management/commands/enrich_breast_cancer_omop_data.py
@@ -280,7 +280,8 @@ def _resolve_concept(vocabulary_id, concept_code, concept_name):
     """
     candidates = list(
         Concept.objects
-        .filter(vocabulary_id=vocabulary_id, concept_code=concept_code)
+        .filter(vocabulary_id=vocabulary_id, concept_code=concept_code,
+                invalid_reason__isnull=True)
         .order_by('concept_id')[:5]
     )
     if not candidates:
@@ -509,22 +510,23 @@ class Command(BaseCommand):
         # Pre-fetch all wearable LOINC concepts in one query. This avoids N+1
         # Concept.objects.get() calls inside _create_missing_wearable_measurements
         # and provides an early abort if any required concept is missing.
-        self._write_progress('Pre-fetching wearable LOINC concepts...')
         wearable_concepts = {}
-        # Scope by (vocabulary_id, concept_code): a bare concept_code is
-        # ambiguous — 852 codes are reused across vocabularies — and four
-        # wearable metrics live in HK-Wearable rather than LOINC.
-        for metric_key, concept_code in WEARABLE_CONCEPT_CODE.items():
-            concept = Concept.objects.filter(
-                vocabulary_id=WEARABLE_CONCEPT_VOCAB[metric_key],
-                concept_code=concept_code,
-            ).first()
-            if concept is None:
-                raise CommandError(
-                    f'Required wearable concept {concept_code!r} ({metric_key}) '
-                    f'not found in Concept table. Run seed_omop_concepts first.'
+        if person_ids:
+            self._write_progress('Pre-fetching wearable LOINC concepts...')
+            # Scope by (vocabulary_id, concept_code): a bare concept_code is
+            # ambiguous — 852 codes are reused across vocabularies — and four
+            # wearable metrics live in HK-Wearable rather than LOINC.
+            for metric_key, concept_code in WEARABLE_CONCEPT_CODE.items():
+                concept = Concept.objects.filter(
+                    vocabulary_id=WEARABLE_CONCEPT_VOCAB[metric_key],
+                    concept_code=concept_code,
+                ).first()
+                if concept is None:
+                    raise CommandError(
+                        f'Required wearable concept {concept_code!r} ({metric_key}) '
+                        f'not found in Concept table. Run seed_omop_concepts first.'
                 )
-            wearable_concepts[metric_key] = concept
+                wearable_concepts[metric_key] = concept
 
         ehr_type_concept_id = CONCEPT_EHR_TYPE
         counts = {

--- a/omop_core/management/commands/enrich_breast_cancer_omop_data.py
+++ b/omop_core/management/commands/enrich_breast_cancer_omop_data.py
@@ -35,6 +35,7 @@ Usage:
     python manage.py enrich_breast_cancer_omop_data --confirm --org-slugs abc-foundation,bbc-foundation --limit 50
     python manage.py enrich_breast_cancer_omop_data --confirm --person-ids 1341,1410
 """
+import logging
 import random
 import time
 from datetime import date, timedelta
@@ -56,28 +57,73 @@ from omop_core.services.patient_record_service import refresh_patient_record
 from omop_core.services.lot_regimens import REGIMEN_CONCEPT_IDS, get_regimen_name
 from omop_core.signals import suppress_patient_record_refresh
 
+logger = logging.getLogger(__name__)
 
-# SNOMED CT codes read by _get_behavior_data / _get_assessment_data but not
-# present in this DB's Concept table at all (no SNOMED vocabulary loaded
-# here — confirmed via direct query). Used as the concept_id too, since
-# there's no existing Athena surrogate id to reuse and these numeric SNOMED
-# codes are well outside this DB's existing concept_id range.
+
+# Concepts read by _get_behavior_data / _get_assessment_data, as
+# (vocabulary_id, concept_code). Resolved against the loaded vocabulary — never
+# minted, and never keyed by concept_id.
+#
+# These were originally used as the concept_id itself, on the reasoning that no
+# SNOMED vocabulary was loaded and the numeric codes sat well outside the
+# database's concept_id range. Loading Athena invalidated both halves: the
+# genuine concepts now exist, so minting at concept_id=int(code) creates a
+# duplicate that shadows them, and it poisoned MAX(concept_id), which next_pk's
+# self-heal then adopted. See #415.
+#
+# KNOWN DEFECT, deliberately not fixed here: the four response codes are
+# semantically wrong. SNOMED 182840001-182843004 mean "Drug treatment stopped -
+# medical advice / ineffective / side effect / inconvenient", not Complete /
+# Partial / Progressive / Stable response. They are left in place because six
+# consumers read them (views.py, episode_service, patient_record_service,
+# bulk_import_fhir_bundle, fill_org_analytics_gaps, OMOP2PatientInfo.md) and
+# because the correct fix is per-disease outcome value sets, not a like-for-like
+# swap: of the five diseases supported here only breast cancer uses RECIST.
+# Lymphoma uses Lugano, myeloma IMWG, CLL iwCLL — and IMWG's VGPR/sCR and
+# iwCLL's CRi/PR-L have no RECIST equivalent, so one four-value set cannot
+# express them. Tracked separately; see the hemonc roadmap's P5.
+# TRADEOFF, deliberate: the three tobacco concepts are non-standard in Athena
+# (4144272 / 4310250 / 4298794 all have standard_concept=NULL) and have no
+# 'Maps to' edge to a Standard concept, so observation_concept_id will hold a
+# non-standard concept. That deviates from OMOP's convention and means these
+# rows are invisible to concept_ancestor rollups — a cohort query walking the
+# hierarchy from a Standard concept will not see them.
+#
+# It is still the right call here. The only "Standard" tobacco rows in the
+# database were this command's own mints, which hardcoded standard_concept='S'
+# and so fabricated a standardness the genuine concept does not have. Using the
+# real non-standard concept is honest; inventing a Standard one is what we are
+# stopping.
+#
+# The conformant alternative is a question/answer pair — observation_concept_id
+# = a tobacco-status question concept, value_as_concept_id = a Standard LOINC
+# answer (LA18978-9 "Never smoker", LA15920-4 "Former smoker",
+# LA18976-3 "Current every day smoker"). That restructures how the observation
+# is written and every reader keyed on these SNOMED codes, so it is tracked
+# separately rather than smuggled in here.
 _TOBACCO_CODES = {
-    '266919005': ('Never smoked tobacco', 0.7),
-    '8517006':   ('Ex-smoker', 0.2),
-    '77176002':  ('Current smoker', 0.1),
+    ('SNOMED', '266919005'): ('Never smoked tobacco', 0.7),
+    ('SNOMED', '8517006'):   ('Ex-smoker', 0.2),
+    ('SNOMED', '77176002'):  ('Smoker', 0.1),
 }
 _RESPONSE_CODES = {
-    '182840001': 'Complete Response',
-    '182841002': 'Partial Response',
-    '182843004': 'Stable Disease',
-    '182842009': 'Progressive Disease',
+    ('SNOMED', '182840001'): 'Complete Response',
+    ('SNOMED', '182841002'): 'Partial Response',
+    ('SNOMED', '182843004'): 'Stable Disease',
+    ('SNOMED', '182842009'): 'Progressive Disease',
 }
 
 # Rough clinical-stage -> (T, M) mapping, used only to synthesize a plausible
 # tumor/metastasis Observation pair consistent with the patient's existing
 # patient_record.stage value (LOINC 21905-5 / 21901-4, read by
 # _get_assessment_data to set measurable_disease_by_recist_status).
+# LOINC observations written by _get_assessment_data for tumour/metastasis
+# staging. Preflighted alongside the behaviour and response concepts.
+_STAGING_CODES = {
+    '21905-5': 'Primary tumor.clinical [Class] Cancer',
+    '21901-4': 'Distant metastases.pathology [Class] Cancer',
+}
+
 _STAGE_TO_TM = {
     'I': ('T1', 'M0'), 'IA': ('T1', 'M0'), 'IB': ('T1', 'M0'),
     'II': ('T2', 'M0'), 'IIA': ('T2', 'M0'), 'IIB': ('T2', 'M0'),
@@ -141,18 +187,6 @@ _BC_THERAPY_PLANS = {
 }
 
 
-def _get_or_create_snomed_vocabulary():
-    vocab, _ = Vocabulary.objects.get_or_create(
-        vocabulary_id='SNOMED',
-        defaults={
-            'vocabulary_name': 'Systematic Nomenclature of Medicine - Clinical Terms',
-            'vocabulary_reference': 'http://www.snomed.org',
-            'vocabulary_version': 'SNOMED CT (synthetic, benchmark seed)',
-            'vocabulary_concept_id': 0,
-        },
-    )
-    return vocab
-
 
 def _get_or_create_domain(domain_id):
     domain, _ = Domain.objects.get_or_create(
@@ -185,6 +219,12 @@ def _get_or_create_hemonc_vocabulary():
 def _get_or_create_regimen_concept(concept_id, regimen_key):
     """Get or create the HemOnc regimen Concept for a known concept_id.
 
+    KNOWN DEFECT, not fixed here: this mints with concept_code=str(concept_id),
+    so the code is fabricated rather than the genuine HemOnc code ('Elo-Rd').
+    That is the same shadow-producing class of defect as the
+    concept_id=int(code) minting this change removes, inverted. Fixing it means
+    resolving regimens against HemOnc, a larger piece of work; see #415.
+
     Therapy backfill resolves a regimen's HemOnc concept_id from
     REGIMEN_CONCEPT_IDS; on a DB where that Concept row was never loaded we
     create it so the backfilled DrugExposure references a real regimen concept
@@ -207,37 +247,68 @@ def _get_or_create_regimen_concept(concept_id, regimen_key):
     )
 
 
-def _get_or_create_concept(concept_code, concept_name):
-    """Get or create a SNOMED Concept row keyed by concept_code, using the
-    numeric code itself as concept_id (see module docstring for why).
+def _concept_ids_for(code_table):
+    """concept_ids for a {(vocabulary_id, concept_code): ...} table.
 
-    Also ensures the Vocabulary/Domain/ConceptClass rows it references exist —
-    true on the real staging DB (seeded separately), but not on a freshly
-    migrated local/test DB, where these reference tables start empty."""
-    concept_id = int(concept_code)
-    try:
-        existing = Concept.objects.get(concept_id=concept_id)
-    except Concept.DoesNotExist:
-        _get_or_create_snomed_vocabulary()
-        _get_or_create_domain('Observation')
-        _get_or_create_concept_class('Clinical Observation')
-        return Concept.objects.create(
-            concept_id=concept_id,
-            concept_name=concept_name,
-            domain_id='Observation',
-            vocabulary_id='SNOMED',
-            concept_class_id='Clinical Observation',
-            standard_concept='S',
-            concept_code=concept_code,
-            valid_start_date='1970-01-01',
-            valid_end_date='2099-12-31',
-        )
-    if existing.concept_code != concept_code:
+    Reads the vocabulary from the key rather than hardcoding it, so the query
+    cannot drift away from the table and silently return an empty guard set.
+    """
+    from django.db.models import Q
+    predicate = Q()
+    for vocabulary_id, concept_code in code_table:
+        predicate |= Q(vocabulary_id=vocabulary_id, concept_code=concept_code)
+    if not predicate:
+        return set()
+    return set(Concept.objects.filter(predicate).values_list('concept_id', flat=True))
+
+
+def _resolve_concept(vocabulary_id, concept_code, concept_name):
+    """Resolve a concept by (vocabulary_id, concept_code) — never mint one.
+
+    This previously created a Concept keyed by ``concept_id = int(concept_code)``
+    when the lookup missed. That was safe only while no real vocabulary was
+    loaded; against an Athena-loaded database it minted a duplicate that shadows
+    the genuine concept, and because concept resolution elsewhere is an unordered
+    ``.first()``, which row won became arbitrary. It also poisoned
+    ``MAX(concept_id)``, which ``next_pk``'s self-heal adopted, producing the
+    392021xxx mint block. See #415.
+
+    Resolution is by (vocabulary_id, concept_code) because that is OMOP's natural
+    key. Raising rather than minting is the point: synthetic enrichment must not
+    invent vocabulary content, and a missing concept means the vocabulary is not
+    loaded, which the operator needs to know.
+    """
+    candidates = list(
+        Concept.objects
+        .filter(vocabulary_id=vocabulary_id, concept_code=concept_code)
+        .order_by('concept_id')[:5]
+    )
+    if not candidates:
         raise CommandError(
-            f'Concept id {concept_id} already exists for a different concept_code '
-            f'({existing.concept_code!r}, expected {concept_code!r}) — refusing to overwrite.'
+            f'Concept ({vocabulary_id}, {concept_code}) — {concept_name} — not found. '
+            f'Run seed_omop_concepts, or load the full vocabulary with '
+            f'load_athena_vocabularies. This command no longer mints OBSERVATION '
+            f'concepts: creating one at concept_id=int(code) produced duplicates '
+            f'shadowing the genuine concepts (#415). (Regimen concepts are still '
+            f'minted by _get_or_create_regimen_concept — tracked separately.)'
         )
-    return existing
+    if len(candidates) > 1:
+        # Duplicates for one (vocabulary, code) are the #415 defect itself, and
+        # they are the current state of staging for every code this command
+        # uses. Refusing outright would make the command — and
+        # generate_import_enrich_synthea_bc, which calls it — unrunnable until
+        # that cleanup lands. Pick the lowest concept_id instead: genuine Athena
+        # concepts have lower ids than the code-as-id mints that shadow them
+        # (4144272 vs 266919005), so this deterministically prefers the real
+        # row. Deterministic-and-warned beats both arbitrary and dead.
+        chosen = candidates[0]
+        logger.warning(
+            'enrich_breast_cancer_omop_data duplicate concept vocabulary=%s code=%s '
+            'ids=%s chose=%s — clean these up, see #415',
+            vocabulary_id, concept_code,
+            ', '.join(str(c.concept_id) for c in candidates), chosen.concept_id)
+        return chosen
+    return candidates[0]
 
 
 class _IdAllocator:
@@ -413,14 +484,27 @@ class Command(BaseCommand):
         observation_ids = _IdAllocator(Observation, 'observation_id')
         drug_exposure_ids = _IdAllocator(DrugExposure, 'drug_exposure_id')
 
-        if not dry_run:
-            # Ensure the SNOMED codes _get_behavior_data/_get_assessment_data
-            # read actually exist as Concept rows before touching any person.
-            self._write_progress('Ensuring required SNOMED concepts exist...')
-            for code, (name, _weight) in _TOBACCO_CODES.items():
-                _get_or_create_concept(code, name)
-            for code, name in _RESPONSE_CODES.items():
-                _get_or_create_concept(code, name)
+        # Preflight, in dry run too — skipping it in dry run meant the preview
+        # reported success and exited 0 where --confirm fails on the same
+        # database. Skipped entirely when no person will be enriched
+        # (--refresh-only), since these concepts are then never read.
+        if person_ids:
+            self._write_progress('Checking required concepts exist...')
+            for (vocab, code), (name, _weight) in _TOBACCO_CODES.items():
+                _resolve_concept(vocab, code, name)
+            for (vocab, code), name in _RESPONSE_CODES.items():
+                _resolve_concept(vocab, code, name)
+            # _make also writes these two staging observations. Leaving them out
+            # meant --dry-run exited 0 while --confirm raised mid-loop, after
+            # earlier persons had already committed.
+            for code, name in _STAGING_CODES.items():
+                _resolve_concept('LOINC', code, name)
+
+        # Person-invariant, so resolved once here rather than per patient in
+        # _create_missing_observations — the same reasoning as the wearable
+        # prefetch below.
+        self._tobacco_concept_ids = _concept_ids_for(_TOBACCO_CODES)
+        self._response_concept_ids = _concept_ids_for(_RESPONSE_CODES)
 
         # Pre-fetch all wearable LOINC concepts in one query. This avoids N+1
         # Concept.objects.get() calls inside _create_missing_wearable_measurements
@@ -656,16 +740,27 @@ class Command(BaseCommand):
         )
         obs_date = (record.diagnosis_date if record and record.diagnosis_date else date.today())
 
-        def _make(concept_code, value_as_string):
+        def _make(key, value_as_string):
+            """key is (vocabulary_id, concept_code), or a bare LOINC code."""
             nonlocal created
-            concept = Concept.objects.filter(concept_code=concept_code).first()
+            vocabulary_id, concept_code = key if isinstance(key, tuple) else ('LOINC', key)
+            # order_by is not cosmetic: with a genuine concept and a code-as-id
+            # shadow both present, an unordered .first() can write the shadow —
+            # the behaviour this change exists to prevent. Lowest id prefers the
+            # genuine Athena row.
+            concept = Concept.objects.filter(
+                vocabulary_id=vocabulary_id, concept_code=concept_code
+            ).order_by('concept_id').first()
             if concept is None:
                 if not dry_run:
                     raise CommandError(
-                        f'Concept code {concept_code!r} not found — expected it to have '
-                        f'been created up front in handle().'
+                        f'Concept ({vocabulary_id}, {concept_code}) not found. This '
+                        f'command does not create observation concepts; seed them with '
+                        f'seed_omop_concepts or load the full vocabulary.'
                     )
-                created += 1  # dry-run: concept doesn't exist yet, but would be created
+                # Dry run with the vocabulary absent. Nothing would be created —
+                # this command no longer mints — so report the observation as
+                # blocked rather than counting it as work.
                 return
             if concept.concept_id in existing_concept_ids:
                 return
@@ -687,11 +782,15 @@ class Command(BaseCommand):
         # *different* tobacco code than a prior run would otherwise pass the
         # per-concept check in _make() and add a second, contradictory
         # tobacco-status observation instead of being a no-op.
-        tobacco_concept_ids = {int(code) for code in _TOBACCO_CODES}
+        # Resolved once in handle() and passed down: these are person-invariant,
+        # and this method runs per patient. Resolving rather than assuming
+        # concept_id == int(code) is the point — that assumption is what minted
+        # duplicates shadowing the genuine SNOMED concepts (#415).
+        tobacco_concept_ids = self._tobacco_concept_ids
         if not existing_concept_ids & tobacco_concept_ids:
-            codes, weights = zip(*[(c, w) for c, (_, w) in _TOBACCO_CODES.items()])
-            tobacco_code = random.choices(codes, weights=weights, k=1)[0]
-            _make(tobacco_code, None)
+            keys, weights = zip(*[(k, w) for k, (_, w) in _TOBACCO_CODES.items()])
+            tobacco_key = random.choices(keys, weights=weights, k=1)[0]
+            _make(tobacco_key, None)
 
         # Tumor/metastasis staging, consistent with the patient's existing
         # stage. Deterministic (not random), so the per-concept check in
@@ -702,17 +801,21 @@ class Command(BaseCommand):
             _make('21901-4', m_val)
 
         # Best response — same category-guard reasoning as tobacco above.
-        response_concept_ids = {int(code) for code in _RESPONSE_CODES}
+        response_concept_ids = self._response_concept_ids
         if not existing_concept_ids & response_concept_ids:
-            response_code = random.choices(
+            response_key = random.choices(
                 list(_RESPONSE_CODES.keys()), weights=[0.3, 0.35, 0.25, 0.10], k=1,
             )[0]
-            _make(response_code, None)
+            _make(response_key, None)
 
         return created
 
     def _measurement_concept_for_code(self, loinc_code):
-        concept = Concept.objects.filter(concept_code=loinc_code).first()
+        # Scoped to LOINC: a bare concept_code lookup is ambiguous, since codes
+        # are reused across vocabularies and shadow rows may exist for the same
+        # code. This is the same defect fixed in _make.
+        concept = Concept.objects.filter(
+            vocabulary_id='LOINC', concept_code=loinc_code).order_by('concept_id').first()
         if concept:
             return concept
         return Concept.objects.filter(concept_id=CONCEPT_GENERIC_LAB).first()

--- a/omop_core/management/commands/seed_omop_concepts.py
+++ b/omop_core/management/commands/seed_omop_concepts.py
@@ -97,6 +97,8 @@ _CONCEPT_CLASSES = [
     dict(concept_class_id='Gender',              concept_class_name='Gender',               concept_class_concept_id=0),
     dict(concept_class_id='Regimen',             concept_class_name='Regimen',              concept_class_concept_id=0),
     dict(concept_class_id='Undefined',           concept_class_name='Undefined',            concept_class_concept_id=0),
+    dict(concept_class_id='Clinical Finding',    concept_class_name='Clinical Finding',     concept_class_concept_id=0),
+    dict(concept_class_id='Context-dependent',   concept_class_name='Context-dependent',    concept_class_concept_id=0),
 ]
 
 
@@ -349,6 +351,29 @@ _CONCEPTS = [
     _c(1761351,  'Flights climbed [#] Reporting Period',                       'Observation', 'LOINC', 'Clinical Observation', 'S', '100304-5', date(2022, 8, 8)),
     _c(1001786,  'Calories burned in unspecified time --during activity',      'Measurement', 'LOINC', 'Clinical Observation', 'S', '93819-1',  date(2019, 12, 13)),
 
+    # ------------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # Concepts read by enrich_breast_cancer_omop_data, seeded with their genuine
+    # Athena concept_ids so a database without a full vocabulary load can still
+    # run enrichment. The command previously minted these itself at
+    # concept_id=int(code), which produced the duplicate rows in #415.
+    #
+    # concept_name is the vocabulary's own, NOT the meaning the command assigns.
+    # The four 1828xxxx codes really do mean "drug treatment stopped"; the
+    # command uses them for treatment response, which is a known defect left in
+    # place because six consumers read them and the correct fix is per-disease
+    # outcome value sets (RECIST for breast cancer, Lugano for lymphoma, IMWG
+    # for myeloma, iwCLL for CLL). Seeding them under their real names keeps the
+    # vocabulary honest and makes the mismatch visible.
+    # ------------------------------------------------------------------
+    _c(4144272, 'Never smoked tobacco',                    'Observation', 'SNOMED', 'Clinical Finding',    None, '266919005'),
+    _c(4310250, 'Ex-smoker',                               'Observation', 'SNOMED', 'Clinical Finding',    None, '8517006'),
+    _c(4298794, 'Smoker',                                  'Observation', 'SNOMED', 'Clinical Finding',    None, '77176002'),
+    _c(4057412, 'Drug treatment stopped - medical advice', 'Observation', 'SNOMED', 'Context-dependent',   'S',  '182840001'),
+    _c(4082386, 'Doctor stopped drugs - ineffective',      'Observation', 'SNOMED', 'Context-dependent',   'S',  '182841002'),
+    _c(4056953, 'Doctor stopped drugs - side effect',      'Observation', 'SNOMED', 'Context-dependent',   'S',  '182842009'),
+    _c(4056954, 'Doctor stopped drugs - inconvenient',     'Observation', 'SNOMED', 'Context-dependent',   'S',  '182843004'),
+
     # Wearable metrics with NO LOINC equivalent — locally minted, quarantined
     # under HK-Wearable with source='HealthKey' and ids in the OHDSI custom
     # range. LOINC has no concept for step length, double-support percentage,
@@ -504,9 +529,25 @@ class Command(BaseCommand):
                         cc_created += 1
 
             # Concepts
-            c_created = c_existing = 0
+            c_created = c_existing = c_skipped = 0
             for row in _CONCEPTS:
+                clash_ids = list(
+                    Concept.objects
+                    .filter(vocabulary_id=row['vocabulary_id'],
+                            concept_code=row['concept_code'])
+                    .exclude(concept_id=row['concept_id'])
+                    .values_list('concept_id', flat=True)[:5]
+                )
                 if dry_run:
+                    if clash_ids:
+                        # Reported in the preview too: without this the dry run
+                        # promised rows the real run skips.
+                        self.stdout.write(self.style.WARNING(
+                            f"  [would skip] {row['concept_id']:>8}  "
+                            f"{row['concept_code']:<12}  already present under "
+                            f"concept_id {clash_ids} — would duplicate"))
+                        c_skipped += 1
+                        continue
                     exists = Concept.objects.filter(concept_id=row['concept_id']).exists()
                     status = 'exists' if exists else 'would create'
                     self.stdout.write(
@@ -516,6 +557,20 @@ class Command(BaseCommand):
                     else:
                         c_existing += 1
                 else:
+                    # get_or_create keys on concept_id alone, so on a database
+                    # that already holds a different row for this
+                    # (vocabulary_id, concept_code) — e.g. a legacy mint at
+                    # concept_id=int(code) — it would insert a second one and
+                    # manufacture the very shadow this seeding exists to avoid.
+                    # There is no unique constraint to stop it (see #415).
+                    if clash_ids:
+                        self.stdout.write(self.style.WARNING(
+                            f"  skipped {row['concept_id']} "
+                            f"({row['vocabulary_id']}, {row['concept_code']}): already "
+                            f"present under concept_id {clash_ids} — seeding would "
+                            f"create a duplicate. Clean up first (#415)."))
+                        c_skipped += 1
+                        continue
                     _, created = Concept.objects.get_or_create(
                         concept_id=row['concept_id'], defaults=row)
                     if created:
@@ -531,6 +586,7 @@ class Command(BaseCommand):
             f'Domains: {d_created} new  |  '
             f'ConceptClasses: {cc_created} new  |  '
             f'Concepts: {c_created} new, {c_existing} already present'
+            + (f', {c_skipped} skipped (would duplicate)' if c_skipped else '')
         )
         if dry_run:
             self.stdout.write(self.style.WARNING(f'\nDry-run summary: {summary}'))

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -3501,3 +3501,30 @@ class ConceptIdIsNotAConceptCodeTest(TestCase):
         self.assertEqual(
             resolved.concept_id, 4144272,
             'must pick the genuine Athena row, not the code-as-id shadow')
+
+    def test_resolve_concept_ignores_retired_duplicates(self):
+        """Athena loads retain invalid concepts for history.
+
+        Resolution must not let the "lowest concept_id wins" duplicate heuristic
+        pick a retired row over the active concept.
+        """
+        from omop_core.management.commands.enrich_breast_cancer_omop_data import (
+            _resolve_concept,
+        )
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+
+        call_command('seed_omop_concepts', verbosity=0)
+        vocab = Vocabulary.objects.get(vocabulary_id='SNOMED')
+        domain = Domain.objects.get(domain_id='Observation')
+        cc = ConceptClass.objects.get(concept_class_id='Clinical Finding')
+        Concept.objects.create(
+            concept_id=4000000, concept_name='Retired never smoked tobacco',
+            domain=domain, vocabulary=vocab, concept_class=cc,
+            standard_concept='S', concept_code='266919005', invalid_reason='U',
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31))
+
+        resolved = _resolve_concept('SNOMED', '266919005', 'Never smoked tobacco')
+
+        self.assertEqual(
+            resolved.concept_id, 4144272,
+            'retired candidates must not be selected even when they sort lower')

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -3404,3 +3404,100 @@ class PlaceholderBirthYearTest(_OmopBase):
             pi.patient_age,
             today.year - 1975 - ((today.month, today.day) < (6, 1)),
         )
+
+
+
+class ConceptIdIsNotAConceptCodeTest(TestCase):
+    """No concept may use its own concept_code as its concept_id (see #415).
+
+    That single pattern caused the largest vocabulary defect in this database.
+    enrich_breast_cancer_omop_data minted concepts at concept_id=int(code) on
+    the reasoning that no SNOMED vocabulary was loaded and the numeric codes sat
+    outside the id range. Loading Athena invalidated both halves: the genuine
+    concepts existed, so the mints shadowed them, and MAX(concept_id) jumped to
+    392021009, which next_pk's self-heal adopted — allocating 141 further mints
+    behind it.
+    """
+
+    def test_no_seeded_concept_uses_its_code_as_its_id(self):
+        from omop_core.management.commands.seed_omop_concepts import _CONCEPTS
+
+        offenders = [
+            (r['concept_id'], r['concept_code']) for r in _CONCEPTS
+            if str(r['concept_id']) == str(r['concept_code'])
+        ]
+        self.assertEqual(
+            offenders, [],
+            f'concept_id must never equal concept_code: {offenders}')
+
+    def test_enrichment_resolves_concepts_instead_of_minting(self):
+        """The command must refuse to invent vocabulary content.
+
+        Raising is the desired behaviour: a missing concept means the vocabulary
+        is not loaded, which the operator needs to know. Minting silently
+        produced a shadow of the genuine concept.
+        """
+        from omop_core.management.commands.enrich_breast_cancer_omop_data import (
+            _resolve_concept,
+        )
+        from omop_core.models import Concept
+
+        with self.assertRaises(CommandError) as ctx:
+            _resolve_concept('SNOMED', '999999999', 'Not a real concept')
+        self.assertIn('no longer mints OBSERVATION concepts', str(ctx.exception))
+        self.assertFalse(
+            Concept.objects.filter(concept_id=999999999).exists(),
+            'no concept may be created at concept_id=int(code)')
+
+    def test_response_code_defect_is_recorded_not_silently_swapped(self):
+        """The four response codes are semantically wrong — SNOMED
+        182840001-182843004 mean "drug treatment stopped", not treatment
+        response — but they are deliberately left in place.
+
+        Swapping in RECIST codes would entrench a solid-tumour vocabulary across
+        five diseases, only one of which uses RECIST: lymphoma uses Lugano,
+        myeloma IMWG, CLL iwCLL, and IMWG's VGPR/sCR and iwCLL's CRi/PR-L have
+        no RECIST equivalent. The correct fix is per-disease value sets. This
+        test pins the current state so the defect cannot be quietly "fixed" by a
+        like-for-like swap.
+        """
+        import inspect
+        from omop_core.management.commands import enrich_breast_cancer_omop_data as mod
+
+        self.assertEqual(
+            {code for _, code in mod._RESPONSE_CODES},
+            {'182840001', '182841002', '182842009', '182843004'})
+        source = inspect.getsource(mod)
+        self.assertIn('KNOWN DEFECT', source,
+                      'the mismatch must stay documented at the code table')
+
+    def test_duplicate_concept_is_resolved_deterministically_not_by_error(self):
+        """The duplicate branch had a NameError: it called logger.warning() in a
+        module with no logger. Nothing exercised it, so the fix for the
+        unrunnable-on-staging blocker was itself broken — staging would have
+        raised NameError instead of the CommandError it replaced.
+
+        Lowest concept_id is chosen because genuine Athena rows have lower ids
+        than the code-as-id mints that shadow them (4144272 vs 266919005).
+        """
+        from omop_core.management.commands.enrich_breast_cancer_omop_data import (
+            _resolve_concept,
+        )
+        from omop_core.models import Concept, ConceptClass, Domain, Vocabulary
+
+        call_command('seed_omop_concepts', verbosity=0)
+        vocab = Vocabulary.objects.get(vocabulary_id='SNOMED')
+        domain = Domain.objects.get(domain_id='Observation')
+        cc = ConceptClass.objects.get(concept_class_id='Clinical Finding')
+        # The code-as-id shadow, alongside the genuine row seeded at 4144272.
+        Concept.objects.create(
+            concept_id=266919005, concept_name='Never smoked tobacco',
+            domain=domain, vocabulary=vocab, concept_class=cc,
+            standard_concept='S', concept_code='266919005',
+            valid_start_date=date(1970, 1, 1), valid_end_date=date(2099, 12, 31))
+
+        resolved = _resolve_concept('SNOMED', '266919005', 'Never smoked tobacco')
+
+        self.assertEqual(
+            resolved.concept_id, 4144272,
+            'must pick the genuine Athena row, not the code-as-id shadow')

--- a/tests/test_enrich_breast_cancer_omop_data.py
+++ b/tests/test_enrich_breast_cancer_omop_data.py
@@ -13,7 +13,7 @@ from io import StringIO
 import pytest
 from django.core.management import call_command, CommandError
 
-from omop_core.models import DrugExposure, Measurement, Observation, PatientRecord
+from omop_core.models import Concept, DrugExposure, Measurement, Observation, PatientRecord
 from omop_core.services.mappings import (
     WEARABLE_CONCEPT_CODE, WEARABLE_CONCEPT_VOCAB,
 )
@@ -304,6 +304,30 @@ class TestRefreshesPatientRecord:
         org = PatientRecordFactory(person=breast_person, disease='Breast Cancer').organization
         PatientRecordFactory(person=other_person, organization=org, disease='Multiple Myeloma')
         refreshed = []
+
+        monkeypatch.setattr(
+            'omop_core.management.commands.enrich_breast_cancer_omop_data.refresh_patient_record',
+            lambda person: refreshed.append(person.person_id),
+        )
+
+        call_command(
+            'enrich_breast_cancer_omop_data',
+            org_slugs=org.slug,
+            refresh_only=True,
+        )
+
+        assert refreshed == [breast_person.person_id]
+
+    def test_refresh_only_does_not_require_wearable_concepts(self, monkeypatch):
+        breast_person = PersonFactory()
+        org = PatientRecordFactory(person=breast_person, disease='Breast Cancer').organization
+        refreshed = []
+        wearable_filters = [
+            {'vocabulary_id': WEARABLE_CONCEPT_VOCAB[metric_key], 'concept_code': code}
+            for metric_key, code in WEARABLE_CONCEPT_CODE.items()
+        ]
+        for lookup in wearable_filters:
+            Concept.objects.filter(**lookup).delete()
 
         monkeypatch.setattr(
             'omop_core.management.commands.enrich_breast_cancer_omop_data.refresh_patient_record',

--- a/tests/test_enrich_breast_cancer_omop_data.py
+++ b/tests/test_enrich_breast_cancer_omop_data.py
@@ -52,6 +52,27 @@ def _seed_loinc_concepts_the_command_assumes_exist():
     }.items():
         _loinc_concept(code, name)
 
+    # Behaviour and response concepts, derived from the command's own tables.
+    # The command resolves these by (vocabulary_id, concept_code) and raises if
+    # one is missing — it no longer mints them, because minting at
+    # concept_id=int(code) produced duplicates shadowing the genuine SNOMED
+    # concepts (#415). Deriving the fixture keeps it in step when a code changes,
+    # which a literal list would not.
+    #
+    # The four response codes remain the SNOMED 1828xxxx values even though they
+    # mean "Drug treatment stopped - medical advice / ineffective / side effect
+    # / inconvenient" rather than treatment response. That mismatch is a known
+    # defect left in place deliberately: six consumers read them, and the fix is
+    # per-disease outcome value sets, since only breast cancer uses RECIST
+    # (lymphoma uses Lugano, myeloma IMWG, CLL iwCLL).
+    from omop_core.management.commands.enrich_breast_cancer_omop_data import (
+        _RESPONSE_CODES, _TOBACCO_CODES,
+    )
+    for (vocab, code), (name, _weight) in _TOBACCO_CODES.items():
+        _loinc_concept(code, name, vocabulary_id=vocab, domain_id='Observation')
+    for (vocab, code), name in _RESPONSE_CODES.items():
+        _loinc_concept(code, name, vocabulary_id=vocab, domain_id='Observation')
+
     observation_domain = {
         'steps', 'active_minutes', 'sleep_duration', 'flights_climbed',
     }


### PR DESCRIPTION
`enrich_breast_cancer_omop_data._get_or_create_concept` resolved only by `concept_id` and minted a row at `concept_id = int(concept_code)` when the lookup missed.

The module comment explains the original reasoning — no SNOMED vocabulary was loaded, and the numeric codes sat well outside the database's `concept_id` range. Loading the vocabulary invalidated both halves.

## What the mints did

Worse than duplicating. They hardcoded `standard_concept='S'`, fabricating a standardness the genuine rows do not have:

```
4144272    SNOMED  266919005  std=None   <- genuine Athena row
266919005  SNOMED  266919005  std=S      <- the mint
```

So any query filtering `standard_concept='S'` preferred the invention. All seven codes this command manages have both rows on staging.

**Scope note:** this writer is *not* the producer of the `392021xxx` block in #436. Its largest code is `266919005`, below `392021009`, and it only wrote `vocabulary_id='SNOMED'`, so it cannot account for that block's `sct` or CVX rows. It produced the code-as-id rows *below* the block — cleanup tracked in #452.

## The change

`_get_or_create_concept` becomes `_resolve_concept`, resolving by `(vocabulary_id, concept_code)`.

**On duplicates it picks the lowest `concept_id` and logs a warning**, rather than raising. Raising was the first attempt and would have left this command — and `generate_import_enrich_synthea_bc`, which calls it — unrunnable on staging, where every one of the seven codes currently has a duplicate. Lowest id deterministically prefers the genuine Athena row over a code-as-id mint (`4144272` < `266919005`). That is a deliberate softening of a guard: deterministic-and-logged rather than arbitrary or dead.

`seed_omop_concepts` seeds all seven with their **genuine Athena `concept_id`s**, under the vocabulary's own `concept_name` rather than the meaning this command assigns them. It now also refuses to seed a row that would create a second entry for an existing `(vocabulary_id, concept_code)` — `get_or_create` keys on `concept_id` alone, so on a database holding the old mint it would otherwise manufacture the very shadow the seeding exists to avoid.

## The response codes are NOT changed

An earlier revision of this PR replaced the four SNOMED response codes with LOINC RECIST answer values. **That was removed.** The SNOMED codes stay.

They are semantically wrong — `182840001`-`182843004` mean *"Drug treatment stopped - medical advice / ineffective / side effect / inconvenient"*, not treatment response — but a like-for-like swap is the wrong fix on two counts. Six consumers read them (`views.py`, `episode_service`, `patient_record_service`, `bulk_import_fhir_bundle`, `fill_org_analytics_gaps`, `OMOP2PatientInfo.md`), and of the five diseases supported here only breast cancer uses RECIST:

| Disease | Criterion |
|---|---|
| Breast cancer | RECIST 1.1 |
| Follicular lymphoma, DLBCL | Lugano 2014 |
| Multiple myeloma | IMWG |
| CLL | iwCLL 2018 |

IMWG's `VGPR`/`sCR` and iwCLL's `CRi`/`PR-L` have no RECIST equivalent, so no four-value set can express them. The correct fix is per-disease outcome value sets. The mismatch is documented at the code table and **pinned by a test** so it cannot be quietly swapped later.

## A deliberate tradeoff, recorded

The three tobacco concepts are genuinely non-standard in the vocabulary (`4144272`/`4310250`/`4298794` all `standard_concept=NULL`) with **no `Maps to` target**, so `observation_concept_id` now holds a non-standard concept and those rows are invisible to `concept_ancestor` roll-ups.

It is still the right call: the only "Standard" tobacco rows in the database were this command's own mints. Using the real non-standard concept is honest; inventing a Standard one is what is being stopped. The conformant alternative — a question/answer pair with a Standard LOINC answer in `value_as_concept_id` — restructures the observation and every reader keyed on these codes, so it is tracked in #451 rather than smuggled in here.

## Other fixes

- The preflight runs in dry-run mode too (it previously reported success and exited 0 where `--confirm` fails), but is skipped when no person will be enriched, so `--refresh-only` no longer aborts on concepts it never reads.
- The staging LOINC codes `21905-5`/`21901-4` are preflighted, closing another dry-run/confirm divergence.
- `_make` and `_measurement_concept_for_code` now order by `concept_id` instead of an unordered `.first()`, which could otherwise write the shadow this change exists to avoid.
- The guard-set queries read the vocabulary from the code table rather than hardcoding it; the two lookups are hoisted out of the per-patient loop; the dead `_get_or_create_snomed_vocabulary` helper is removed.
- The "no longer mints" message is scoped to **observation** concepts, because `_get_or_create_regimen_concept` still mints with a fabricated `concept_code` — tracked in #450.

## Tests

Four new, including one that seeds a duplicate pair and asserts the genuine row is chosen. That branch previously called `logger.warning()` in a module with no `logger` defined, so it raised `NameError` — the fix for the blocker was itself broken, and nothing exercised it. Removing the import now fails the test with the exact `NameError`.

- Django: `Ran 1319 tests` — `OK (skipped=1)`
- pytest: 177 passed

## Related

#450 regimen minting · #451 smoking-status modelling · #452 the code-as-id rows on staging · #453 six writers claiming `standard_concept='S'` without `source='HealthKey'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
