### PR TITLE
Add organization vocabulary usage tab

### DIFF
--- a/frontend/src/components/OrgAdmin/OrgDetail.test.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.test.tsx
@@ -26,12 +26,65 @@ const ORG_DATA = {
   created_at: "2024-01-01T00:00:00Z",
 };
 
+const VOCABULARY_DATA = {
+  org_slug: "acme",
+  org_name: "Acme Clinic",
+  concept_count: 2,
+  concepts: [
+    {
+      concept_id: 9800001,
+      vocabulary_id: "SNOMED",
+      concept_code: "254837009",
+      concept_name: "Breast cancer",
+      domain_id: "Condition",
+      standard_concept: "S",
+      source: null,
+      group: "athena",
+      group_label: "Athena / external",
+      group_order: 0,
+      patient_count: 2,
+      instance_count: 3,
+      usage: [
+        {
+          table: "condition_occurrence",
+          column: "condition_concept_id",
+          role: "concept",
+          instance_count: 3,
+        },
+      ],
+    },
+    {
+      concept_id: 2000000101,
+      vocabulary_id: "HK-Wearable",
+      concept_code: "HK-WEAR-STRIDE",
+      concept_name: "HealthKey wearable stride",
+      domain_id: "Measurement",
+      standard_concept: "S",
+      source: "HealthKey",
+      group: "healthkey",
+      group_label: "HealthKey: HK-Wearable",
+      group_order: 1,
+      patient_count: 1,
+      instance_count: 1,
+      usage: [
+        {
+          table: "measurement",
+          column: "measurement_source_concept_id",
+          role: "source_concept",
+          instance_count: 1,
+        },
+      ],
+    },
+  ],
+};
+
 function setupMocks(overrides: Partial<typeof ORG_DATA> = {}) {
   const orgData = { ...ORG_DATA, ...overrides };
   mockGet.mockImplementation((url: string) => {
     if (url.includes("/orgs/acme/trusts/")) return Promise.resolve({ data: [] });
     if (url.includes("/orgs/acme/invitations/")) return Promise.resolve({ data: [] });
     if (url.includes("/orgs/acme/access/")) return Promise.resolve({ data: [] });
+    if (url.includes("/orgs/acme/vocabulary/")) return Promise.resolve({ data: VOCABULARY_DATA });
     if (url.includes("/orgs/acme/")) return Promise.resolve({ data: orgData });
     if (url.includes("/stats/org-disease/")) return Promise.resolve({ data: [] });
     if (url.includes("/orgs/")) return Promise.resolve({ data: [] });
@@ -187,6 +240,47 @@ describe("OrgDetail — Invite form", () => {
 
     fireEvent.change(roleSelect, { target: { value: "doctor" } });
     expect(screen.queryByPlaceholderText("Search by name or ID...")).not.toBeInTheDocument();
+  });
+});
+
+describe("OrgDetail — Vocabulary", () => {
+  it("loads and renders organization vocabulary usage", async () => {
+    setupMocks();
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Vocabulary"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Breast cancer")).toBeInTheDocument();
+    });
+    expect(mockGet).toHaveBeenCalledWith("/orgs/acme/vocabulary/");
+    expect(screen.getByText("SNOMED")).toBeInTheDocument();
+    expect(screen.getByText("HK-Wearable")).toBeInTheDocument();
+    expect(screen.getByText(/condition_occurrence/)).toBeInTheDocument();
+    expect(screen.getByText(/measurement/)).toBeInTheDocument();
+  });
+
+  it("filters vocabulary rows by search text", async () => {
+    setupMocks();
+    renderOrgDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Vocabulary"));
+    await waitFor(() => {
+      expect(screen.getByText("Breast cancer")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Search vocabulary, code, name..."), {
+      target: { value: "wearable" },
+    });
+
+    expect(screen.queryByText("Breast cancer")).not.toBeInTheDocument();
+    expect(screen.getByText("HealthKey wearable stride")).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/OrgAdmin/OrgDetail.tsx
+++ b/frontend/src/components/OrgAdmin/OrgDetail.tsx
@@ -78,7 +78,38 @@ interface OrgStatsData {
   disease_counts: DiseaseCount[];
 }
 
-type Section = 'settings' | 'trusts' | 'admins' | 'invitations' | 'stats';
+interface VocabularyUsageDetail {
+  table: string;
+  column: string;
+  role: string;
+  instance_count: number;
+}
+
+interface VocabularyConcept {
+  concept_id: number;
+  vocabulary_id: string;
+  concept_code: string;
+  concept_name: string;
+  domain_id: string;
+  standard_concept: string | null;
+  source: string | null;
+  group: 'athena' | 'healthkey' | 'nonconforming';
+  group_label: string;
+  group_order: number;
+  patient_count: number;
+  instance_count: number;
+  usage: VocabularyUsageDetail[];
+}
+
+interface OrgVocabularyData {
+  org_slug: string;
+  org_name: string;
+  concept_count: number;
+  concepts: VocabularyConcept[];
+}
+
+type Section = 'settings' | 'trusts' | 'admins' | 'invitations' | 'stats' | 'vocabulary';
+type VocabularySort = 'default' | 'patients' | 'instances' | 'name';
 
 export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const [org, setOrg] = useState<Org | null>(null);
@@ -87,6 +118,11 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [accessGrants, setAccessGrants] = useState<AccessGrant[]>([]);
   const [orgStats, setOrgStats] = useState<OrgStatsData | null>(null);
+  const [vocabularyData, setVocabularyData] = useState<OrgVocabularyData | null>(null);
+  const [vocabularyLoading, setVocabularyLoading] = useState(false);
+  const [vocabularyError, setVocabularyError] = useState<string | null>(null);
+  const [vocabularySearch, setVocabularySearch] = useState('');
+  const [vocabularySort, setVocabularySort] = useState<VocabularySort>('default');
   const [activeSection, setActiveSection] = useState<Section>('settings');
   const [error, setError] = useState<string | null>(null);
 
@@ -158,6 +194,19 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { fetchAll(); }, [fetchAll]);
+
+  const fetchVocabulary = useCallback(async () => {
+    try {
+      setVocabularyLoading(true);
+      setVocabularyError(null);
+      const res = await api.get<OrgVocabularyData>(`${base}/vocabulary/`);
+      setVocabularyData(res.data);
+    } catch {
+      setVocabularyError('Failed to load vocabulary usage.');
+    } finally {
+      setVocabularyLoading(false);
+    }
+  }, [base]);
 
   const handleSaveSettings = async () => {
     try {
@@ -328,10 +377,44 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
   const sections: { key: Section; label: string }[] = [
     { key: 'settings', label: 'Settings' },
     { key: 'stats', label: 'Stats' },
+    { key: 'vocabulary', label: 'Vocabulary' },
     { key: 'trusts', label: 'Access Rules' },
     { key: 'admins', label: 'Access Grants' },
     { key: 'invitations', label: 'Invitations' },
   ];
+  const vocabularyQuery = vocabularySearch.trim().toLowerCase();
+  const vocabularyRows = [...(vocabularyData?.concepts ?? [])]
+    .filter(row => !vocabularyQuery || [
+      row.vocabulary_id,
+      row.concept_code,
+      row.concept_name,
+      row.domain_id,
+      row.source ?? '',
+    ].some(value => value.toLowerCase().includes(vocabularyQuery)))
+    .sort((a, b) => {
+      if (vocabularySort === 'patients') {
+        return b.patient_count - a.patient_count || b.instance_count - a.instance_count;
+      }
+      if (vocabularySort === 'instances') {
+        return b.instance_count - a.instance_count || b.patient_count - a.patient_count;
+      }
+      if (vocabularySort === 'name') {
+        return a.concept_name.localeCompare(b.concept_name);
+      }
+      return (
+        a.group_order - b.group_order ||
+        a.vocabulary_id.localeCompare(b.vocabulary_id) ||
+        b.patient_count - a.patient_count ||
+        b.instance_count - a.instance_count ||
+        a.concept_name.localeCompare(b.concept_name)
+      );
+    });
+  const handleSectionChange = (section: Section) => {
+    setActiveSection(section);
+    if (section === 'vocabulary' && !vocabularyData && !vocabularyLoading) {
+      fetchVocabulary();
+    }
+  };
 
   return (
     <div className="p-6 space-y-4">
@@ -350,7 +433,7 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
         {sections.map(s => (
           <button
             key={s.key}
-            onClick={() => setActiveSection(s.key)}
+            onClick={() => handleSectionChange(s.key)}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
               activeSection === s.key
                 ? 'border-blue-600 text-blue-600'
@@ -450,6 +533,113 @@ export default function OrgDetail({ slug, isStaff, onBack }: OrgDetailProps) {
                 )}
               </tfoot>
             </table>
+          )}
+        </div>
+      )}
+
+      {/* Vocabulary */}
+      {activeSection === 'vocabulary' && (
+        <div className="space-y-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="font-medium text-gray-900">Vocabulary Usage</h2>
+              <p className="text-sm text-gray-500">
+                Org-scoped clinical concepts with distinct patient counts and total OMOP row counts.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <input
+                type="search"
+                value={vocabularySearch}
+                onChange={e => setVocabularySearch(e.target.value)}
+                placeholder="Search vocabulary, code, name..."
+                className="w-full min-w-64 border border-gray-300 rounded px-3 py-1.5 text-sm sm:w-72"
+              />
+              <select
+                value={vocabularySort}
+                onChange={e => setVocabularySort(e.target.value as VocabularySort)}
+                className="border border-gray-300 rounded px-2 py-1.5 text-sm"
+              >
+                <option value="default">Vocabulary order</option>
+                <option value="patients">Patient count</option>
+                <option value="instances">Instance count</option>
+                <option value="name">Concept name</option>
+              </select>
+            </div>
+          </div>
+
+          {vocabularyLoading && <p className="text-sm text-gray-500">Loading vocabulary usage...</p>}
+          {vocabularyError && <p className="text-sm text-red-500">{vocabularyError}</p>}
+          {!vocabularyLoading && !vocabularyError && vocabularyRows.length === 0 && (
+            <p className="text-sm text-gray-500">No vocabulary usage found for this organization.</p>
+          )}
+          {vocabularyRows.length > 0 && (
+            <div className="overflow-x-auto border border-gray-200 rounded-lg">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Vocabulary</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Concept</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Domain</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Patients</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Instances</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Usage</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {vocabularyRows.map(row => (
+                    <tr key={row.concept_id} className="border-t border-gray-100 align-top">
+                      <td className="px-4 py-3">
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium text-gray-900">{row.vocabulary_id}</span>
+                          <span className={`w-fit rounded px-2 py-0.5 text-xs font-medium ${
+                            row.group === 'nonconforming'
+                              ? 'bg-amber-100 text-amber-800'
+                              : row.group === 'healthkey'
+                                ? 'bg-emerald-100 text-emerald-700'
+                                : 'bg-blue-100 text-blue-700'
+                          }`}>
+                            {row.group_label}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="max-w-md">
+                          <div className="font-medium text-gray-900">{row.concept_name}</div>
+                          <div className="mt-1 text-xs text-gray-500">
+                            {row.concept_code} <span className="text-gray-300">|</span> #{row.concept_id}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        <div>{row.domain_id}</div>
+                        <div className="mt-1 text-xs text-gray-400">
+                          {row.standard_concept || 'non-standard'}{row.source ? ` / ${row.source}` : ''}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium text-gray-900">{row.patient_count}</td>
+                      <td className="px-4 py-3 text-right font-medium text-gray-900">{row.instance_count}</td>
+                      <td className="px-4 py-3 text-xs text-gray-600">
+                        <div className="flex max-w-xs flex-wrap gap-1.5">
+                          {row.usage.slice(0, 3).map(usage => (
+                            <span
+                              key={`${row.concept_id}-${usage.table}-${usage.column}`}
+                              className="rounded bg-gray-100 px-2 py-0.5"
+                              title={`${usage.table}.${usage.column}`}
+                            >
+                              {usage.table}: {usage.instance_count}
+                            </span>
+                          ))}
+                          {row.usage.length > 3 && (
+                            <span className="rounded bg-gray-100 px-2 py-0.5">+{row.usage.length - 3}</span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </div>
       )}

--- a/patient_portal/api/org_views.py
+++ b/patient_portal/api/org_views.py
@@ -19,7 +19,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.core.validators import URLValidator
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Count, F, Q
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -88,7 +88,10 @@ def _send_invitation_email(invitation) -> None:
         )
         raise InvitationEmailError
 
-from omop_core.models import Organization, OrgTrust, OrgInvitation, GroupAccess
+from omop_core.models import (
+    ConditionOccurrence, DrugExposure, Measurement, Observation,
+    Organization, OrgTrust, OrgInvitation, GroupAccess, ProcedureOccurrence,
+)
 from omop_core.services.organization_cleanup import delete_organization_with_patient_cascade
 from omop_core.services.access import get_admin_orgs
 from omop_core.services.pk import next_pk
@@ -132,6 +135,122 @@ def _get_or_create_invitee_identity(email):
 
 
 ROLE_RANK = {'org_admin': 3, 'doctor': 2, 'analyst': 1, 'patient': 0}
+
+NONCONFORMING_VOCABULARIES = frozenset({'LOCAL', 'FHIR', 'sct'})
+
+VOCABULARY_USAGE_SOURCES = (
+    (ConditionOccurrence, 'condition_occurrence', (
+        ('condition_concept', 'concept'),
+        ('condition_source_concept', 'source_concept'),
+    )),
+    (ProcedureOccurrence, 'procedure_occurrence', (
+        ('procedure_concept', 'concept'),
+        ('procedure_source_concept', 'source_concept'),
+    )),
+    (DrugExposure, 'drug_exposure', (
+        ('drug_concept', 'concept'),
+        ('drug_source_concept', 'source_concept'),
+    )),
+    (Measurement, 'measurement', (
+        ('measurement_concept', 'concept'),
+        ('measurement_source_concept', 'source_concept'),
+    )),
+    (Observation, 'observation', (
+        ('observation_concept', 'concept'),
+        ('observation_source_concept', 'source_concept'),
+    )),
+)
+
+
+def _vocabulary_group(vocabulary_id, source):
+    if vocabulary_id in NONCONFORMING_VOCABULARIES:
+        return 'nonconforming', 2, 'Non-conforming'
+    if (vocabulary_id or '').startswith('HK-') or source == 'HealthKey':
+        return 'healthkey', 1, f'HealthKey: {vocabulary_id}'
+    return 'athena', 0, 'Athena / external'
+
+
+def _org_vocabulary_usage(org):
+    concepts = {}
+
+    def ensure_concept(row):
+        concept_id = row['concept_id']
+        if concept_id not in concepts:
+            group, group_order, group_label = _vocabulary_group(
+                row['vocabulary_id'], row['source'],
+            )
+            concepts[concept_id] = {
+                'concept_id': concept_id,
+                'vocabulary_id': row['vocabulary_id'],
+                'concept_code': row['concept_code'],
+                'concept_name': row['concept_name'],
+                'domain_id': row['domain_id'],
+                'standard_concept': row['standard_concept'],
+                'source': row['source'],
+                'group': group,
+                'group_label': group_label,
+                'group_order': group_order,
+                'patient_ids': set(),
+                'instance_count': 0,
+                'usage': [],
+            }
+        return concepts[concept_id]
+
+    for model, table_name, fields in VOCABULARY_USAGE_SOURCES:
+        base_qs = model.objects.filter(person__patient_record__organization=org)
+        pk_name = model._meta.pk.name
+        for field_name, role in fields:
+            field_filter = {f'{field_name}__isnull': False}
+            value_exprs = {
+                'concept_id': F(f'{field_name}_id'),
+                'vocabulary_id': F(f'{field_name}__vocabulary_id'),
+                'concept_code': F(f'{field_name}__concept_code'),
+                'concept_name': F(f'{field_name}__concept_name'),
+                'domain_id': F(f'{field_name}__domain_id'),
+                'standard_concept': F(f'{field_name}__standard_concept'),
+                'source': F(f'{field_name}__source'),
+            }
+            usage_rows = (
+                base_qs
+                .filter(**field_filter)
+                .values(**value_exprs)
+                .annotate(instance_count=Count(pk_name))
+            )
+            for row in usage_rows:
+                concept = ensure_concept(row)
+                count = row['instance_count']
+                concept['instance_count'] += count
+                concept['usage'].append({
+                    'table': table_name,
+                    'column': f'{field_name}_id',
+                    'role': role,
+                    'instance_count': count,
+                })
+
+            patient_rows = (
+                base_qs
+                .filter(**field_filter)
+                .values('person_id', concept_id=F(f'{field_name}_id'))
+                .distinct()
+            )
+            for row in patient_rows:
+                if row['concept_id'] in concepts:
+                    concepts[row['concept_id']]['patient_ids'].add(row['person_id'])
+
+    result = []
+    for concept in concepts.values():
+        concept['patient_count'] = len(concept.pop('patient_ids'))
+        concept['usage'].sort(key=lambda item: (-item['instance_count'], item['table'], item['column']))
+        result.append(concept)
+
+    result.sort(key=lambda row: (
+        row['group_order'],
+        row['vocabulary_id'] or '',
+        -row['patient_count'],
+        -row['instance_count'],
+        row['concept_name'] or '',
+    ))
+    return result
 
 
 def _normalize_redirect_url(role, redirect_url):
@@ -589,6 +708,20 @@ class OrgAccessDetailView(APIView):
         grant = get_object_or_404(GroupAccess, id=access_id, org=org)
         grant.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class OrgVocabularyUsageView(APIView):
+    permission_classes = [IsStaffOrOrgAdmin]
+
+    def get(self, request, slug):
+        org = _get_org(slug)
+        concepts = _org_vocabulary_usage(org)
+        return Response({
+            'org_slug': org.slug,
+            'org_name': org.name,
+            'concept_count': len(concepts),
+            'concepts': concepts,
+        })
 
 
 # ---------------------------------------------------------------------------

--- a/patient_portal/api/urls.py
+++ b/patient_portal/api/urls.py
@@ -22,7 +22,7 @@ from .org_views import (
     OrgListCreateView, OrgDetailView,
     OrgInviteView, OrgInvitationListView, OrgInvitationDetailView,
     OrgTrustListCreateView, OrgTrustDetailView,
-    OrgAccessListView, OrgAccessDetailView,
+    OrgAccessListView, OrgAccessDetailView, OrgVocabularyUsageView,
     confirm_invitation,
 )
 
@@ -77,4 +77,5 @@ urlpatterns = [
     path('orgs/<slug:slug>/trusts/<int:trust_id>/', OrgTrustDetailView.as_view(), name='org-trust-detail'),
     path('orgs/<slug:slug>/access/', OrgAccessListView.as_view(), name='org-access-list'),
     path('orgs/<slug:slug>/access/<int:access_id>/', OrgAccessDetailView.as_view(), name='org-access-detail'),
+    path('orgs/<slug:slug>/vocabulary/', OrgVocabularyUsageView.as_view(), name='org-vocabulary-usage'),
 ]

--- a/patient_portal/api/v1_urls.py
+++ b/patient_portal/api/v1_urls.py
@@ -25,7 +25,7 @@ from .org_views import (
     OrgListCreateView, OrgDetailView,
     OrgInviteView, OrgInvitationListView, OrgInvitationDetailView,
     OrgTrustListCreateView, OrgTrustDetailView,
-    OrgAccessListView, OrgAccessDetailView,
+    OrgAccessListView, OrgAccessDetailView, OrgVocabularyUsageView,
     confirm_invitation, org_invitation_lookup, org_public_info, OrgPatientSignupView,
 )
 from .patient_invitations import (
@@ -101,6 +101,7 @@ urlpatterns = [
     path('orgs/<slug:slug>/trusts/<int:trust_id>/', OrgTrustDetailView.as_view(), name='v1-org-trust-detail'),
     path('orgs/<slug:slug>/access/', OrgAccessListView.as_view(), name='v1-org-access-list'),
     path('orgs/<slug:slug>/access/<int:access_id>/', OrgAccessDetailView.as_view(), name='v1-org-access-detail'),
+    path('orgs/<slug:slug>/vocabulary/', OrgVocabularyUsageView.as_view(), name='v1-org-vocabulary-usage'),
     path('orgs/<slug:slug>/public/', org_public_info, name='v1-org-public-info'),
     path('orgs/<slug:slug>/patient-signup/', OrgPatientSignupView.as_view(), name='v1-org-patient-signup'),
 ]

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -8936,6 +8936,167 @@ class OrgViewSetStaffTest(TestCase):
         self.assertTrue(Person.objects.filter(pk=other_person.pk).exists())
 
 
+class OrgVocabularyUsageAPITest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.staff = _make_user('vocab-staff@example.com', is_staff=True)
+        self.admin = _make_user('vocab-admin@example.com')
+        self.user = _make_user('vocab-user@example.com')
+        self.org = _make_org('Vocabulary Org', 'vocab-org')
+        self.other_org = _make_org('Other Vocabulary Org', 'other-vocab-org')
+        GroupAccess.objects.create(identity=self.admin, org=self.org, role='org_admin')
+
+        self.type_concept = self._concept(
+            9800000, 'EHR', 'OMOP4976890', 'Type Concept', 'Type Concept',
+        )
+        self.snomed = self._concept(
+            9800001, 'Breast cancer', '254837009', 'SNOMED', 'Condition',
+        )
+        self.hk = self._concept(
+            2000000101, 'HealthKey wearable stride', 'HK-WEAR-STRIDE',
+            'HK-Wearable', 'Measurement', source='HealthKey',
+        )
+        self.fhir = self._concept(
+            9800003, 'FHIR-coded legacy row', 'FHIR-LEGACY', 'FHIR', 'Observation',
+        )
+        self.generic_lab = self._concept(
+            9800004, 'Generic lab', '0', 'None', 'Measurement',
+        )
+
+        self.person_a = Person.objects.create(person_id=9801)
+        self.person_b = Person.objects.create(person_id=9802)
+        self.other_person = Person.objects.create(person_id=9803)
+        PatientRecord.objects.create(person=self.person_a, organization=self.org)
+        PatientRecord.objects.create(person=self.person_b, organization=self.org)
+        PatientRecord.objects.create(person=self.other_person, organization=self.other_org)
+
+        ConditionOccurrence.objects.create(
+            condition_occurrence_id=98001,
+            person=self.person_a,
+            condition_concept=self.snomed,
+            condition_start_date=date.today(),
+            condition_type_concept=self.type_concept,
+        )
+        ConditionOccurrence.objects.create(
+            condition_occurrence_id=98002,
+            person=self.person_b,
+            condition_concept=self.snomed,
+            condition_start_date=date.today(),
+            condition_type_concept=self.type_concept,
+        )
+        ConditionOccurrence.objects.create(
+            condition_occurrence_id=98003,
+            person=self.other_person,
+            condition_concept=self.snomed,
+            condition_start_date=date.today(),
+            condition_type_concept=self.type_concept,
+        )
+        Measurement.objects.create(
+            measurement_id=98004,
+            person=self.person_a,
+            measurement_concept=self.hk,
+            measurement_date=date.today(),
+            measurement_type_concept=self.type_concept,
+        )
+        Measurement.objects.create(
+            measurement_id=98005,
+            person=self.person_b,
+            measurement_concept=self.generic_lab,
+            measurement_source_concept=self.hk,
+            measurement_date=date.today(),
+            measurement_type_concept=self.type_concept,
+        )
+        Observation.objects.create(
+            observation_id=98006,
+            person=self.person_a,
+            observation_concept=self.fhir,
+            observation_date=date.today(),
+            observation_type_concept=self.type_concept,
+        )
+        Observation.objects.create(
+            observation_id=98007,
+            person=self.person_a,
+            observation_concept=self.fhir,
+            observation_date=date.today(),
+            observation_type_concept=self.type_concept,
+        )
+
+    def _concept(self, concept_id, name, code, vocabulary_id, domain_id,
+                 concept_class_id='Clinical Finding', standard='S', source=None):
+        vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id=vocabulary_id,
+            defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0},
+        )
+        domain, _ = Domain.objects.get_or_create(
+            domain_id=domain_id,
+            defaults={'domain_name': domain_id, 'domain_concept_id': 0},
+        )
+        concept_class, _ = ConceptClass.objects.get_or_create(
+            concept_class_id=concept_class_id,
+            defaults={
+                'concept_class_name': concept_class_id,
+                'concept_class_concept_id': 0,
+            },
+        )
+        return Concept.objects.create(
+            concept_id=concept_id,
+            concept_name=name,
+            concept_code=code,
+            vocabulary=vocab,
+            domain=domain,
+            concept_class=concept_class,
+            standard_concept=standard,
+            source=source,
+            valid_start_date=date.today(),
+            valid_end_date=date(2099, 12, 31),
+        )
+
+    def test_returns_org_scoped_vocabulary_usage_counts(self):
+        self.client.force_authenticate(user=self.staff)
+
+        resp = self.client.get('/api/orgs/vocab-org/vocabulary/')
+
+        self.assertEqual(resp.status_code, 200)
+        by_id = {row['concept_id']: row for row in resp.data['concepts']}
+        self.assertEqual(by_id[self.snomed.concept_id]['patient_count'], 2)
+        self.assertEqual(by_id[self.snomed.concept_id]['instance_count'], 2)
+        self.assertEqual(by_id[self.hk.concept_id]['patient_count'], 2)
+        self.assertEqual(by_id[self.hk.concept_id]['instance_count'], 2)
+        self.assertEqual(by_id[self.hk.concept_id]['group'], 'healthkey')
+        self.assertEqual(by_id[self.fhir.concept_id]['patient_count'], 1)
+        self.assertEqual(by_id[self.fhir.concept_id]['instance_count'], 2)
+        self.assertEqual(by_id[self.fhir.concept_id]['group'], 'nonconforming')
+        self.assertNotIn(self.type_concept.concept_id, by_id)
+        self.assertTrue(any(
+            usage['column'] == 'measurement_source_concept_id'
+            for usage in by_id[self.hk.concept_id]['usage']
+        ))
+
+    def test_orders_external_then_healthkey_then_nonconforming(self):
+        self.client.force_authenticate(user=self.staff)
+
+        resp = self.client.get('/api/orgs/vocab-org/vocabulary/')
+
+        self.assertEqual(resp.status_code, 200)
+        groups = [row['group'] for row in resp.data['concepts']]
+        self.assertLess(groups.index('athena'), groups.index('healthkey'))
+        self.assertLess(groups.index('healthkey'), groups.index('nonconforming'))
+
+    def test_org_admin_can_read_own_org_vocabulary(self):
+        self.client.force_authenticate(user=self.admin)
+
+        resp = self.client.get('/api/orgs/vocab-org/vocabulary/')
+
+        self.assertEqual(resp.status_code, 200)
+
+    def test_non_admin_cannot_read_org_vocabulary(self):
+        self.client.force_authenticate(user=self.user)
+
+        resp = self.client.get('/api/orgs/vocab-org/vocabulary/')
+
+        self.assertEqual(resp.status_code, 403)
+
+
 class OrganizationCleanupServiceTest(TestCase):
     """Shared org deletion helper must cascade patient data."""
 


### PR DESCRIPTION
Closes #462.\n\n## Summary\n- add org-scoped vocabulary usage API for clinical concept/source concept columns\n- group concepts as Athena/external, HealthKey, or non-conforming local vocabularies\n- add Vocabulary tab to org admin detail with search, sorting, patient counts, instance counts, and usage chips\n\n## Tests\n- DEBUG=True DATABASE_URL=postgresql://postgres@localhost:5432/promop_test_462 /Users/adam/promop/.venv/bin/python -m pytest patient_portal/tests.py::OrgVocabularyUsageAPITest -q\n- npm test -- OrgDetail.test.tsx\n- npm run build\n- DEBUG=True DATABASE_URL=postgresql://postgres@localhost:5432/promop_test_462 /Users/adam/promop/.venv/bin/python manage.py check\n- DEBUG=True DATABASE_URL=postgresql://postgres@localhost:5432/promop_test_462 /Users/adam/promop/.venv/bin/python manage.py makemigrations --check --dry-run