### PR TITLE
fix: renaming a patient silently did nothing

### DIFF
--- a/frontend/src/components/Patient/PatientDetail.name.test.tsx
+++ b/frontend/src/components/Patient/PatientDetail.name.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Renaming a patient must actually persist and re-render the header.
+ *
+ * scheduleAutoSave carried the edited name alongside the field data, but doSave
+ * only ever sent data.info — so `patient_name` never reached the server. The
+ * rename looked accepted, the header kept the old name, and a reload confirmed
+ * the old name because Person.given_name/family_name had never changed.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import PatientDetail from "./PatientDetail";
+
+vi.mock("@/api/axios", () => ({
+  default: { get: vi.fn(), patch: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => ({ personId: "3542" }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/useVocabulary", () => ({
+  useVocabulary: () => ({ options: [], source: null, loading: false }),
+}));
+
+import api from "@/api/axios";
+
+const PATIENT = {
+  id: 1,
+  person_id: 3542,
+  patient_name: "Alishia Tawny Howell",
+  disease: "Malignant tumor of breast",
+  email: "alishia@example.com",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (api.get as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+    if (url.includes("/patient-info/")) {
+      return Promise.resolve({
+        data: { patient_info: PATIENT, user: null, patient_name: PATIENT.patient_name },
+      });
+    }
+    return Promise.resolve({ data: [] });
+  });
+  (api.patch as ReturnType<typeof vi.fn>).mockResolvedValue({ data: {} });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function renderAndWaitForLoad() {
+  render(<PatientDetail />);
+  await waitFor(() =>
+    expect(screen.getByDisplayValue("Alishia Tawny Howell")).toBeInTheDocument(),
+  );
+}
+
+describe("PatientDetail - renaming a patient", () => {
+  it("sends patient_name on the PATCH when the name changes", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    await renderAndWaitForLoad();
+
+    fireEvent.change(screen.getByDisplayValue("Alishia Tawny Howell"), {
+      target: { value: "Adam Blum" },
+    });
+    // Autosave is debounced by 2s.
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    await waitFor(() => expect(api.patch).toHaveBeenCalled());
+    const [, body] = (api.patch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(body).toMatchObject({ patient_name: "Adam Blum" });
+  });
+
+  it("updates the header so the old name stops being displayed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    await renderAndWaitForLoad();
+    // The header renders the loaded name before any edit.
+    expect(screen.getAllByText("Alishia Tawny Howell").length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByDisplayValue("Alishia Tawny Howell"), {
+      target: { value: "Adam Blum" },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText("Alishia Tawny Howell")).not.toBeInTheDocument(),
+    );
+    expect(screen.getAllByText("Adam Blum").length).toBeGreaterThan(0);
+  });
+
+  it("omits patient_name when only a clinical field changed", async () => {
+    // Person.given_name/family_name are written unconditionally when the key is
+    // present, so sending it on every autosave would rewrite the row on each
+    // keystroke elsewhere in the form.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    await renderAndWaitForLoad();
+
+    fireEvent.change(screen.getByDisplayValue("alishia@example.com"), {
+      target: { value: "adam@example.com" },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    await waitFor(() => expect(api.patch).toHaveBeenCalled());
+    const [, body] = (api.patch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(body).not.toHaveProperty("patient_name");
+  });
+});

--- a/frontend/src/components/Patient/PatientDetail.tsx
+++ b/frontend/src/components/Patient/PatientDetail.tsx
@@ -319,8 +319,25 @@ export default function PatientDetail({
     const seq = ++saveSeqRef.current;
     setSaveStatus("saving");
     try {
-      await api.patch(`/patient-info/${personId}/`, data.info);
+      // Renaming a patient silently did nothing. scheduleAutoSave carries the
+      // edited name alongside the field data, but only data.info was sent — and
+      // data.info is the whole GET response, which already carries the ORIGINAL
+      // patient_name. So every autosave wrote the old name straight back over
+      // Person.given_name/family_name, and the header kept rendering it through
+      // reloads included.
+      //
+      // Strip it unconditionally and re-add it only on a real rename. Sending
+      // the server's own value back is never useful and is actively harmful for
+      // a patient with no name: get_patient_name synthesises "Patient 3542",
+      // which the view would split into given_name="Patient", family_name="3542".
+      const { patient_name: _stale, ...info } = data.info as Record<string, unknown>;
+      const renamed = !!data.name && data.name !== patientNameRef.current;
+      const payload = renamed ? { ...info, patient_name: data.name } : info;
+      await api.patch(`/patient-info/${personId}/`, payload);
       if (seq === saveSeqRef.current) {
+        // Header state is set once on load, so without this the new name only
+        // appears after a refetch.
+        if (renamed) setPatientName(data.name);
         setSaveStatus("saved");
         setTimeout(() => setSaveStatus((s) => (s === "saved" ? "idle" : s)), 1200);
       }

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -169,6 +169,53 @@ def _record_provenance(record, source, source_user_id, target_patient_id=None, m
     )
 
 
+def _pop_patient_name(data):
+    """Take patient_name out of a PATCH body, returning (name_or_None, rest).
+
+    `patient_name` is a SerializerMethodField over Person.given_name/family_name,
+    not a PatientRecord column, so it can only be applied by hand. Leaving it in
+    the body means DRF silently drops it as read-only and logs it as an ignored
+    field — which is exactly how renaming a patient came to be a no-op on
+    /api/patient-info/{id}/ while working on /api/patient-info/me/.
+    """
+    if hasattr(data, 'pop'):
+        name = data.pop('patient_name', None)
+        # QueryDict.pop returns a list; DRF's parsed JSON dict returns a scalar.
+        if isinstance(name, list):
+            name = name[0] if name else None
+        return name, data
+    return data.get('patient_name'), {
+        k: v for k, v in data.items() if k != 'patient_name'
+    }
+
+
+def _apply_patient_name(person, patient_name):
+    """Rename a Person from a free-text 'Given Family' string. Returns True if written.
+
+    Only writes a real change. Clients that PATCH the whole record echo
+    patient_name back unchanged on every autosave, and for a person with no name
+    the serializer synthesises "Patient {id}" — writing that back would set
+    given_name='Patient', family_name='<id>'. Guarding on difference makes the
+    echo harmless while keeping a genuine rename working.
+    """
+    if patient_name is None:
+        return False
+    incoming = str(patient_name).strip()
+    # Compare against what the serializer would have rendered, not against the
+    # split name. That catches both echoes with one test: the real name, and the
+    # "Patient {id}" placeholder get_patient_name synthesises for an unnamed
+    # person — which a naive comparison would happily write back as
+    # given_name='Patient', family_name='<id>'.
+    current = f'{person.given_name or ""} {person.family_name or ""}'.strip()
+    if incoming == (current or f'Patient {person.person_id}'):
+        return False
+    parts = incoming.split(None, 1)
+    person.given_name = parts[0] if parts else ''
+    person.family_name = parts[1] if len(parts) > 1 else ''
+    person.save(update_fields=['given_name', 'family_name'])
+    return True
+
+
 def _changed_fields(patient_record, previous_values, prev_val):
     """Fields whose stored value actually moved during this PATCH.
 
@@ -516,11 +563,19 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # patient_name maps onto Person, not PatientRecord, so it has to be
+        # applied by hand — the same treatment /patient-info/me/ gives it. Left
+        # in the body it is dropped as read-only, which is why renaming a
+        # patient from the UI silently did nothing: this is the route the client
+        # PATCHes.
+        _patient_name, _patch_data = _pop_patient_name(request.data)
+        _apply_patient_name(person, _patient_name)
+
         # Capture previous values for fields being changed (exclude provenance meta-fields).
         # Use {field}_id for FK fields so we get a serializable PK, not a model object.
         _prov_meta = {'source', 'source_user_id', 'modification_reason'}
         _read_only = set(PatientRecordSerializer.Meta.read_only_fields)
-        _ignored_ro = sorted((set(request.data) & _read_only) - _prov_meta)
+        _ignored_ro = sorted((set(_patch_data) & _read_only) - _prov_meta)
         if _ignored_ro:
             # DRF silently drops read-only fields from the input — surface the
             # attempt so API consumers learn the derived therapy-id fields are
@@ -536,11 +591,11 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             return getattr(obj, field, None)
         previous_values = {
             field: _prev_val(patient_info, field)
-            for field in request.data
+            for field in _patch_data
             if field not in _prov_meta and field not in _read_only and hasattr(patient_info, field)
         }
 
-        serializer = PatientRecordSerializer(patient_info, data=request.data, partial=True)
+        serializer = PatientRecordSerializer(patient_info, data=_patch_data, partial=True)
         serializer.is_valid(raise_exception=True)
 
         try:
@@ -555,7 +610,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                 changed_fields = _changed_fields(patient_info, previous_values, _prev_val)
                 if prov_source:
                     _record_provenance(patient_info, prov_source, prov_user_id, modification_reason=prov_reason, organization=get_request_org(request))
-                sync_to_omop(patient_info, changed_fields, changed_data=dict(request.data))
+                sync_to_omop(patient_info, changed_fields, changed_data=dict(_patch_data))
                 # PHR-S FM TI.1.2#04 — record field-level revision history.
                 _write_record_revisions(patient_info, previous_values, request)
                 if prov_source:
@@ -759,14 +814,8 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             })
 
         # PATCH
-        patient_name = request.data.pop('patient_name', None) if hasattr(request.data, 'pop') else request.data.get('patient_name')
-        patch_data = {k: v for k, v in request.data.items() if k != 'patient_name'}
-
-        if patient_name is not None:
-            parts = str(patient_name).strip().split(None, 1)
-            person.given_name = parts[0] if parts else ''
-            person.family_name = parts[1] if len(parts) > 1 else ''
-            person.save(update_fields=['given_name', 'family_name'])
+        patient_name, patch_data = _pop_patient_name(request.data)
+        _apply_patient_name(person, patient_name)
 
         serializer = PatientRecordSerializer(patient_info, data=patch_data, partial=True)
         serializer.is_valid(raise_exception=True)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -4509,6 +4509,42 @@ class PatientRecordOmopSyncTest(_SmartBase):
         pi.refresh_from_db()
         self.assertEqual(pi.user_edited_fields, [])
 
+    # --- patient_name write-through -------------------------------------------
+
+    def test_patch_patient_name_renames_the_person(self):
+        person = Person.objects.create(
+            person_id=91110, given_name='Alishia', family_name='Tawny Howell')
+        pi = PatientRecord.objects.create(person=person, organization=self.organization)
+
+        self._patch(pi, {'patient_name': 'Adam Blum'})
+
+        person.refresh_from_db()
+        self.assertEqual((person.given_name, person.family_name), ('Adam', 'Blum'))
+
+    def test_echoing_the_synthesised_name_back_does_not_corrupt_the_person(self):
+        """A client PATCHing the whole record echoes patient_name unchanged. For
+        a person with no name the serializer synthesises 'Patient {id}', and
+        writing that back would set given_name='Patient', family_name='91111'."""
+        person = Person.objects.create(person_id=91111, given_name='', family_name='')
+        pi = PatientRecord.objects.create(person=person, organization=self.organization)
+
+        self._patch(pi, {'patient_name': f'Patient {person.person_id}'})
+
+        person.refresh_from_db()
+        self.assertEqual(person.given_name, '')
+        self.assertEqual(person.family_name, '')
+
+    def test_echoing_an_unchanged_name_is_a_no_op(self):
+        person = Person.objects.create(
+            person_id=91112, given_name='Alishia', family_name='Tawny Howell')
+        pi = PatientRecord.objects.create(person=person, organization=self.organization)
+
+        self._patch(pi, {'patient_name': 'Alishia Tawny Howell', 'stage': 'II'})
+
+        person.refresh_from_db()
+        self.assertEqual(
+            (person.given_name, person.family_name), ('Alishia', 'Tawny Howell'))
+
     def test_patched_stage_survives_a_later_refresh(self):
         """End-to-end for #434: the exact sequence that lost the staging
         patient's stage — PATCH it, then re-derive."""


### PR DESCRIPTION
## Symptom

Renaming a patient in the UI appears to work, but the profile header keeps showing the old name — and a reload confirms it, because the name was never saved. Reproduced with "Alishia Tawny Howell": edit **Patient Name**, and the header, initials and avatar colour all keep rendering the original.

## Two independent faults

Either one alone was enough to break this, which is why it survived.

**1. The client never sent the new name.** `scheduleAutoSave` stashes it as `pendingDataRef.current.name`, but `doSave` PATCHed `data.info` only:

```js
pendingDataRef.current = { info, name };   // name captured...
await api.patch(`/patient-info/${personId}/`, data.info);   // ...and never sent
```

Worse than an omission: `data.info` is the whole GET response, which already carries the **original** `patient_name`. So every autosave echoed the old name back to the server.

**2. The route the client PATCHes never handled it.** `partial_update` on `/api/patient-info/{id}/` does not extract `patient_name` — only `/api/patient-info/me/` does. It is a `SerializerMethodField` over `Person.given_name`/`family_name`, not a `PatientRecord` column, so DRF dropped it as read-only and logged it under `read_only_patch_fields_ignored`.

`patientNameRef` was assigned on line 272 and read nowhere — the comparison it exists for had never been finished. The federation variant (`federation/PatientInfo.tsx:166`) *does* send `patient_name`, so only this component was affected.

## Fix

Extract `patient_name` on **both** routes through one shared pair of helpers (`_pop_patient_name` / `_apply_patient_name`) so the two cannot drift apart again. On the client, strip the echoed copy and send the edited name only on a real rename, then update the header state — it is set once on load, so otherwise the new name appears only after a refetch.

## A trap the fix opens, and closes

`get_patient_name` synthesises `"Patient {id}"` for a person with no name. Now that an echoed `patient_name` reaches a route that *acts* on it, writing that back would set `given_name='Patient'`, `family_name='3542'` — corrupting the row on an unrelated autosave.

`_apply_patient_name` compares the incoming string against **what the serializer would have rendered**, not against the split name. That catches both echo forms — the real name and the synthesised placeholder — in a single test, while leaving a genuine rename to write.

## Tests

6 new. Frontend: a rename sends `patient_name` and the old name stops being displayed; an unrelated edit omits it. Backend: a rename lands on `Person`, an unchanged echo is a no-op, and the synthesised placeholder does not corrupt the row.

**1274 Django + 177 pytest + 183 frontend, all green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
