### PR TITLE
Make the bulk OMOP write endpoints idempotent (#454)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -717,14 +717,41 @@ The five OMOP clinical CRUD endpoints (`conditions`, `drug-exposures`, `measurem
 `observations`, `procedures`) accept a **JSON array** on POST for callers that have
 already parsed FHIR into OMOP rows. Single-dict POSTs are unchanged.
 
-Contract: `201` with `{"created": N, "ids": [...]}`, ids in request order. One
-transaction, all-or-nothing. One batch is one person (mixed-person → 400). Server
-assigns PKs via `next_pk_batch` (client-supplied PKs → 400). Per-index validation
-errors. Max 1,000 rows (`OMOP_BULK_MAX_ROWS`) → 413. Provenance comes from the
-`X-Provenance-Source` / `X-Provenance-User-Id` headers and applies to the whole
-batch; no source means no `ProvenanceRecord`, matching the single-row path.
+Contract: `201` with `{"created": N, "updated": M, "ids": [...]}`, one id per
+request row in request order. One transaction, all-or-nothing. One batch is one
+person (mixed-person → 400). Server assigns PKs via `next_pk_batch`
+(client-supplied PKs → 400). Per-index validation errors. Max 1,000 rows
+(`OMOP_BULK_MAX_ROWS`) → 413. Provenance comes from the `X-Provenance-Source` /
+`X-Provenance-User-Id` headers and applies to the whole batch; no source means no
+`ProvenanceRecord`, matching the single-row path.
 
-Two things to know before touching this code:
+**The write is idempotent by default** (issue #454). Rows are upserted on the
+event identity in `_UPSERT_KEYS`, the same identity
+`fhir/sync.py::_upsert_clinical` uses — so an ETL re-run, a retry after a read
+timeout, or a re-parse converges instead of duplicating. Semantics per key:
+event already present → left in place, its concept updated when it changed and
+any stacked historical duplicates collapsed onto the earliest row; otherwise
+inserted. Repeats within one batch collapse to a single row (last occurrence
+wins). Only the concept column is rewritten on a matched row — every other
+column is left as stored, so a re-run cannot quietly overwrite a corrected
+value. Only inserted rows get a `ProvenanceRecord`. `?upsert=false` restores
+append-only writes.
+
+| Model | Event identity |
+|---|---|
+| ConditionOccurrence, DrugExposure, Observation, ProcedureOccurrence | `(source_value, date)` |
+| Measurement | `(source_value, date, datetime, value_as_number)` |
+
+Measurement is the deliberate divergence: a patient legitimately has several
+distinct results for one analyte on one day, so `(source_value, date)` alone
+would not dedup a re-run — it would delete real results. The wider key matches
+what `fhir/sync.py::_insert_discrete_observations` already dedups on. The concept
+column stays *outside* every key, which is what lets a vocabulary load upgrade a
+stored row in place instead of stranding a duplicate beside it.
+
+A row with no `source_value` or no date has no identity and is always inserted.
+
+Three things to know before touching this code:
 
 - **`bulk_create` does not fire `post_save`**, so the `omop_core/signals.py` receivers
   that rebuild `PatientRecord` do not run. The bulk path calls `refresh_patient_record`
@@ -732,8 +759,14 @@ Two things to know before touching this code:
   rows that the read model never reflects.
 - **Query count must stay flat in batch size.** DRF resolves FKs with a per-row
   `queryset.get(pk=...)`; `_prefetch_bulk_related` collapses that to one query per FK
-  column. `BulkOmopWriteTest` asserts this with `CaptureQueriesContext` at two batch
-  sizes — treat a failure there as a real regression, not a flaky threshold.
+  column. The upsert match is one superset `SELECT` for the whole batch, not the
+  per-key query `_upsert_clinical` can afford on a small FHIR compartment.
+  `BulkOmopWriteTest` and `BulkOmopUpsertTest` assert this with
+  `CaptureQueriesContext` at two batch sizes — treat a failure there as a real
+  regression, not a flaky threshold.
+- **The collapse path deletes rows, and `post_delete` receivers are live.** The
+  whole write block runs inside `suppress_patient_record_refresh()`; without it a
+  batch that collapses duplicates fires one refresh per deleted row.
 
 ---
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -4570,6 +4570,189 @@ def _prefetch_bulk_related(serializer, rows):
             field.to_internal_value = _cached_pk_lookup(field, objs)
 
 
+#: Identity of a clinical event for the idempotent bulk write, mirroring
+#: ``fhir/sync.py::_upsert_clinical``: ``(source_value, date)`` is "the stable
+#: identity of a clinical event, independent of how its code resolves", so the
+#: concept column stays *outside* the key and is upgraded in place when a
+#: vocabulary load resolves a code that previously fell back to 'No matching
+#: concept'.
+#:
+#: Measurement is the one deliberate divergence. A patient legitimately has
+#: several distinct results for one analyte on one day (repeat draws, sub-daily
+#: vitals), so keying it on (source_value, date) alone would not dedup a re-run
+#: — it would delete real results and keep one. Its timestamp and value
+#: therefore join the key, which is exactly what
+#: ``fhir/sync.py::_insert_discrete_observations`` already dedups discrete
+#: readings on.
+#:
+#: Format: model name -> (source_value field, date field, concept field, extra key fields)
+_UPSERT_KEYS = {
+    'ConditionOccurrence': ('condition_source_value', 'condition_start_date',
+                            'condition_concept', ()),
+    'DrugExposure':        ('drug_source_value', 'drug_exposure_start_date',
+                            'drug_concept', ()),
+    'Measurement':         ('measurement_source_value', 'measurement_date',
+                            'measurement_concept',
+                            ('measurement_datetime', 'value_as_number')),
+    'Observation':         ('observation_source_value', 'observation_date',
+                            'observation_concept', ()),
+    'ProcedureOccurrence': ('procedure_source_value', 'procedure_date',
+                            'procedure_concept', ()),
+}
+
+
+def _upsert_key(instance, sv_field, date_field, extra_fields):
+    """Event identity of one unsaved row, or None when it has none.
+
+    A row with no source_value or no date cannot be matched against anything, so
+    it is always inserted rather than silently merged with every other keyless
+    row in the batch. Numeric parts need no normalisation: Python compares and
+    hashes Decimal against int/float by value, so Decimal('5.00000') off the row
+    and Decimal('5.0') off the request body land in the same bucket.
+    """
+    sv = getattr(instance, sv_field, None)
+    event_date = getattr(instance, date_field, None)
+    if not sv or event_date is None:
+        return None
+    return (sv, event_date) + tuple(getattr(instance, f, None) for f in extra_fields)
+
+
+class _UpsertPlan:
+    """What one bulk batch resolves to once matched against the person's rows.
+
+    Built with a single SELECT and executed with a constant number of statements
+    regardless of batch size — the property ``BulkOmopUpsertTest`` pins with
+    ``CaptureQueriesContext``. Per-row ``.get()``/``.save()`` here is what the
+    endpoint exists to avoid; ``fhir/sync.py::_upsert_clinical`` can afford its
+    per-key query because a FHIR compartment is small, a 1,000-row ETL chunk is
+    not.
+    """
+
+    def __init__(self, to_insert, row_slots, collapse_ids, to_update, touched_ids):
+        self.to_insert = to_insert        # unsaved rows needing a pk, in order
+        self.row_slots = row_slots        # per input row: ('new', slot) | ('old', pk)
+        self.collapse_ids = collapse_ids  # stacked duplicates to delete
+        self.to_update = to_update        # [(pk, concept_id)] — concept changed
+        self.touched_ids = touched_ids    # existing rows updated or de-stacked
+
+
+def _plan_bulk_upsert(model_cls, pk_field, model_name, person, instances):
+    """Match a batch of unsaved rows against what `person` already has.
+
+    Same three outcomes as ``_upsert_clinical``: an event already on file is left
+    in place (its concept updated when it changed, its stacked historical
+    duplicates collapsed onto the earliest row), and anything else is inserted.
+    Only the concept is rewritten on a matched row — every other column is left
+    as stored, so a re-run cannot quietly overwrite a value someone corrected.
+    Repeats of one event *within* the batch collapse to a single row, last
+    occurrence winning, so a source bundle that reports an event twice does not
+    write it twice.
+    """
+    sv_field, date_field, concept_field, extra_fields = _UPSERT_KEYS[model_name]
+    cid_attr = f'{concept_field}_id'
+
+    keys = [_upsert_key(inst, sv_field, date_field, extra_fields)
+            for inst in instances]
+    keyed = [k for k in keys if k is not None]
+
+    # One SELECT for every row of this person that could match the batch. The
+    # (source_value IN …, date IN …) pair is a superset of the real key set —
+    # narrowing it to exact tuples would need a per-key OR term, i.e. the query
+    # growth this endpoint exists to avoid. The superset is bounded by the
+    # person's own rows for those source values.
+    existing = {}   # key -> [pk, …] ascending
+    existing_cid = {}
+    if keyed:
+        columns = (pk_field, cid_attr, sv_field, date_field) + tuple(extra_fields)
+        rows = model_cls.objects.filter(**{
+            'person': person,
+            f'{sv_field}__in': {k[0] for k in keyed},
+            f'{date_field}__in': {k[1] for k in keyed},
+        }).order_by(pk_field).values_list(*columns)
+        for row in rows:
+            key = (row[2], row[3]) + tuple(row[4:])
+            if key in existing:
+                existing[key].append(row[0])
+            else:
+                existing[key] = [row[0]]
+                existing_cid[key] = row[1]
+
+    # Last occurrence of a repeated key wins, matching _upsert_clinical's
+    # "desired" dict — so the batch converges on the row the producer emitted
+    # most recently rather than the first one it happened to serialise.
+    last_index = {}
+    for i, key in enumerate(keys):
+        if key is not None:
+            last_index[key] = i
+
+    to_insert, row_slots = [], [None] * len(instances)
+    insert_slot, collapse_ids, to_update, touched_ids = {}, [], [], []
+
+    for i, (inst, key) in enumerate(zip(instances, keys)):
+        if key is None:                       # no identity — always insert
+            row_slots[i] = ('new', len(to_insert))
+            to_insert.append(inst)
+            continue
+
+        if key in existing:
+            keep = existing[key][0]
+            row_slots[i] = ('old', keep)
+            if last_index[key] != i:
+                continue                      # decide the key once, on its last row
+            extras = existing[key][1:]
+            collapse_ids.extend(extras)
+            new_cid = getattr(inst, cid_attr, None)
+            if existing_cid[key] != new_cid:
+                to_update.append((keep, new_cid))
+                touched_ids.append(keep)
+            elif extras:
+                touched_ids.append(keep)
+            continue
+
+        if key in insert_slot:                # repeated within this batch
+            slot = insert_slot[key]
+            if last_index[key] == i:
+                to_insert[slot] = inst
+        else:
+            slot = insert_slot[key] = len(to_insert)
+            to_insert.append(inst)
+        row_slots[i] = ('new', slot)
+
+    return _UpsertPlan(to_insert, row_slots, collapse_ids, to_update, touched_ids)
+
+
+def _apply_upsert_plan(plan, model_cls, pk_field, model_name):
+    """Execute a plan: collapse duplicates, update changed concepts, insert the
+    rest. Returns (ids aligned with the input rows, newly inserted ids)."""
+    concept_field = _UPSERT_KEYS[model_name][2]
+    cid_attr = f'{concept_field}_id'
+
+    if plan.collapse_ids:
+        # Provenance first: it points at rows that are about to disappear, and a
+        # GenericForeignKey has no FK cascade to clean it up.
+        ProvenanceRecord.objects.filter(
+            content_type=ContentType.objects.get_for_model(model_cls),
+            object_id__in=plan.collapse_ids,
+        ).delete()
+        model_cls.objects.filter(**{f'{pk_field}__in': plan.collapse_ids}).delete()
+
+    if plan.to_update:
+        model_cls.objects.bulk_update(
+            [model_cls(**{pk_field: pk, cid_attr: cid}) for pk, cid in plan.to_update],
+            [concept_field],
+        )
+
+    new_ids = []
+    if plan.to_insert:
+        new_ids = list(next_pk_batch(model_cls, pk_field, len(plan.to_insert)))
+        for row, pk in zip(plan.to_insert, new_ids):
+            setattr(row, pk_field, pk)
+        model_cls.objects.bulk_create(plan.to_insert)
+
+    ids = [new_ids[ref] if kind == 'new' else ref for kind, ref in plan.row_slots]
+    return ids, new_ids
+
+
 class _OmopBulkCreateMixin:
     """Accept a JSON *list* on POST and insert the rows in one batched transaction.
 
@@ -4583,6 +4766,12 @@ class _OmopBulkCreateMixin:
     * A single dict body is untouched and still goes through the normal DRF path.
     * All-or-nothing: the whole batch shares one ``transaction.atomic()``.
     * One batch is one person. Mixed-person batches are rejected with 400.
+    * Idempotent by default (issue #454): rows are upserted on the event identity
+      ``_UPSERT_KEYS`` defines, the same identity ``fhir/sync.py::_upsert_clinical``
+      uses, so re-posting a batch converges instead of duplicating. The response
+      reports ``created`` vs ``updated``; ``ids`` stays positionally aligned with
+      the request rows and names the row each one resolved to. ``?upsert=false``
+      restores the append-only behaviour.
     * Query count is bounded by a constant, not by the number of rows.
     * ``bulk_create`` does not fire ``post_save``, so the ``omop_core.signals``
       receivers that rebuild ``PatientRecord`` never run. The refresh is therefore
@@ -4645,7 +4834,8 @@ class _OmopBulkCreateMixin:
         validated = serializer.validated_data
 
         if not validated:
-            return Response({'created': 0, 'ids': []}, status=status.HTTP_201_CREATED)
+            return Response({'created': 0, 'updated': 0, 'ids': []},
+                            status=status.HTTP_201_CREATED)
 
         # One batch is one person, by construction on the producer side.
         people = {attrs.get('person') for attrs in validated}
@@ -4684,6 +4874,14 @@ class _OmopBulkCreateMixin:
         skip_refresh = str(
             request.query_params.get('skip_refresh', 'false')
         ).strip().lower() in ('1', 'true', 'yes')
+        # Idempotent by default: the endpoint carries no idempotency key of any
+        # kind, so an ETL re-run, a retry after a read timeout, or a re-parse
+        # would otherwise duplicate every row it had already written. Callers
+        # that genuinely want append-only writes (an audit-style feed of rows
+        # with no stable identity) pass ?upsert=false.
+        upsert = str(
+            request.query_params.get('upsert', 'true')
+        ).strip().lower() not in ('0', 'false', 'no')
 
         from omop_core.signals import suppress_patient_record_refresh
 
@@ -4692,19 +4890,29 @@ class _OmopBulkCreateMixin:
             # receivers would not run anyway. Suppressing explicitly is the
             # documented house idiom for bulk writes (omop_core/signals.py) and
             # keeps "one refresh per batch, never per row" true even if a future
-            # change introduces a per-row save() in here.
+            # change introduces a per-row save() in here. The upsert path *does*
+            # delete collapsed duplicates, and post_delete receivers are live —
+            # so here the suppression is load-bearing, not just defensive.
             with suppress_patient_record_refresh():
-                ids = next_pk_batch(model_cls, pk_field, len(validated))
-                instances = []
-                for attrs, pk in zip(validated, ids):
-                    attrs = dict(attrs)
-                    attrs[pk_field] = pk
-                    instances.append(model_cls(**attrs))
-                model_cls.objects.bulk_create(instances)
+                instances = [model_cls(**dict(attrs)) for attrs in validated]
+                if upsert:
+                    plan = _plan_bulk_upsert(
+                        model_cls, pk_field, model_name, person, instances)
+                    ids, new_ids = _apply_upsert_plan(
+                        plan, model_cls, pk_field, model_name)
+                    updated = len(plan.touched_ids)
+                else:
+                    new_ids = list(next_pk_batch(model_cls, pk_field, len(instances)))
+                    for inst, pk in zip(instances, new_ids):
+                        setattr(inst, pk_field, pk)
+                    model_cls.objects.bulk_create(instances)
+                    ids, updated = list(new_ids), 0
 
             # No source supplied means no ProvenanceRecord, matching the single-row
             # path — inventing a source would make provenance unfalsifiable.
-            if source:
+            # Only inserted rows get one: an upsert that left a row untouched
+            # wrote nothing to attribute, matching _upsert_clinical.
+            if source and new_ids:
                 ct = ContentType.objects.get_for_model(model_cls)
                 ProvenanceRecord.objects.bulk_create([
                     ProvenanceRecord(
@@ -4716,7 +4924,7 @@ class _OmopBulkCreateMixin:
                         content_type=ct,
                         object_id=pk,
                     )
-                    for pk in ids
+                    for pk in new_ids
                 ])
 
             # Deliberately inside the transaction, and deliberately unguarded:
@@ -4736,7 +4944,7 @@ class _OmopBulkCreateMixin:
                 refresh_patient_record(person)
 
         return Response(
-            {'created': len(ids), 'ids': list(ids)},
+            {'created': len(new_ids), 'updated': updated, 'ids': list(ids)},
             status=status.HTTP_201_CREATED,
         )
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -4606,9 +4606,14 @@ def _upsert_key(instance, sv_field, date_field, extra_fields):
 
     A row with no source_value or no date cannot be matched against anything, so
     it is always inserted rather than silently merged with every other keyless
-    row in the batch. Numeric parts need no normalisation: Python compares and
-    hashes Decimal against int/float by value, so Decimal('5.00000') off the row
-    and Decimal('5.0') off the request body land in the same bucket.
+    row in the batch. The numeric part needs no normalisation *because both sides
+    are Decimal*: value_as_number is a DecimalField, so DRF hands back a Decimal
+    and the DB column returns one, and Decimal compares and hashes across
+    exponents — Decimal('5.00000') off the row and Decimal('5.0') off the request
+    body land in the same bucket. That does not generalise to float: most
+    non-integer floats compare unequal to the Decimal of the same literal
+    (Decimal('0.1') != 0.1), so a FloatField joining a key here would need
+    explicit normalisation to one type.
     """
     sv = getattr(instance, sv_field, None)
     event_date = getattr(instance, date_field, None)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -16676,7 +16676,7 @@ class BulkOmopWriteTest(TestCase):
     def test_empty_list_is_a_noop(self):
         resp = self.client.post('/api/v1/measurements/', [], format='json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(resp.data, {'created': 0, 'ids': []})
+        self.assertEqual(resp.data, {'created': 0, 'updated': 0, 'ids': []})
 
     # --- query count ------------------------------------------------------
 
@@ -16795,8 +16795,11 @@ class BulkOmopWriteTest(TestCase):
         self.assertEqual(Measurement.objects.count(), before)
 
     def test_batch_at_exactly_the_limit_is_accepted(self):
+        # Distinct rows: the batch has to actually write OMOP_BULK_MAX_ROWS rows
+        # for the limit to mean anything, and since the write is idempotent
+        # (issue #454) a batch of identical rows would collapse to one.
         from patient_portal.api.views import OMOP_BULK_MAX_ROWS
-        rows = self._rows(1) * OMOP_BULK_MAX_ROWS
+        rows = self._rows(OMOP_BULK_MAX_ROWS)
         resp = self.client.post(
             '/api/v1/measurements/?skip_refresh=true', rows, format='json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
@@ -17102,3 +17105,417 @@ class BulkOmopWriteTest(TestCase):
             '/api/v1/measurements/', self._rows(3), format='json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
         self.assertEqual(resp.data['created'], 3)
+
+
+class BulkOmopUpsertTest(TestCase):
+    """The bulk OMOP write endpoints are idempotent (issue #454).
+
+    The endpoint carries no idempotency key, so before this every ETL re-run,
+    every retry after a read timeout, and every re-parse duplicated rows the
+    server already held — one observed patient ended up with 8,879 measurements
+    from retries of writes that had in fact succeeded. Source bundles also repeat
+    events internally (41 conditions parsing to 30 distinct events), so even the
+    first load was not convergent.
+
+    These cover the four semantics ported from fhir/sync.py::_upsert_clinical —
+    re-post is a no-op, a changed concept updates in place, within-batch repeats
+    collapse, pre-existing stacked duplicates collapse — plus the properties that
+    had to survive: one refresh per batch, and a query count flat in batch size.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        _make_vocab_fixtures()
+        cls.person = Person.objects.create(person_id=32001)
+        cls.other_person = Person.objects.create(person_id=32002)
+        PatientRecord.objects.create(person=cls.person)
+        PatientRecord.objects.create(person=cls.other_person)
+
+        cls.m_concept = Concept.objects.get(concept_id=3000963)
+        # Stands in for the concept a later vocabulary load resolves the same
+        # source code to; any Concept row works, the FK is not domain-checked.
+        cls.upgraded_concept = Concept.objects.get(concept_id=4112853)
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+
+        cls.service_identity = Identity.objects.get_or_create(
+            issuer='urn:service', sub='bulk-upsert-test',
+        )[0]
+        cls.service_identity.set_unusable_password()
+        cls.service_identity.save()
+
+    def setUp(self):
+        from django.core.cache import cache
+        cache.clear()
+        self.client = APIClient()
+        self.client.force_authenticate(
+            user=self.service_identity, token="service-token")
+
+    # --- helpers ----------------------------------------------------------
+
+    def _rows(self, n, person=None, start_day=0, concept=None):
+        person = person or self.person
+        concept = concept or self.m_concept
+        base = date(2024, 1, 1)
+        return [
+            {
+                'person': person.person_id,
+                'measurement_concept': concept.concept_id,
+                'measurement_date': (base + timedelta(days=start_day + i)).isoformat(),
+                'measurement_type_concept': self.type_concept.concept_id,
+                'value_as_number': 5.0 + i,
+                'measurement_source_value': f'LOCAL-{i}',
+            }
+            for i in range(n)
+        ]
+
+    def _conditions(self, source_values, day='2024-01-01', concept=None):
+        concept = concept or self.m_concept
+        return [
+            {
+                'person': self.person.person_id,
+                'condition_concept': concept.concept_id,
+                'condition_start_date': day,
+                'condition_type_concept': self.type_concept.concept_id,
+                'condition_source_value': sv,
+            }
+            for sv in source_values
+        ]
+
+    def _post(self, rows, route='measurements', query='?skip_refresh=true'):
+        resp = self.client.post(f'/api/v1/{route}/{query}', rows, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        return resp.data
+
+    # --- acceptance criteria ---------------------------------------------
+
+    def test_reposting_the_same_batch_writes_no_new_rows(self):
+        """The headline case: an ETL re-run converges instead of doubling."""
+        rows = self._rows(4)
+        first = self._post(rows)
+        self.assertEqual(first['created'], 4)
+        self.assertEqual(first['updated'], 0)
+
+        second = self._post(rows)
+        self.assertEqual(second['created'], 0)
+        self.assertEqual(second['updated'], 0)
+        self.assertEqual(
+            Measurement.objects.filter(person=self.person).count(), 4,
+            're-posting an unchanged batch duplicated the rows')
+        # The second response still names a row per request row — the caller can
+        # keep using ids positionally without knowing whether it inserted.
+        self.assertEqual(second['ids'], first['ids'])
+
+    def test_changed_concept_updates_in_place_instead_of_duplicating(self):
+        """A vocabulary load upgrading 'No matching concept' must not strand a
+        duplicate — the stored row's concept is corrected in place."""
+        rows = self._conditions(['C50.9'])
+        created = self._post(rows, route='conditions')
+        self.assertEqual(created['created'], 1)
+
+        upgraded = self._conditions(['C50.9'], concept=self.upgraded_concept)
+        resp = self._post(upgraded, route='conditions')
+        self.assertEqual(resp['created'], 0)
+        self.assertEqual(resp['updated'], 1)
+
+        rows_now = ConditionOccurrence.objects.filter(person=self.person)
+        self.assertEqual(rows_now.count(), 1, 'the concept change duplicated the row')
+        self.assertEqual(
+            rows_now.first().condition_concept_id, self.upgraded_concept.concept_id)
+        self.assertEqual(resp['ids'], created['ids'], 'the row identity changed')
+
+    def test_repeats_within_one_batch_collapse_to_one_row(self):
+        """Source bundles repeat events; the first load must still converge."""
+        rows = self._conditions(['C50.9', 'C50.9', 'I10', 'C50.9'])
+        resp = self._post(rows, route='conditions')
+
+        self.assertEqual(resp['created'], 2)
+        self.assertEqual(
+            ConditionOccurrence.objects.filter(person=self.person).count(), 2)
+        # Every request row still maps to the row it resolved to, so a caller
+        # that stored ids positionally is not silently misaligned.
+        self.assertEqual(len(resp['ids']), 4)
+        self.assertEqual(resp['ids'][0], resp['ids'][1])
+        self.assertEqual(resp['ids'][0], resp['ids'][3])
+        self.assertNotEqual(resp['ids'][0], resp['ids'][2])
+
+    def test_last_occurrence_of_a_repeated_key_wins(self):
+        """Matches _upsert_clinical's last-wins `desired` dict, so the batch
+        converges on what the producer emitted most recently."""
+        rows = self._conditions(['C50.9']) + self._conditions(
+            ['C50.9'], concept=self.upgraded_concept)
+        resp = self._post(rows, route='conditions')
+
+        self.assertEqual(resp['created'], 1)
+        stored = ConditionOccurrence.objects.get(person=self.person)
+        self.assertEqual(
+            stored.condition_concept_id, self.upgraded_concept.concept_id)
+
+    def test_preexisting_stacked_duplicates_are_collapsed(self):
+        """Rows a previous non-idempotent load already doubled are cleaned up on
+        the next write, onto the earliest row."""
+        appended = self._post(
+            self._conditions(['C50.9']), route='conditions',
+            query='?skip_refresh=true&upsert=false')
+        again = self._post(
+            self._conditions(['C50.9']), route='conditions',
+            query='?skip_refresh=true&upsert=false')
+        self.assertEqual(
+            ConditionOccurrence.objects.filter(person=self.person).count(), 2)
+
+        resp = self._post(self._conditions(['C50.9']), route='conditions')
+        self.assertEqual(resp['created'], 0)
+        self.assertEqual(resp['updated'], 1)
+        remaining = list(ConditionOccurrence.objects.filter(person=self.person))
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(
+            remaining[0].condition_occurrence_id, appended['ids'][0],
+            'duplicates collapsed onto the wrong row — the earliest must survive')
+        self.assertFalse(
+            ConditionOccurrence.objects.filter(
+                condition_occurrence_id=again['ids'][0]).exists())
+
+    def test_collapsing_a_duplicate_removes_its_provenance(self):
+        """ProvenanceRecord points at rows via a GenericForeignKey, so nothing
+        cascades — a collapsed duplicate would leave a dangling record behind."""
+        from omop_core.models import ProvenanceRecord
+        from django.contrib.contenttypes.models import ContentType
+
+        headers = {'HTTP_X_PROVENANCE_SOURCE': 'EHR_SYNC',
+                   'HTTP_X_PROVENANCE_USER_ID': 'etl-run-9'}
+        first = self.client.post(
+            '/api/v1/conditions/?skip_refresh=true&upsert=false',
+            self._conditions(['C50.9']), format='json', **headers).data
+        dupe = self.client.post(
+            '/api/v1/conditions/?skip_refresh=true&upsert=false',
+            self._conditions(['C50.9']), format='json', **headers).data
+
+        ct = ContentType.objects.get_for_model(ConditionOccurrence)
+        self.assertEqual(ProvenanceRecord.objects.filter(content_type=ct).count(), 2)
+
+        self._post(self._conditions(['C50.9']), route='conditions')
+
+        self.assertEqual(
+            list(ProvenanceRecord.objects.filter(content_type=ct)
+                 .values_list('object_id', flat=True)),
+            [first['ids'][0]],
+            'provenance for the collapsed duplicate outlived the row')
+
+    def test_repost_writes_no_extra_provenance(self):
+        """An upsert that touched nothing wrote nothing to attribute."""
+        from omop_core.models import ProvenanceRecord
+        from django.contrib.contenttypes.models import ContentType
+
+        headers = {'HTTP_X_PROVENANCE_SOURCE': 'EHR_SYNC'}
+        rows = self._rows(3)
+        self.client.post('/api/v1/measurements/?skip_refresh=true', rows,
+                         format='json', **headers)
+        self.client.post('/api/v1/measurements/?skip_refresh=true', rows,
+                         format='json', **headers)
+
+        ct = ContentType.objects.get_for_model(Measurement)
+        self.assertEqual(ProvenanceRecord.objects.filter(content_type=ct).count(), 3)
+
+    # --- key shape --------------------------------------------------------
+
+    def test_same_day_measurements_with_different_values_both_survive(self):
+        """Measurement diverges from _upsert_clinical's (source_value, date) key.
+
+        A repeat draw of one analyte on one day is a real second result. Keying
+        measurements on (source_value, date) alone would make this batch write
+        one row and — worse — delete the other on the next load.
+        """
+        rows = [dict(self._rows(1)[0], value_as_number=v) for v in (5.0, 9.5)]
+        resp = self._post(rows)
+
+        self.assertEqual(resp['created'], 2)
+        self.assertEqual(
+            sorted(float(m.value_as_number) for m in
+                   Measurement.objects.filter(person=self.person)),
+            [5.0, 9.5])
+
+        # …and re-posting both still converges.
+        again = self._post(rows)
+        self.assertEqual(again['created'], 0)
+        self.assertEqual(Measurement.objects.filter(person=self.person).count(), 2)
+
+    def test_measurement_concept_still_upgrades_in_place(self):
+        """The concept stays outside the measurement key, so a vocabulary load
+        updates the row rather than stranding a duplicate next to it."""
+        rows = self._rows(1)
+        self._post(rows)
+        upgraded = [dict(rows[0],
+                         measurement_concept=self.upgraded_concept.concept_id)]
+        resp = self._post(upgraded)
+
+        self.assertEqual(resp['created'], 0)
+        self.assertEqual(resp['updated'], 1)
+        stored = Measurement.objects.get(person=self.person)
+        self.assertEqual(
+            stored.measurement_concept_id, self.upgraded_concept.concept_id)
+
+    def test_rows_without_an_identity_are_always_inserted(self):
+        """No source_value means no event identity. Such rows must not all
+        collapse into one another — insert, as the endpoint always did."""
+        rows = [
+            {
+                'person': self.person.person_id,
+                'measurement_concept': self.m_concept.concept_id,
+                'measurement_date': '2024-02-01',
+                'measurement_type_concept': self.type_concept.concept_id,
+                'value_as_number': 7.0,
+            }
+            for _ in range(3)
+        ]
+        resp = self._post(rows)
+        self.assertEqual(resp['created'], 3)
+        self.assertEqual(len(set(resp['ids'])), 3)
+
+    def test_upsert_is_scoped_to_the_batch_person(self):
+        """Another person's identical event must not be matched or collapsed."""
+        other = self._rows(2, person=self.other_person)
+        self.client.post('/api/v1/measurements/?skip_refresh=true', other,
+                         format='json')
+        resp = self._post(self._rows(2))
+
+        self.assertEqual(resp['created'], 2)
+        self.assertEqual(Measurement.objects.filter(person=self.person).count(), 2)
+        self.assertEqual(
+            Measurement.objects.filter(person=self.other_person).count(), 2)
+
+    def test_upsert_false_restores_append_only_writes(self):
+        """The escape hatch for callers that really do want every row appended."""
+        rows = self._rows(2)
+        self._post(rows, query='?skip_refresh=true&upsert=false')
+        resp = self._post(rows, query='?skip_refresh=true&upsert=false')
+
+        self.assertEqual(resp['created'], 2)
+        self.assertEqual(resp['updated'], 0)
+        self.assertEqual(Measurement.objects.filter(person=self.person).count(), 4)
+
+    def test_all_five_resource_types_are_idempotent(self):
+        cases = [
+            ('conditions', ConditionOccurrence, {
+                'condition_concept': self.m_concept.concept_id,
+                'condition_start_date': '2024-01-01',
+                'condition_type_concept': self.type_concept.concept_id,
+                'condition_source_value': 'SRC-1',
+            }),
+            ('drug-exposures', DrugExposure, {
+                'drug_concept': self.m_concept.concept_id,
+                'drug_exposure_start_date': '2024-01-01',
+                'drug_type_concept': self.type_concept.concept_id,
+                'drug_source_value': 'SRC-1',
+            }),
+            ('measurements', Measurement, {
+                'measurement_concept': self.m_concept.concept_id,
+                'measurement_date': '2024-01-01',
+                'measurement_type_concept': self.type_concept.concept_id,
+                'measurement_source_value': 'SRC-1',
+            }),
+            ('observations', Observation, {
+                'observation_concept': self.m_concept.concept_id,
+                'observation_date': '2024-01-01',
+                'observation_type_concept': self.type_concept.concept_id,
+                'observation_source_value': 'SRC-1',
+            }),
+            ('procedures', ProcedureOccurrence, {
+                'procedure_concept': self.m_concept.concept_id,
+                'procedure_date': '2024-01-01',
+                'procedure_type_concept': self.type_concept.concept_id,
+                'procedure_source_value': 'SRC-1',
+            }),
+        ]
+        for route, model, fields in cases:
+            with self.subTest(route=route):
+                rows = [dict(fields, person=self.person.person_id)] * 2
+                first = self._post(rows, route=route)
+                second = self._post(rows, route=route)
+                self.assertEqual(first['created'], 1, f'{route}: within-batch repeat')
+                self.assertEqual(second['created'], 0, f'{route}: re-post')
+                self.assertEqual(
+                    model.objects.filter(person=self.person).count(), 1,
+                    f'{route}: not idempotent')
+
+    # --- properties that had to survive ----------------------------------
+
+    def test_upsert_query_count_does_not_scale_with_batch_size(self):
+        """The matching SELECT must stay one query, not one per row.
+
+        _upsert_clinical queries per key, which a small FHIR compartment can
+        afford and a 1,000-row ETL chunk cannot — so the bulk path resolves the
+        whole batch with a single superset SELECT. Measured on the re-post, the
+        expensive case: every row matches something.
+        """
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
+        def repost_cost(n, start_day):
+            rows = self._rows(n, start_day=start_day)
+            self._post(rows)
+            with CaptureQueriesContext(connection) as ctx:
+                self._post(rows)
+            return len(ctx)
+
+        self._post(self._rows(1, start_day=900))    # warm process-level caches
+        q_small = repost_cost(5, 100)
+        q_large = repost_cost(40, 200)
+        self.assertLess(
+            q_large - q_small, 10,
+            f'query count scaled with batch size: {q_small} queries to re-post 5 '
+            f'rows, {q_large} for 40. The upsert is doing per-row work.')
+
+    def test_refresh_still_runs_once_per_batch(self):
+        """The read model must not go stale, and must not be rebuilt per row —
+        including on the re-post path, where bulk_update and the collapse delete
+        would otherwise each fire their own signal-driven refresh."""
+        from unittest import mock
+        from omop_core.services import patient_record_service as prs
+
+        rows = self._conditions(['C50.9', 'I10'])
+        self.client.post('/api/v1/conditions/?skip_refresh=true&upsert=false',
+                         rows, format='json')
+        self.client.post('/api/v1/conditions/?skip_refresh=true&upsert=false',
+                         rows, format='json')
+
+        real = prs.refresh_patient_record
+        calls = []
+
+        def counting(person, *a, **kw):
+            calls.append(getattr(person, 'person_id', person))
+            return real(person, *a, **kw)
+
+        upgraded = self._conditions(['C50.9', 'I10'], concept=self.upgraded_concept)
+        with mock.patch('patient_portal.api.views.refresh_patient_record', counting), \
+             mock.patch.object(prs, 'refresh_patient_record', counting):
+            resp = self.client.post('/api/v1/conditions/', upgraded, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(resp.data['updated'], 2)
+        self.assertEqual(
+            calls, [self.person.person_id],
+            f'an upsert batch triggered {len(calls)} refreshes; expected exactly 1')
+
+    def test_skip_refresh_still_defers_the_refresh_on_the_upsert_path(self):
+        rows = self._rows(2)
+        self._post(rows)
+        derived_before = PatientRecord.objects.get(person=self.person).derived_at
+        self._post(rows)
+        self.assertEqual(
+            PatientRecord.objects.get(person=self.person).derived_at,
+            derived_before)
+
+    def test_refresh_reflects_a_collapsed_duplicate(self):
+        """The read model is rebuilt after the collapse, not before it."""
+        rows = self._conditions(['C50.9'])
+        self.client.post('/api/v1/conditions/?upsert=false', rows, format='json')
+        self.client.post('/api/v1/conditions/?upsert=false', rows, format='json')
+        derived_before = PatientRecord.objects.get(person=self.person).derived_at
+
+        resp = self.client.post('/api/v1/conditions/', rows, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(
+            ConditionOccurrence.objects.filter(person=self.person).count(), 1)
+        self.assertNotEqual(
+            PatientRecord.objects.get(person=self.person).derived_at,
+            derived_before,
+            'the collapse landed without refreshing the read model')


### PR DESCRIPTION
The five bulk clinical endpoints always INSERTed, so an ETL re-run, a retry after a read timeout, or a re-parse duplicated every row the server already held. Loading the HealthTree curehub corpus into staging surfaced this hard: re-uploading one unchanged bundle doubled every clinical row, and two patients that looked like failed writes turned out to hold 8,879 and 7,000 measurements from retries of writes that had in fact succeeded. Source bundles also repeat events internally (41 conditions parsing to 30 distinct events), so even the first load was not convergent. The endpoint has no idempotency key of any kind, so the only safe default is to converge.