### PR TITLE
WIP: browser-direct clinical writes — permissions, provenance, and the defects e2e found

### DIFF
--- a/ctomop/settings.py
+++ b/ctomop/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import os
 from pathlib import Path
 import dj_database_url
+from corsheaders.defaults import default_headers as default_cors_headers
 from dotenv import load_dotenv
 
 from ctomop.frontend_paths import resolve_frontend_root
@@ -311,6 +312,16 @@ else:
         if origin.strip()
     ]
 CORS_ALLOW_CREDENTIALS = True
+
+# Provenance travels in headers rather than the body so a payload cannot claim
+# an actor it did not authenticate as. They are not in the CORS default list, so
+# without naming them here a browser preflight refuses them and every
+# cross-origin clinical write fails before it reaches a view.
+CORS_ALLOW_HEADERS = (
+    *default_cors_headers,
+    'x-provenance-source',
+    'x-provenance-user-id',
+)
 
 # ── Pluggable partner auth providers ──────────────────────────────────────
 # PartnerAuthentication iterates these in order; the first provider that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: postgres:15
@@ -35,20 +33,31 @@ services:
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       PORT: 8000
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-}
+      # Browsers calling this API from another origin — the patient and admin
+      # apps writing clinical rows directly — need that origin listed here.
+      # Settings require it whenever DEBUG is off.
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-}
+      # Patient and staff callers authenticate with a Firebase ID token.
+      # Setting FIREBASE_AUTH_EMULATOR_HOST switches the SDK to emulator
+      # credentials, which is how the end-to-end suite signs in without a real
+      # Firebase project. Leave it unset anywhere real tokens are expected.
+      FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID:-}
+      FIREBASE_AUTH_EMULATOR_HOST: ${FIREBASE_AUTH_EMULATOR_HOST:-}
+      FIREBASE_SKIP_REVOCATION_CHECK: ${FIREBASE_SKIP_REVOCATION_CHECK:-}
     ports:
-      - "8000:8000"
+      # Host port is configurable: 8000 is commonly already taken by a sibling
+      # service in a full local stack.
+      - "${PROMOP_HOST_PORT:-8000}:8000"
+    # The gunicorn flags stay on one line: a folded scalar keeps the newline of
+    # any line indented deeper than the block's first, so wrapped flags arrive
+    # as separate shell commands and the server never starts.
     command: >
       sh -c "
         python manage.py migrate --noinput &&
         python manage.py setup_admin &&
-        gunicorn ctomop.wsgi:application
-          --bind 0.0.0.0:8000
-          --workers 4
-          --threads 2
-          --timeout 120
-          --access-logfile -
-          --error-logfile -
-          --log-level info
+        gunicorn ctomop.wsgi:application --bind 0.0.0.0:8000 --workers 4 --threads 2 --timeout 120 --access-logfile - --error-logfile - --log-level info
       "
 
 volumes:

--- a/omop_core/authorization.py
+++ b/omop_core/authorization.py
@@ -4,16 +4,62 @@ Authorization helpers for patient data access.
 Three access paths checked in order:
 1. Self-access (Identity → PatientUser → person_id matches target)
 2. Personal representative (Identity → PersonalRepresentative → person_id, verified only)
-3. Professional group access (Identity → GroupAccess → group ∩ patient's groups, non-expired)
+3. Professional access (Identity → GroupAccess → the patient's group *or* org, non-expired)
+
+Every professional check goes through ``professional_grants``. It used to be
+written out at each call site, and the copies had drifted: reading and role
+lookup matched only group grants while writing matched group *and* org, so an
+org-level grant permitted a write its holder could not read back.
 """
 from django.db import models
 from django.utils import timezone
 
 from .models import (
     GroupAccess,
-    PatientGroupMembership,
     PersonalRepresentative,
 )
+
+#: Roles that make someone a professional with respect to a patient. Note what
+#: is absent: ``patient``. That role is how an identity is marked as belonging
+#: to an organization, not as having any standing over its other patients — a
+#: check that treated it as a grant would let one patient read every other
+#: patient in their org. Their own record reaches them through self-access.
+PROFESSIONAL_READ_ROLES = frozenset({'org_admin', 'doctor', 'analyst'})
+
+#: Analysts read; they do not write.
+PROFESSIONAL_WRITE_ROLES = frozenset({'org_admin', 'doctor'})
+
+# Most privileged first. A grant can be held through more than one path, and a
+# caller asking for "the" role wants the strongest one rather than whichever the
+# database returned first.
+_ROLE_PRECEDENCE = ['org_admin', 'doctor', 'analyst']
+
+
+def professional_grants(actor_identity, target_person_id: int, roles):
+    """Non-expired ``GroupAccess`` rows through which the actor reaches the patient.
+
+    A grant reaches a patient either through a group the patient belongs to or
+    through the organization that holds their record. Both are real grants; a
+    check that honours only one of them is a bug, which is why this is in one
+    place.
+
+    ``roles`` is required rather than defaulting to "any". The permissive
+    default is the one nobody should get by accident: at org scope it spans
+    every patient the organization holds.
+    """
+    now = timezone.now()
+    return GroupAccess.objects.filter(
+        identity=actor_identity,
+        role__in=roles,
+    ).filter(
+        models.Q(expires_at__isnull=True) | models.Q(expires_at__gt=now),
+    ).filter(
+        models.Q(
+            group__memberships__person_id=target_person_id,
+        ) | models.Q(
+            org__patients__person_id=target_person_id,
+        )
+    )
 
 
 def can_access_patient(actor_identity, target_person_id: int) -> bool:
@@ -44,24 +90,11 @@ def can_access_patient(actor_identity, target_person_id: int) -> bool:
     ).exists():
         return True
 
-    # 3. Professional group access (non-expired)
-    now = timezone.now()
-    actor_groups = GroupAccess.objects.filter(
-        identity=actor_identity,
-    ).filter(
-        models.Q(expires_at__isnull=True) | models.Q(expires_at__gt=now),
-    ).values_list('group_id', flat=True)
-
-    if not actor_groups:
-        return False
-
-    return PatientGroupMembership.objects.filter(
-        group_id__in=actor_groups,
-        person_id=target_person_id,
+    # 3. Professional access. Analysts read but do not write, which is the only
+    #    difference between this role set and can_write_patient's.
+    return professional_grants(
+        actor_identity, target_person_id, roles=PROFESSIONAL_READ_ROLES,
     ).exists()
-
-
-_WRITE_ROLES = frozenset({'org_admin', 'doctor'})
 
 
 def can_write_patient(actor_identity, target_person_id: int) -> bool:
@@ -95,18 +128,8 @@ def can_write_patient(actor_identity, target_person_id: int) -> bool:
         return True
 
     # Professional access: only doctor / org_admin roles may write
-    now = timezone.now()
-    return GroupAccess.objects.filter(
-        identity=actor_identity,
-        role__in=_WRITE_ROLES,
-    ).filter(
-        models.Q(expires_at__isnull=True) | models.Q(expires_at__gt=now),
-    ).filter(
-        models.Q(
-            group__memberships__person_id=target_person_id,
-        ) | models.Q(
-            org__patients__person_id=target_person_id,
-        )
+    return professional_grants(
+        actor_identity, target_person_id, roles=PROFESSIONAL_WRITE_ROLES,
     ).exists()
 
 
@@ -135,14 +158,12 @@ def get_actor_role(actor_identity, target_person_id: int) -> str | None:
     ).exists():
         return 'representative'
 
-    now = timezone.now()
-    grant = GroupAccess.objects.filter(
-        identity=actor_identity,
-        group__memberships__person_id=target_person_id,
-    ).filter(
-        models.Q(expires_at__isnull=True) | models.Q(expires_at__gt=now),
-    ).first()
-    if grant:
-        return grant.role
+    roles = set(
+        professional_grants(actor_identity, target_person_id, roles=PROFESSIONAL_READ_ROLES)
+        .values_list('role', flat=True)
+    )
+    for role in _ROLE_PRECEDENCE:
+        if role in roles:
+            return role
 
     return None

--- a/patient_portal/api/lab_results/sync.py
+++ b/patient_portal/api/lab_results/sync.py
@@ -24,7 +24,7 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from omop_core.authorization import can_access_patient, get_actor_role
+from omop_core.authorization import can_access_patient
 from omop_core.models import (
     CareSite, Concept, Measurement, MeasurementOwnership,
     Person, ProvenanceRecord, VisitOccurrence,

--- a/patient_portal/api/middleware.py
+++ b/patient_portal/api/middleware.py
@@ -99,7 +99,15 @@ def _classify_event_type(request):
 
 
 def _get_client_id(request):
-    """Extract OAuth2 client_id from the token on the request, if present."""
+    """Extract an identifier for the credential the request arrived on.
+
+    Bounded and non-sensitive by construction. A partner token puts a
+    ``TokenClaims`` on ``request.auth``, whose ``str()`` is a repr of every
+    claim in the token: far past the 255-char column, so the audit row failed
+    to persist for every partner-authenticated request, and verbose enough in
+    the SIEM stream to be worth not emitting. The issuer and subject identify
+    the caller, which is what this field is read for.
+    """
     token = getattr(request, 'auth', None)
     if token is None:
         return None
@@ -107,7 +115,11 @@ def _get_client_id(request):
     app = getattr(token, 'application', None)
     if app:
         return app.client_id
-    return str(token)
+    issuer = getattr(token, 'issuer', None)
+    sub = getattr(token, 'sub', None)
+    if issuer or sub:
+        return f"{issuer or ''}|{sub or ''}"[:255]
+    return str(token)[:255]
 
 
 def _get_resource_id(request):
@@ -198,7 +210,7 @@ class AuditLogMiddleware:
             status_code=entry['status_code'],
             user_id=entry['user_id'],
             user_email=(entry['user_email'] or '')[:254] or None,
-            client_id=entry['client_id'],
+            client_id=(entry['client_id'] or '')[:255] or None,
             resource_id=entry['resource_id'],
             ip_address=(entry['ip_address'] or '')[:64] or None,
             duration_ms=entry['duration_ms'],

--- a/patient_portal/api/serializers.py
+++ b/patient_portal/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from patient_portal.models import Identity, PatientConsent, PatientMessage
 from omop_core.models import (
-    PatientRecord, Concept,
+    PatientRecord, Concept, Death,
     ConditionOccurrence, DrugExposure, Measurement, Observation, ProcedureOccurrence,
     PatientDocument, PatientTrialEnrollment, ProvenanceRecord,
     Survey, PatientSurveyResponse,
@@ -758,6 +758,22 @@ class ObservationSerializer(serializers.ModelSerializer):
             'is_erroneous', 'erroneous_reason',
         ]
         extra_kwargs = {'observation_id': {'required': False}}
+
+
+class DeathSerializer(serializers.ModelSerializer):
+    """OMOP Death.
+
+    ``person`` is the primary key — one row per person, by construction — so
+    there is no separate id field and a re-post of the same person is an
+    update rather than a duplicate.
+    """
+
+    class Meta:
+        model = Death
+        fields = [
+            'person', 'death_date', 'death_datetime', 'death_type_concept',
+            'cause_concept', 'cause_source_value', 'cause_source_concept',
+        ]
 
 
 class ProcedureOccurrenceSerializer(serializers.ModelSerializer):

--- a/patient_portal/api/urls.py
+++ b/patient_portal/api/urls.py
@@ -6,7 +6,8 @@ from .views import (
     PersonViewSet,
     # OMOP clinical event ViewSets
     ConditionOccurrenceViewSet, DrugExposureViewSet, MeasurementViewSet,
-    ObservationViewSet, ProcedureOccurrenceViewSet, EpisodeViewSet, EpisodeEventViewSet,
+    ObservationViewSet, ProcedureOccurrenceViewSet, DeathViewSet,
+    EpisodeViewSet, EpisodeEventViewSet,
     # Document storage
     PatientDocumentViewSet,
     # Clinical trial enrollment tracker (metadata from EXACT)
@@ -44,6 +45,7 @@ router.register(r'drug-exposures', DrugExposureViewSet, basename='drug-exposures
 router.register(r'measurements', MeasurementViewSet, basename='measurements')
 router.register(r'observations', ObservationViewSet, basename='observations')
 router.register(r'procedures', ProcedureOccurrenceViewSet, basename='procedures')
+router.register(r'deaths', DeathViewSet, basename='deaths')
 router.register(r'episodes', EpisodeViewSet, basename='episodes')
 router.register(r'episode-events', EpisodeEventViewSet, basename='episode-events')
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -347,6 +347,7 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             # group access see their whole panel; is_staff bypasses this entirely.
             from patient_portal.models import PatientUser
             from omop_core.models import PatientGroupMembership, GroupAccess
+            from omop_core.authorization import PROFESSIONAL_READ_ROLES
             from django.utils import timezone
             from django.db.models import Q
 
@@ -370,9 +371,16 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
             # Org-admin access includes trust-derived admin orgs.
             admin_org_ids = list(get_admin_orgs(self.request.user).values_list('id', flat=True))
 
-            # Group grants: see patients in those groups
+            # Group grants: see patients in those groups. Filtered by role for
+            # the same reason can_access_patient is — a patient identity carries
+            # a `patient`-role grant to mark which group it belongs to, and
+            # counting that as professional access would show one patient every
+            # other patient in their group. Their own record is already in
+            # accessible_pids by self-access.
             actor_group_ids = list(
-                active_grants.filter(group__isnull=False).values_list('group_id', flat=True)
+                active_grants.filter(
+                    group__isnull=False, role__in=PROFESSIONAL_READ_ROLES,
+                ).values_list('group_id', flat=True)
             )
             if actor_group_ids:
                 group_pids = PatientGroupMembership.objects.filter(

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -70,7 +70,7 @@ from .providers.base import TokenClaims
 from .serializers import (
     UserSerializer, PatientRecordSerializer, PatientListSerializer, ProvenanceRecordSerializer,
     ConditionOccurrenceSerializer, DrugExposureSerializer, MeasurementSerializer,
-    ObservationSerializer, ProcedureOccurrenceSerializer,
+    ObservationSerializer, ProcedureOccurrenceSerializer, DeathSerializer,
     EpisodeSerializer, EpisodeEventSerializer,
     PatientDocumentSerializer, PatientTrialEnrollmentSerializer,
     SurveySerializer, PatientSurveyResponseSerializer,
@@ -163,6 +163,64 @@ def _extract_provenance(request):
     )
     modification_reason = body.get('modification_reason')
     return source, source_user_id, modification_reason
+
+
+_PROVENANCE_SOURCES = frozenset(dict(ProvenanceRecord.SOURCE_CHOICES))
+
+
+def _is_person_actor(request) -> bool:
+    """True when a person made this request, rather than a machine.
+
+    Partner tokens (Firebase, SAML) and session cookies belong to people.
+    A service token, or an OAuth2 access token bound to a registered
+    application, is a backend whose identity is fixed and known from the
+    credential itself.
+    """
+    if is_service_token(request):
+        return False
+    auth = getattr(request, 'auth', None)
+    # django-oauth-toolkit AccessToken carries the application it was issued to.
+    return auth is None or getattr(auth, 'application', None) is None
+
+
+def _require_provenance(request):
+    """Reject a write that does not say where it came from.
+
+    Recording provenance is opt-in: no source header means no ProvenanceRecord,
+    and the row lands anyway. A clinical row with no origin cannot be audited,
+    corrected with confidence, or attributed — and for a write made on a
+    patient's behalf there is nothing at all to say who acted. Silently
+    accepting those is worse than refusing them, because the gap only becomes
+    visible long after the data is in.
+
+    Applied to the clinical viewsets that accept browser-direct writes, and
+    only to callers who are people (``requires_provenance`` plus
+    ``_is_person_actor``). Two populations are deliberately left alone, because
+    tightening either is a migration rather than a fix: machine callers, whose
+    identity the credential already fixes and who have integrations written
+    against today's contract, and the survey endpoint, which this service's own
+    frontend posts to.
+
+    The source is also checked against the vocabulary. It is stored on a
+    ``choices`` field, which Django does not enforce on ``create()``, so an
+    unrecognised value would sit in the column and quietly fail every filter
+    written against the real ones.
+    """
+    from rest_framework.exceptions import ValidationError
+
+    source, _, _ = _extract_provenance(request)
+    if not source:
+        raise ValidationError({'source': [
+            'Provenance is required: send an X-Provenance-Source header (or a '
+            'source field) naming where this write came from. One of: '
+            f'{", ".join(sorted(_PROVENANCE_SOURCES))}.'
+        ]})
+    if source not in _PROVENANCE_SOURCES:
+        raise ValidationError({'source': [
+            f'Unknown provenance source {source!r}. One of: '
+            f'{", ".join(sorted(_PROVENANCE_SOURCES))}.'
+        ]})
+    return source
 
 
 def _record_provenance(record, source, source_user_id, target_patient_id=None, modification_reason=None, organization=None):
@@ -4355,8 +4413,15 @@ class PersonViewSet(viewsets.GenericViewSet):
     Endpoints:
       POST /api/persons/find_or_create/  — resolve OIDC identity to a Person row
       PATCH /api/persons/{person_id}/    — fill-if-empty demographic patch
+
+    ``PatientCrudPermission`` rather than the base class so a clinician holding
+    ``GroupAccess`` can resolve a patient they may already write for. Under the
+    base class only staff and service tokens could POST here, which left a
+    clinician able to record a patient's labs but unable to find the
+    ``person_id`` to record them against. What that clinician may then see is
+    decided per-person inside the action, not by the method.
     """
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = Person.objects.all()
     lookup_field = 'person_id'
 
@@ -4381,7 +4446,9 @@ class PersonViewSet(viewsets.GenericViewSet):
         # link and mint a second Person for a patient who already has one,
         # scattering their record across two person_ids. Consult the identity
         # link first, and backfill the columns so both paths agree from then on.
+        from omop_core.authorization import can_access_patient
         from patient_portal.models import PatientUser
+        from rest_framework.exceptions import PermissionDenied
 
         person = None
         created = False
@@ -4405,6 +4472,13 @@ class PersonViewSet(viewsets.GenericViewSet):
                         person.refresh_from_db()
 
         if person is None:
+            # Minting a Person is privileged. A clinician calling this for an
+            # identity nobody has seen would be creating records, and — since
+            # the response distinguishes "found" from "created" — could use it
+            # to learn which subjects exist. Resolution is what a clinician
+            # needs, so they get resolution only.
+            if not self._may_create_person(request):
+                raise PermissionDenied('Access denied.')
             try:
                 _new_person_id = next_pk(Person, 'person_id')
                 person, created = Person.objects.get_or_create(
@@ -4416,8 +4490,25 @@ class PersonViewSet(viewsets.GenericViewSet):
                 # Concurrent first-call race: another request won the INSERT
                 person = Person.objects.get(actor_iss=actor_iss, actor_sub=actor_sub)
                 created = False
+        elif not self._may_create_person(request):
+            # An existing person is only disclosed to a caller who already
+            # holds access to them, so the endpoint cannot be used to probe.
+            if not can_access_patient(request.user, person.person_id):
+                raise PermissionDenied('Access denied.')
+
         http_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response({'person_id': person.person_id, 'created': created}, status=http_status)
+
+    @staticmethod
+    def _may_create_person(request) -> bool:
+        """Staff and trusted backends provision patients; clinicians resolve them.
+
+        The same machine/person split ``_require_provenance`` uses. A service
+        token or a registered OAuth client is a backend whose job includes
+        bringing patients into the system; a patient or clinician arriving on a
+        partner token or a session is not.
+        """
+        return not _is_person_actor(request) or getattr(request.user, 'is_staff', False)
 
     def partial_update(self, request, person_id=None):
         """
@@ -4856,6 +4947,12 @@ class _OmopBulkCreateMixin:
                 status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             )
 
+        # Same rule as the single-row path: a list body would otherwise be a way
+        # to write clinical rows with no origin at all. Deliberately after the
+        # size guards, so an oversized batch still reports 413 rather than
+        # having its real problem masked by a missing header.
+        self._check_provenance(request)
+
         model_name = self.serializer_class.Meta.model.__name__
         pk_field, model_cls = _MODEL_PK_MAP[model_name]
 
@@ -4995,12 +5092,35 @@ class _OmopBulkCreateMixin:
 
 class _ProvenanceMixin:
     """Record provenance on create/update when source headers/body fields are present."""
+
+    #: Refuse a write from a person that carries no provenance source. Set on
+    #: the clinical viewsets that accept browser-direct writes; see
+    #: ``_require_provenance`` for why it is not simply on by default.
+    requires_provenance = False
+
+    def _check_provenance(self, request):
+        if self.requires_provenance and _is_person_actor(request):
+            _require_provenance(request)
+
     def _prov(self, obj):
         source, user_id, reason = _extract_provenance(self.request)
         if source:
-            _record_provenance(obj, source, user_id, modification_reason=reason, organization=get_request_org(self.request))
+            # target_patient_id is what makes an on-behalf-of write legible: the
+            # actor is in source_user_id, but without the subject a reader can
+            # only tell that someone wrote something, not for whom. Every model
+            # this mixin serves carries `person`; the getattr keeps a future one
+            # that does not from breaking the write.
+            person_id = getattr(obj, 'person_id', None)
+            _record_provenance(
+                obj, source, user_id,
+                target_patient_id=str(person_id) if person_id is not None else None,
+                modification_reason=reason,
+                organization=get_request_org(self.request),
+            )
 
     def perform_create(self, serializer):
+        self._check_provenance(self.request)
+
         # Auto-generate PK if not supplied
         model_name = serializer.Meta.model.__name__
         if model_name in _MODEL_PK_MAP:
@@ -5041,6 +5161,10 @@ class _ProvenanceMixin:
         self._prov(obj)
 
     def perform_update(self, serializer):
+        # An edit needs an origin as much as an insert does — more so, since it
+        # is replacing something a different actor may have written.
+        self._check_provenance(self.request)
+
         # Trusted backend (service-token): skip ACL — already validated at
         # the permission layer (ScopedTokenPermission).
         if is_service_token(self.request):
@@ -5076,6 +5200,7 @@ class ConditionOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFi
     serializer_class = ConditionOccurrenceSerializer
     permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = ConditionOccurrence.objects.all()
+    requires_provenance = True
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
 
@@ -5085,6 +5210,7 @@ class DrugExposureViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMix
     serializer_class = DrugExposureSerializer
     permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = DrugExposure.objects.all()
+    requires_provenance = True
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
 
@@ -5094,6 +5220,7 @@ class MeasurementViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixi
     serializer_class = MeasurementSerializer
     permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = Measurement.objects.all()
+    requires_provenance = True
     ordering_fields = ['measurement_date', 'measurement_id']
     ordering = ['-measurement_date']
     throttle_classes = [ScopedRateThrottle]
@@ -5132,6 +5259,7 @@ class ObservationViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixi
     serializer_class = ObservationSerializer
     permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = Observation.objects.all()
+    requires_provenance = True
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
 
@@ -5141,8 +5269,46 @@ class ProcedureOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFi
     serializer_class = ProcedureOccurrenceSerializer
     permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = ProcedureOccurrence.objects.all()
+    requires_provenance = True
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+class DeathViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+    """OMOP Death. The model existed with no route, so mortality was unwritable.
+
+    One row per person — ``person`` is the primary key — so a second report for
+    the same person is a correction of the first, not a new event. POST
+    converges on that row rather than failing on the key, which keeps a
+    retried or re-sent report from turning into an error the caller has to
+    special-case.
+    """
+    serializer_class = DeathSerializer
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
+    queryset = Death.objects.all()
+    requires_provenance = True
+    lookup_field = 'person_id'
+
+    def create(self, request, *args, **kwargs):
+        person_id = request.data.get('person') if isinstance(request.data, dict) else None
+        existing = (
+            Death.objects.filter(person_id=person_id).first()
+            if person_id is not None else None
+        )
+        if existing is None:
+            return super().create(request, *args, **kwargs)
+
+        # Deliberately not get_object(): that re-applies the read queryset, and
+        # read and write access are not the same set here — an org-level
+        # GroupAccess grant permits a write but not a read, so resolving the row
+        # that way would 404 a caller who is entitled to correct it. Going
+        # through perform_update applies the write rule, which is the one that
+        # governs this request.
+        serializer = self.get_serializer(existing, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 @method_decorator(csrf_exempt, name='dispatch')
@@ -5150,6 +5316,7 @@ class EpisodeViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = EpisodeSerializer
     permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = Episode.objects.all()
+    requires_provenance = True
 
 
 @method_decorator(csrf_exempt, name='dispatch')

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -5035,7 +5035,7 @@ class _ProvenanceMixin:
 @method_decorator(csrf_exempt, name='dispatch')
 class ConditionOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ConditionOccurrenceSerializer
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = ConditionOccurrence.objects.all()
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
@@ -5044,7 +5044,7 @@ class ConditionOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFi
 @method_decorator(csrf_exempt, name='dispatch')
 class DrugExposureViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = DrugExposureSerializer
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = DrugExposure.objects.all()
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
@@ -5053,7 +5053,7 @@ class DrugExposureViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMix
 @method_decorator(csrf_exempt, name='dispatch')
 class MeasurementViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = MeasurementSerializer
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = Measurement.objects.all()
     ordering_fields = ['measurement_date', 'measurement_id']
     ordering = ['-measurement_date']
@@ -5091,7 +5091,7 @@ class MeasurementViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixi
 @method_decorator(csrf_exempt, name='dispatch')
 class ObservationViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ObservationSerializer
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = Observation.objects.all()
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
@@ -5100,7 +5100,7 @@ class ObservationViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixi
 @method_decorator(csrf_exempt, name='dispatch')
 class ProcedureOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ProcedureOccurrenceSerializer
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = ProcedureOccurrence.objects.all()
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'omop_write'
@@ -5109,7 +5109,7 @@ class ProcedureOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFi
 @method_decorator(csrf_exempt, name='dispatch')
 class EpisodeViewSet(_ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = EpisodeSerializer
-    permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
+    permission_classes = [PatientCrudPermission, PatientSelfScopePermission]
     queryset = Episode.objects.all()
 
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -166,15 +166,24 @@ def _extract_provenance(request):
 
 
 def _record_provenance(record, source, source_user_id, target_patient_id=None, modification_reason=None, organization=None):
-    """Create a ProvenanceRecord pointing at any model instance."""
-    ProvenanceRecord.objects.create(
-        source=source,
-        source_user_id=source_user_id or '',
-        target_patient_id=target_patient_id,
-        modification_reason=modification_reason,
-        organization=organization,
+    """Record a ProvenanceRecord pointing at any model instance.
+
+    One row per (record, actor, source), which is what
+    ``uq_provenance_object_actor_source`` requires. The same actor editing the
+    same record again — a patient correcting a value they entered — refreshes
+    that row rather than inserting a second one; creating unconditionally made
+    the second edit fail on the constraint and return a 500.
+    """
+    ProvenanceRecord.objects.update_or_create(
         content_type=ContentType.objects.get_for_model(record),
         object_id=record.pk,
+        source=source,
+        source_user_id=source_user_id or '',
+        defaults={
+            'target_patient_id': target_patient_id,
+            'modification_reason': modification_reason,
+            'organization': organization,
+        },
     )
 
 
@@ -4366,17 +4375,47 @@ class PersonViewSet(viewsets.GenericViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            _new_person_id = next_pk(Person, 'person_id')
-            person, created = Person.objects.get_or_create(
-                actor_iss=actor_iss,
-                actor_sub=actor_sub,
-                defaults={'person_id': _new_person_id},
-            )
-        except IntegrityError:
-            # Concurrent first-call race: another request won the INSERT
-            person = Person.objects.get(actor_iss=actor_iss, actor_sub=actor_sub)
-            created = False
+        # A patient who has signed in to the portal is already linked to a
+        # Person through PatientUser, and that path does not populate
+        # actor_iss/actor_sub. Matching on those columns alone would miss the
+        # link and mint a second Person for a patient who already has one,
+        # scattering their record across two person_ids. Consult the identity
+        # link first, and backfill the columns so both paths agree from then on.
+        from patient_portal.models import PatientUser
+
+        person = None
+        created = False
+        identity = Identity.objects.filter(issuer=actor_iss, sub=actor_sub).first()
+        if identity is not None:
+            link = PatientUser.objects.filter(
+                identity=identity,
+            ).select_related('person').first()
+            if link is not None:
+                person = link.person
+                if not person.actor_sub:
+                    person.actor_iss = actor_iss
+                    person.actor_sub = actor_sub
+                    try:
+                        person.save(update_fields=['actor_iss', 'actor_sub'])
+                    except IntegrityError:
+                        # Another Person already claims this pair — from a call
+                        # made before this resolution order existed. The linked
+                        # person is the authoritative one; leave it unlabelled
+                        # rather than fail the request.
+                        person.refresh_from_db()
+
+        if person is None:
+            try:
+                _new_person_id = next_pk(Person, 'person_id')
+                person, created = Person.objects.get_or_create(
+                    actor_iss=actor_iss,
+                    actor_sub=actor_sub,
+                    defaults={'person_id': _new_person_id},
+                )
+            except IntegrityError:
+                # Concurrent first-call race: another request won the INSERT
+                person = Person.objects.get(actor_iss=actor_iss, actor_sub=actor_sub)
+                created = False
         http_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response({'person_id': person.person_id, 'created': created}, status=http_status)
 

--- a/patient_portal/management/commands/seed_double_write_e2e.py
+++ b/patient_portal/management/commands/seed_double_write_e2e.py
@@ -1,0 +1,168 @@
+"""Fixtures for the double-write end-to-end suite.
+
+The suite drives the real HTTP surface — a browser-shaped client posting
+clinical rows with a user's own credential — so it needs identities that
+exercise each branch of `can_write_patient`: a patient writing their own
+record, a second patient they must not reach, a clinician holding a grant over
+the first patient only, and a staff operator.
+
+Idempotent: running it twice leaves the same rows and re-prints the same ids,
+so a suite can seed on every run without accumulating fixtures.
+
+Refuses to run against a database that looks populated unless `--force` is
+given. These identities have known passwords; creating them next to real
+patient data would be handing out credentials.
+"""
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from omop_core.models import (
+    Concept,
+    ConceptClass,
+    Domain,
+    GroupAccess,
+    Organization,
+    PatientGroup,
+    PatientGroupMembership,
+    Person,
+    Vocabulary,
+)
+from patient_portal.models import Identity, PatientUser
+
+# The suite signs in with these, so they are fixed rather than generated.
+PASSWORD = 'e2e-double-write'
+
+# Firebase is the issuer in every deployed environment; the fixtures mirror its
+# shape so `find_or_create` is exercised with a realistic (issuer, sub) pair.
+ISSUER = 'https://securetoken.google.com/healthkey-e2e'
+
+PATIENT_SUB = 'e2e-patient-a'
+OTHER_SUB = 'e2e-patient-b'
+CLINICIAN_SUB = 'e2e-clinician'
+STAFF_SUB = 'e2e-staff'
+
+PATIENT_PERSON_ID = 9900001
+OTHER_PERSON_ID = 9900002
+
+# Concepts the ECOG payload references. A create fails on the foreign key when
+# the vocabulary has not been loaded, which is the normal state of a fresh
+# container, so the suite cannot assume Athena data is present.
+CONCEPTS = [
+    (36306034, 'ECOG Performance Status score', 'Observation', 'LOINC', '89247-1'),
+    (4193888, 'Patient reported', 'Type Concept', 'SNOMED', 'HK-PATIENT-REPORTED'),
+]
+
+
+class Command(BaseCommand):
+    help = 'Create the identities and concepts the double-write e2e suite needs.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force', action='store_true',
+            help='Seed even when the database already holds unrelated persons.',
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        self._guard(options['force'])
+
+        for concept_id, name, domain, vocab, code in CONCEPTS:
+            self._concept(concept_id, name, domain, vocab, code)
+
+        patient_person = self._person(PATIENT_PERSON_ID)
+        other_person = self._person(OTHER_PERSON_ID)
+
+        patient = self._identity(PATIENT_SUB, 'patient-a@e2e.invalid')
+        other = self._identity(OTHER_SUB, 'patient-b@e2e.invalid')
+        clinician = self._identity(CLINICIAN_SUB, 'clinician@e2e.invalid')
+        staff = self._identity(STAFF_SUB, 'staff@e2e.invalid', is_staff=True)
+
+        PatientUser.objects.get_or_create(identity=patient, defaults={'person': patient_person})
+        PatientUser.objects.get_or_create(identity=other, defaults={'person': other_person})
+
+        # The clinician reaches patient A through a group, and only patient A.
+        # Patient B is deliberately left out of it: the 403 that produces is the
+        # point of the fixture.
+        org, _ = Organization.objects.get_or_create(
+            name='E2E Clinic', defaults={'slug': 'e2e-clinic'},
+        )
+        group, _ = PatientGroup.objects.get_or_create(
+            organization=org, name='E2E Cohort', defaults={'slug': 'e2e-cohort'},
+        )
+        PatientGroupMembership.objects.get_or_create(
+            group=group, person_id=PATIENT_PERSON_ID,
+        )
+        GroupAccess.objects.get_or_create(
+            identity=clinician, group=group, defaults={'role': 'doctor'},
+        )
+
+        self.stdout.write(json.dumps({
+            'password': PASSWORD,
+            'issuer': ISSUER,
+            'patient': {'uid': patient.uid, 'sub': PATIENT_SUB, 'person_id': patient_person.person_id},
+            'other': {'uid': other.uid, 'sub': OTHER_SUB, 'person_id': other_person.person_id},
+            'clinician': {'uid': clinician.uid, 'sub': CLINICIAN_SUB},
+            'staff': {'uid': staff.uid, 'sub': STAFF_SUB},
+        }, indent=2))
+
+    def _guard(self, force):
+        if force:
+            return
+        stray = Person.objects.exclude(
+            person_id__in=[PATIENT_PERSON_ID, OTHER_PERSON_ID],
+        ).exists()
+        if stray:
+            raise CommandError(
+                'This database already holds persons that are not e2e fixtures. '
+                'These identities have published passwords — pass --force only if '
+                'you are certain this is a throwaway database.'
+            )
+
+    def _concept(self, concept_id, name, domain_id, vocabulary_id, code):
+        domain, _ = Domain.objects.get_or_create(
+            domain_id=domain_id, defaults={'domain_name': domain_id, 'domain_concept_id': 0},
+        )
+        vocabulary, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id=vocabulary_id,
+            defaults={'vocabulary_name': vocabulary_id, 'vocabulary_concept_id': 0},
+        )
+        concept_class, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Undefined',
+            defaults={'concept_class_name': 'Undefined', 'concept_class_concept_id': 0},
+        )
+        Concept.objects.update_or_create(
+            concept_id=concept_id,
+            defaults={
+                'concept_name': name,
+                'domain': domain,
+                'vocabulary': vocabulary,
+                'concept_class': concept_class,
+                'standard_concept': 'S',
+                'concept_code': code,
+                'valid_start_date': '1970-01-01',
+                'valid_end_date': '2099-12-31',
+                'source': 'HealthKey',
+            },
+        )
+
+    def _person(self, person_id):
+        person, _ = Person.objects.get_or_create(
+            person_id=person_id, defaults={'year_of_birth': 1980},
+        )
+        return person
+
+    def _identity(self, sub, email, is_staff=False):
+        identity, created = Identity.objects.get_or_create(
+            issuer=ISSUER, sub=sub,
+            defaults={'email': email, 'is_staff': is_staff},
+        )
+        if not created and identity.is_staff != is_staff:
+            identity.is_staff = is_staff
+            identity.save(update_fields=['is_staff'])
+        # Always reset: a rerun must leave the documented password working even
+        # if something else changed it.
+        identity.set_password(PASSWORD)
+        identity.save(update_fields=['password'])
+        return identity

--- a/patient_portal/management/commands/seed_double_write_e2e.py
+++ b/patient_portal/management/commands/seed_double_write_e2e.py
@@ -24,6 +24,7 @@ from omop_core.models import (
     Domain,
     GroupAccess,
     Organization,
+    PatientRecord,
     PatientGroup,
     PatientGroupMembership,
     Person,
@@ -41,6 +42,7 @@ ISSUER = 'https://securetoken.google.com/healthkey-e2e'
 PATIENT_SUB = 'e2e-patient-a'
 OTHER_SUB = 'e2e-patient-b'
 CLINICIAN_SUB = 'e2e-clinician'
+ORG_CLINICIAN_SUB = 'e2e-org-clinician'
 STAFF_SUB = 'e2e-staff'
 
 PATIENT_PERSON_ID = 9900001
@@ -77,6 +79,7 @@ class Command(BaseCommand):
         patient = self._identity(PATIENT_SUB, 'patient-a@e2e.invalid')
         other = self._identity(OTHER_SUB, 'patient-b@e2e.invalid')
         clinician = self._identity(CLINICIAN_SUB, 'clinician@e2e.invalid')
+        org_clinician = self._identity(ORG_CLINICIAN_SUB, 'org-clinician@e2e.invalid')
         staff = self._identity(STAFF_SUB, 'staff@e2e.invalid', is_staff=True)
 
         PatientUser.objects.get_or_create(identity=patient, defaults={'person': patient_person})
@@ -98,12 +101,24 @@ class Command(BaseCommand):
             identity=clinician, group=group, defaults={'role': 'doctor'},
         )
 
+        # A second clinician reaching the same patient through the organization
+        # rather than the group. The two paths are separate grants and were
+        # honoured inconsistently — an org grant permitted a write its holder
+        # could not read back — so the suite exercises both.
+        PatientRecord.objects.get_or_create(
+            person=patient_person, defaults={'organization': org},
+        )
+        GroupAccess.objects.get_or_create(
+            identity=org_clinician, org=org, defaults={'role': 'doctor'},
+        )
+
         self.stdout.write(json.dumps({
             'password': PASSWORD,
             'issuer': ISSUER,
             'patient': {'uid': patient.uid, 'sub': PATIENT_SUB, 'person_id': patient_person.person_id},
             'other': {'uid': other.uid, 'sub': OTHER_SUB, 'person_id': other_person.person_id},
             'clinician': {'uid': clinician.uid, 'sub': CLINICIAN_SUB},
+            'orgClinician': {'uid': org_clinician.uid, 'sub': ORG_CLINICIAN_SUB},
             'staff': {'uid': staff.uid, 'sub': STAFF_SUB},
         }, indent=2))
 

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -1586,13 +1586,15 @@ class OmopObservationsEndpointTest(FhirUploadBase):
             'value_as_string': 'Former',
             'observation_source_value': 'Smoking status',
         }
-        resp = self.client.post('/api/observations/', payload, format='json')
+        resp = self.client.post('/api/observations/', payload, format='json',
+                                HTTP_X_PROVENANCE_SOURCE='EHR_SYNC')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         self.assertTrue(OmopObservation.objects.filter(observation_id=88802).exists())
 
     def test_update_observation(self):
         from omop_core.models import Observation as OmopObservation
-        resp = self.client.patch('/api/observations/88801/', {'value_as_string': 'Current'}, format='json')
+        resp = self.client.patch('/api/observations/88801/', {'value_as_string': 'Current'}, format='json',
+                                 HTTP_X_PROVENANCE_SOURCE='ADMIN_CORRECTION')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(OmopObservation.objects.get(observation_id=88801).value_as_string, 'Current')
 
@@ -1675,13 +1677,15 @@ class OmopProceduresEndpointTest(FhirUploadBase):
             'procedure_type_concept': self._proc_concept.concept_id,
             'procedure_source_value': 'Lumpectomy',
         }
-        resp = self.client.post('/api/procedures/', payload, format='json')
+        resp = self.client.post('/api/procedures/', payload, format='json',
+                                HTTP_X_PROVENANCE_SOURCE='EHR_SYNC')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         self.assertTrue(ProcedureOccurrence.objects.filter(procedure_occurrence_id=88802).exists())
 
     def test_update_procedure(self):
         resp = self.client.patch('/api/procedures/88801/',
-                                 {'procedure_source_value': 'Excisional biopsy'}, format='json')
+                                 {'procedure_source_value': 'Excisional biopsy'}, format='json',
+                                 HTTP_X_PROVENANCE_SOURCE='ADMIN_CORRECTION')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(
             ProcedureOccurrence.objects.get(procedure_occurrence_id=88801).procedure_source_value,
@@ -17621,11 +17625,12 @@ class PatientSelfCreateTest(TestCase):
             'value_as_string': 'ECOG 1',
         }
 
-    def _post(self, identity, person):
+    def _post(self, identity, person, source='PATIENT_SELF'):
         client = APIClient()
         if identity is not None:
             client.force_authenticate(user=identity)
-        return client.post('/api/observations/', self._payload(person), format='json')
+        headers = {'HTTP_X_PROVENANCE_SOURCE': source} if source else {}
+        return client.post('/api/observations/', self._payload(person), format='json', **headers)
 
     def test_patient_creates_own_observation(self):
         resp = self._post(self.patient_a, self.person_a)
@@ -17673,6 +17678,123 @@ class PatientSelfCreateTest(TestCase):
         rows = resp.data['results'] if isinstance(resp.data, dict) else resp.data
         returned = [row['person'] for row in rows]
         self.assertNotIn(self.person_b.person_id, returned)
+
+
+class ClinicalWriteProvenanceTest(TestCase):
+    """A person writing a clinical row must say where the row came from.
+
+    Provenance was opt-in: with no source header the write landed and no
+    ProvenanceRecord was made, leaving a clinical row with no origin and — for
+    a write made on someone's behalf — no record of who acted.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+
+        _make_vocab_fixtures()
+        cls.concept = Concept.objects.get(concept_id=4112853)
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+
+        cls.person = Person.objects.create(person_id=96001, family_name='Prov')
+        PatientRecord.objects.create(person=cls.person)
+        cls.patient = Identity.objects.create_user(email='prov-a@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.patient, person=cls.person)
+
+    def _payload(self):
+        return {
+            'person': self.person.person_id,
+            'observation_concept': self.concept.concept_id,
+            'observation_date': str(date.today()),
+            'observation_type_concept': self.type_concept.concept_id,
+            'value_as_string': 'ECOG 1',
+        }
+
+    def _client(self):
+        client = APIClient()
+        client.force_authenticate(user=self.patient)
+        return client
+
+    def test_create_without_a_source_is_refused(self):
+        resp = self._client().post('/api/observations/', self._payload(), format='json')
+        self.assertEqual(resp.status_code, 400, resp.data)
+        self.assertIn('source', resp.data)
+        self.assertFalse(Observation.objects.filter(person=self.person).exists())
+
+    def test_create_with_a_source_is_accepted_and_recorded(self):
+        from django.contrib.contenttypes.models import ContentType
+        from omop_core.models import ProvenanceRecord
+
+        resp = self._client().post(
+            '/api/observations/', self._payload(), format='json',
+            HTTP_X_PROVENANCE_SOURCE='PATIENT_SELF',
+        )
+        self.assertEqual(resp.status_code, 201, resp.data)
+
+        row = Observation.objects.get(person=self.person)
+        prov = ProvenanceRecord.objects.get(
+            content_type=ContentType.objects.get_for_model(Observation),
+            object_id=row.pk,
+        )
+        self.assertEqual(prov.source, 'PATIENT_SELF')
+
+    def test_the_subject_of_the_write_is_recorded(self):
+        """P3: without target_patient_id a reader learns who acted, not for whom."""
+        from django.contrib.contenttypes.models import ContentType
+        from omop_core.models import ProvenanceRecord
+
+        self._client().post(
+            '/api/observations/', self._payload(), format='json',
+            HTTP_X_PROVENANCE_SOURCE='PATIENT_SELF',
+            HTTP_X_PROVENANCE_USER_ID='acting-user',
+        )
+
+        row = Observation.objects.get(person=self.person)
+        prov = ProvenanceRecord.objects.get(
+            content_type=ContentType.objects.get_for_model(Observation),
+            object_id=row.pk,
+        )
+        self.assertEqual(prov.source_user_id, 'acting-user')
+        self.assertEqual(prov.target_patient_id, str(self.person.person_id))
+
+    def test_an_unrecognised_source_is_refused(self):
+        """The column has choices, which Django does not enforce on create()."""
+        resp = self._client().post(
+            '/api/observations/', self._payload(), format='json',
+            HTTP_X_PROVENANCE_SOURCE='FROM_A_HAT',
+        )
+        self.assertEqual(resp.status_code, 400, resp.data)
+        self.assertIn('source', resp.data)
+
+    def test_update_without_a_source_is_refused(self):
+        row = Observation.objects.create(
+            observation_id=96901,
+            person=self.person,
+            observation_concept=self.concept,
+            observation_date=date.today(),
+            observation_type_concept=self.type_concept,
+            value_as_string='before',
+        )
+        resp = self._client().patch(
+            f'/api/observations/{row.pk}/', {'value_as_string': 'after'}, format='json',
+        )
+        self.assertEqual(resp.status_code, 400, resp.data)
+        row.refresh_from_db()
+        self.assertEqual(row.value_as_string, 'before')
+
+    def test_a_batch_without_a_source_is_refused(self):
+        """A list body must not be a way around the rule."""
+        resp = self._client().post('/api/observations/', [self._payload()], format='json')
+        self.assertEqual(resp.status_code, 400, resp.data)
+        self.assertFalse(Observation.objects.filter(person=self.person).exists())
+
+    def test_a_machine_caller_is_unaffected(self):
+        """Service tokens keep today's contract; tightening them is a migration."""
+        client = APIClient()
+        with self.settings(SERVICE_AUTH_TOKEN='test-service-secret'):
+            client.credentials(HTTP_AUTHORIZATION='Bearer test-service-secret')
+            resp = client.post('/api/observations/', self._payload(), format='json')
+        self.assertEqual(resp.status_code, 201, resp.data)
 
 
 class FindOrCreatePersonTest(TestCase):
@@ -17759,3 +17881,168 @@ class FindOrCreatePersonTest(TestCase):
         self.assertTrue(resp.data['created'])
         self.assertEqual(Person.objects.count(), before + 1)
         self.assertNotEqual(resp.data['person_id'], self.person.person_id)
+
+
+class DeathEndpointTest(TestCase):
+    """`/api/deaths/`. The model existed with no route, so mortality was unwritable."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import GroupAccess, Organization
+        from patient_portal.models import PatientUser
+
+        _make_vocab_fixtures()
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+
+        cls.org = Organization.objects.create(name='Death Org', slug='death-org-98')
+        cls.person = Person.objects.create(person_id=98001, family_name='Late')
+        PatientRecord.objects.create(person=cls.person, organization=cls.org)
+
+        cls.other = Person.objects.create(person_id=98002, family_name='Living')
+        PatientRecord.objects.create(person=cls.other)
+
+        cls.clinician = Identity.objects.create_user(email='death-doc@test.com', password='pw')
+        GroupAccess.objects.create(identity=cls.clinician, org=cls.org, role='doctor')
+
+        cls.patient_other = Identity.objects.create_user(email='death-b@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.patient_other, person=cls.other)
+
+    def _payload(self, person, death_date='2026-02-01'):
+        return {
+            'person': person.person_id,
+            'death_date': death_date,
+            'death_type_concept': self.type_concept.concept_id,
+        }
+
+    def _post(self, identity, payload, source='EHR_SYNC'):
+        client = APIClient()
+        client.force_authenticate(user=identity)
+        headers = {'HTTP_X_PROVENANCE_SOURCE': source} if source else {}
+        return client.post('/api/deaths/', payload, format='json', **headers)
+
+    def test_clinician_records_a_death_for_their_patient(self):
+        from omop_core.models import Death
+
+        resp = self._post(self.clinician, self._payload(self.person))
+        self.assertEqual(resp.status_code, 201, resp.data)
+        self.assertTrue(Death.objects.filter(person=self.person).exists())
+
+    def test_a_second_report_corrects_the_first_rather_than_failing(self):
+        from omop_core.models import Death
+
+        self._post(self.clinician, self._payload(self.person))
+        resp = self._post(self.clinician, self._payload(self.person, '2026-02-03'))
+
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertEqual(Death.objects.filter(person=self.person).count(), 1)
+        self.assertEqual(
+            str(Death.objects.get(person=self.person).death_date), '2026-02-03',
+        )
+
+    def test_clinician_cannot_record_a_death_outside_their_org(self):
+        from omop_core.models import Death
+
+        resp = self._post(self.clinician, self._payload(self.other))
+        self.assertEqual(resp.status_code, 403, resp.data)
+        self.assertFalse(Death.objects.filter(person=self.other).exists())
+
+    def test_a_write_with_no_provenance_is_refused(self):
+        resp = self._post(self.clinician, self._payload(self.person), source=None)
+        self.assertEqual(resp.status_code, 400, resp.data)
+
+    def test_reads_are_scoped_to_the_caller(self):
+        from omop_core.models import Death
+
+        Death.objects.create(
+            person=self.person, death_date=date(2026, 2, 1),
+            death_type_concept=self.type_concept,
+        )
+        client = APIClient()
+        client.force_authenticate(user=self.patient_other)
+        resp = client.get('/api/deaths/')
+
+        self.assertEqual(resp.status_code, 200)
+        rows = resp.data['results'] if isinstance(resp.data, dict) else resp.data
+        self.assertNotIn(self.person.person_id, [r['person'] for r in rows])
+
+    def test_unauthenticated_is_rejected(self):
+        resp = APIClient().post('/api/deaths/', self._payload(self.person), format='json')
+        self.assertIn(resp.status_code, (401, 403))
+
+
+class FindOrCreatePersonClinicianTest(TestCase):
+    """A clinician may resolve a patient they hold access to, and no one else.
+
+    Before this, ``find_or_create`` was staff-only, which left a clinician with
+    a ``GroupAccess`` grant able to write a patient's labs but unable to find
+    the ``person_id`` to write them against.
+    """
+
+    ISSUER = 'https://securetoken.google.com/hk-test'
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import (
+            GroupAccess, Organization, PatientGroup, PatientGroupMembership,
+        )
+        from patient_portal.models import PatientUser
+
+        cls.org = Organization.objects.create(name='Resolve Org', slug='resolve-org-97')
+        cls.group = PatientGroup.objects.create(
+            organization=cls.org, name='Resolve Cohort', slug='resolve-cohort-97',
+        )
+
+        # In the clinician's group.
+        cls.person_in = Person.objects.create(person_id=97001)
+        cls.identity_in = Identity.objects.create(issuer=cls.ISSUER, sub='in-group')
+        PatientUser.objects.create(identity=cls.identity_in, person=cls.person_in)
+        PatientGroupMembership.objects.create(group=cls.group, person_id=cls.person_in.person_id)
+
+        # Outside it.
+        cls.person_out = Person.objects.create(person_id=97002)
+        cls.identity_out = Identity.objects.create(issuer=cls.ISSUER, sub='out-of-group')
+        PatientUser.objects.create(identity=cls.identity_out, person=cls.person_out)
+
+        cls.clinician = Identity.objects.create_user(email='res-doc@test.com', password='pw')
+        GroupAccess.objects.create(identity=cls.clinician, group=cls.group, role='doctor')
+
+    def _post(self, identity, sub):
+        client = APIClient()
+        client.force_authenticate(user=identity)
+        return client.post(
+            '/api/persons/find_or_create/',
+            {'actor_iss': self.ISSUER, 'actor_sub': sub},
+            format='json',
+        )
+
+    def test_clinician_resolves_a_patient_in_their_group(self):
+        resp = self._post(self.clinician, 'in-group')
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertEqual(resp.data['person_id'], self.person_in.person_id)
+        self.assertFalse(resp.data['created'])
+
+    def test_clinician_cannot_resolve_a_patient_outside_their_group(self):
+        resp = self._post(self.clinician, 'out-of-group')
+        self.assertEqual(resp.status_code, 403, resp.data)
+
+    def test_clinician_cannot_mint_a_person(self):
+        """Provisioning stays privileged, and the 'created' flag stays unprobeable."""
+        before = Person.objects.count()
+        resp = self._post(self.clinician, 'nobody-has-this-sub')
+        self.assertEqual(resp.status_code, 403, resp.data)
+        self.assertEqual(Person.objects.count(), before)
+
+    def test_an_unknown_subject_is_refused_the_same_way_as_an_unreachable_one(self):
+        """Both 403, so the response cannot be used to tell which subjects exist."""
+        unknown = self._post(self.clinician, 'nobody-has-this-sub')
+        unreachable = self._post(self.clinician, 'out-of-group')
+        self.assertEqual(unknown.status_code, unreachable.status_code)
+
+    def test_a_patient_cannot_resolve_another_patient(self):
+        resp = self._post(self.identity_in, 'out-of-group')
+        self.assertEqual(resp.status_code, 403, resp.data)
+
+    def test_a_patient_can_resolve_themselves(self):
+        resp = self._post(self.identity_in, 'in-group')
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertEqual(resp.data['person_id'], self.person_in.person_id)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -4024,6 +4024,56 @@ class AuditLogMiddlewareTest(_SmartBase):
         return person, pi
 
     # ------------------------------------------------------------------
+    # Caller identification
+    # ------------------------------------------------------------------
+
+    def test_client_id_for_a_partner_token_is_the_issuer_and_subject(self):
+        """A partner token must not put its whole claim set in the audit row.
+
+        ``PartnerAuthentication`` leaves a ``TokenClaims`` on ``request.auth``,
+        and its ``str()`` is a repr of every claim the token carries — well past
+        the 255-character column. The audit row then failed to insert, so every
+        request authenticated this way went unrecorded, and the SIEM line
+        carried the token's contents.
+        """
+        from patient_portal.api.middleware import _get_client_id
+        from patient_portal.api.providers.base import TokenClaims
+
+        request = type('R', (), {})()
+        request.auth = TokenClaims(
+            issuer='https://securetoken.google.com/hk-test',
+            sub='some-subject',
+            email='p@test.com',
+            name=None,
+            raw={'padding': 'x' * 500},
+        )
+
+        client_id = _get_client_id(request)
+
+        self.assertEqual(client_id, 'https://securetoken.google.com/hk-test|some-subject')
+        self.assertLessEqual(len(client_id), 255)
+
+    def test_audit_row_persists_for_a_partner_token(self):
+        from patient_portal.api.middleware import AuditLogMiddleware
+        from patient_portal.models import AuditEvent
+
+        AuditLogMiddleware._persist({
+            'event': 'record_update',
+            'method': 'PATCH',
+            'path': '/api/observations/1/',
+            'status_code': 200,
+            'client_id': 'x' * 400,
+            'user_id': None,
+            'user_email': None,
+            'resource_id': '1',
+            'ip_address': '127.0.0.1',
+            'duration_ms': 1,
+        })
+
+        row = AuditEvent.objects.order_by('-id').first()
+        self.assertEqual(len(row.client_id), 255)
+
+    # ------------------------------------------------------------------
     # HTTP method coverage
     # ------------------------------------------------------------------
 
@@ -17623,3 +17673,89 @@ class PatientSelfCreateTest(TestCase):
         rows = resp.data['results'] if isinstance(resp.data, dict) else resp.data
         returned = [row['person'] for row in rows]
         self.assertNotIn(self.person_b.person_id, returned)
+
+
+class FindOrCreatePersonTest(TestCase):
+    """``find_or_create`` must return the Person a patient already has.
+
+    Two paths resolve a patient to a Person and they key on different columns.
+    The portal's own ``/api/patient-info/me/`` goes through ``PatientUser`` and
+    never populates ``Person.actor_iss/actor_sub``; ``find_or_create`` matched
+    only on those columns. For any patient who had signed in — the ordinary
+    case — a staff caller resolving them here got a brand-new Person, and
+    anything written against it landed on a record the patient could not see.
+    """
+
+    ISSUER = 'https://securetoken.google.com/hk-test'
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+
+        cls.person = Person.objects.create(person_id=95001, family_name='Linked')
+        cls.identity = Identity.objects.create(issuer=cls.ISSUER, sub='linked-sub')
+        PatientUser.objects.create(identity=cls.identity, person=cls.person)
+
+        cls.staff = Identity.objects.create_user(
+            email='foc-staff@test.com', password='pw', is_staff=True,
+        )
+
+    def _post(self, sub):
+        client = APIClient()
+        client.force_authenticate(user=self.staff)
+        return client.post(
+            '/api/persons/find_or_create/',
+            {'actor_iss': self.ISSUER, 'actor_sub': sub},
+            format='json',
+        )
+
+    def test_returns_the_person_the_identity_is_already_linked_to(self):
+        before = Person.objects.count()
+        resp = self._post('linked-sub')
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertEqual(resp.data['person_id'], self.person.person_id)
+        self.assertFalse(resp.data['created'])
+        self.assertEqual(Person.objects.count(), before)
+
+    def test_backfills_the_actor_columns_so_both_paths_agree(self):
+        self._post('linked-sub')
+        self.person.refresh_from_db()
+        self.assertEqual(self.person.actor_iss, self.ISSUER)
+        self.assertEqual(self.person.actor_sub, 'linked-sub')
+
+    def test_is_idempotent_across_repeated_calls(self):
+        first = self._post('linked-sub')
+        second = self._post('linked-sub')
+        self.assertEqual(first.data['person_id'], second.data['person_id'])
+        self.assertFalse(second.data['created'])
+
+    def test_repeated_provenance_from_one_actor_refreshes_a_single_row(self):
+        """A patient correcting the same value twice must not hit the constraint.
+
+        ``uq_provenance_object_actor_source`` allows one row per
+        (record, actor, source). Recording provenance with an unconditional
+        create meant the second edit by the same actor raised IntegrityError
+        and the request 500ed.
+        """
+        from django.contrib.contenttypes.models import ContentType
+        from omop_core.models import ProvenanceRecord
+        from patient_portal.api.views import _record_provenance
+
+        _record_provenance(self.person, 'PATIENT_SELF', 'actor-1', modification_reason='first')
+        _record_provenance(self.person, 'PATIENT_SELF', 'actor-1', modification_reason='second')
+
+        rows = ProvenanceRecord.objects.filter(
+            content_type=ContentType.objects.get_for_model(Person),
+            object_id=self.person.pk,
+            source_user_id='actor-1',
+        )
+        self.assertEqual(rows.count(), 1)
+        self.assertEqual(rows.first().modification_reason, 'second')
+
+    def test_still_creates_for_an_identity_with_no_person(self):
+        before = Person.objects.count()
+        resp = self._post('brand-new-sub')
+        self.assertEqual(resp.status_code, 201, resp.data)
+        self.assertTrue(resp.data['created'])
+        self.assertEqual(Person.objects.count(), before + 1)
+        self.assertNotEqual(resp.data['person_id'], self.person.person_id)

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -15228,6 +15228,181 @@ class UserlessOAuthTokenDetailTest(TestCase):
         self.assertFalse(can_access_patient(None, pid))
         self.assertFalse(can_write_patient(None, pid))
         self.assertIsNone(get_actor_role(None, pid))
+
+
+class OrgLevelGrantTest(TestCase):
+    """A grant held at org level must mean the same thing to every check.
+
+    `can_write_patient` matched a grant through the patient's group *or* their
+    organization; `can_access_patient` and `get_actor_role` matched only the
+    group. An org-level grant therefore permitted a write its holder could not
+    read back — and any code that resolved a row through a read path before
+    updating it refused a caller who was entitled to make the change.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from omop_core.models import (
+            GroupAccess, Organization, PatientGroup, PatientGroupMembership,
+        )
+
+        cls.org = Organization.objects.create(name='Grant Org', slug='grant-org-99')
+        cls.person = Person.objects.create(person_id=99001)
+        PatientRecord.objects.create(person=cls.person, organization=cls.org)
+
+        # A patient of no organization the grants below reach.
+        cls.outsider = Person.objects.create(person_id=99002)
+        PatientRecord.objects.create(person=cls.outsider)
+
+        cls.org_doctor = Identity.objects.create_user(email='org-doc@test.com', password='pw')
+        GroupAccess.objects.create(identity=cls.org_doctor, org=cls.org, role='doctor')
+
+        cls.org_analyst = Identity.objects.create_user(email='org-analyst@test.com', password='pw')
+        GroupAccess.objects.create(identity=cls.org_analyst, org=cls.org, role='analyst')
+
+        # The same reach, granted through a group instead — the path that always
+        # worked, kept alongside so the two stay comparable.
+        cls.group = PatientGroup.objects.create(
+            organization=cls.org, name='Grant Cohort', slug='grant-cohort-99',
+        )
+        PatientGroupMembership.objects.create(group=cls.group, person_id=cls.person.person_id)
+        cls.group_doctor = Identity.objects.create_user(email='grp-doc@test.com', password='pw')
+        GroupAccess.objects.create(identity=cls.group_doctor, group=cls.group, role='doctor')
+
+    def test_an_org_grant_permits_reading_what_it_permits_writing(self):
+        from omop_core.authorization import can_access_patient, can_write_patient
+
+        pid = self.person.person_id
+        self.assertTrue(can_write_patient(self.org_doctor, pid))
+        self.assertTrue(can_access_patient(self.org_doctor, pid))
+
+    def test_an_org_grant_reports_its_role(self):
+        from omop_core.authorization import get_actor_role
+
+        self.assertEqual(get_actor_role(self.org_doctor, self.person.person_id), 'doctor')
+
+    def test_a_group_grant_behaves_the_same_as_an_org_one(self):
+        from omop_core.authorization import (
+            can_access_patient, can_write_patient, get_actor_role,
+        )
+
+        pid = self.person.person_id
+        self.assertTrue(can_access_patient(self.group_doctor, pid))
+        self.assertTrue(can_write_patient(self.group_doctor, pid))
+        self.assertEqual(get_actor_role(self.group_doctor, pid), 'doctor')
+
+    def test_an_analyst_reads_but_does_not_write(self):
+        """Widening reads must not have widened writes."""
+        from omop_core.authorization import can_access_patient, can_write_patient
+
+        pid = self.person.person_id
+        self.assertTrue(can_access_patient(self.org_analyst, pid))
+        self.assertFalse(can_write_patient(self.org_analyst, pid))
+
+    def test_a_grant_reaches_no_further_than_its_org(self):
+        from omop_core.authorization import (
+            can_access_patient, can_write_patient, get_actor_role,
+        )
+
+        pid = self.outsider.person_id
+        self.assertFalse(can_access_patient(self.org_doctor, pid))
+        self.assertFalse(can_write_patient(self.org_doctor, pid))
+        self.assertIsNone(get_actor_role(self.org_doctor, pid))
+
+    def test_an_expired_grant_reaches_nothing(self):
+        from django.utils import timezone
+        from omop_core.models import GroupAccess
+        from omop_core.authorization import (
+            can_access_patient, can_write_patient, get_actor_role,
+        )
+
+        expired = Identity.objects.create_user(email='expired-doc@test.com', password='pw')
+        GroupAccess.objects.create(
+            identity=expired, org=self.org, role='doctor',
+            expires_at=timezone.now() - timezone.timedelta(days=1),
+        )
+
+        pid = self.person.person_id
+        self.assertFalse(can_access_patient(expired, pid))
+        self.assertFalse(can_write_patient(expired, pid))
+        self.assertIsNone(get_actor_role(expired, pid))
+
+    def test_an_org_grant_with_the_patient_role_confers_nothing(self):
+        """The trap in widening org grants.
+
+        A patient identity carries `GroupAccess(org=..., role='patient')` — it
+        marks which organization they belong to, not standing over its other
+        patients. Matching every role at org scope would let one patient read
+        every other patient in their org. Their own record reaches them by
+        self-access, not through this.
+        """
+        from omop_core.models import GroupAccess
+        from omop_core.authorization import (
+            can_access_patient, can_write_patient, get_actor_role,
+        )
+        from patient_portal.models import PatientUser
+
+        neighbour = Person.objects.create(person_id=99003)
+        PatientRecord.objects.create(person=neighbour, organization=self.org)
+        identity = Identity.objects.create_user(email='org-patient@test.com', password='pw')
+        PatientUser.objects.create(identity=identity, person=neighbour)
+        GroupAccess.objects.create(identity=identity, org=self.org, role='patient')
+
+        # Their own record, through self-access.
+        self.assertTrue(can_access_patient(identity, neighbour.person_id))
+        # A fellow patient of the same org: nothing.
+        pid = self.person.person_id
+        self.assertFalse(can_access_patient(identity, pid))
+        self.assertFalse(can_write_patient(identity, pid))
+        self.assertIsNone(get_actor_role(identity, pid))
+
+    def test_the_patient_list_does_not_expose_group_peers_to_a_patient(self):
+        """The same role trap, in the list query that builds its own set."""
+        from omop_core.models import GroupAccess, PatientGroupMembership
+        from patient_portal.models import PatientUser
+
+        peer = Person.objects.create(person_id=99004)
+        peer_record = PatientRecord.objects.create(person=peer, organization=self.org)
+        PatientGroupMembership.objects.create(group=self.group, person_id=peer.person_id)
+        identity = Identity.objects.create_user(email='grp-patient@test.com', password='pw')
+        PatientUser.objects.create(identity=identity, person=peer)
+        GroupAccess.objects.create(identity=identity, group=self.group, role='patient')
+
+        client = APIClient()
+        client.force_authenticate(user=identity)
+        resp = client.get('/api/patient-info/')
+
+        self.assertEqual(resp.status_code, 200)
+        rows = resp.data.get('results', resp.data) if isinstance(resp.data, dict) else resp.data
+        ids = {row['id'] for row in rows}
+        self.assertIn(peer_record.id, ids, 'their own record')
+        self.assertNotIn(
+            PatientRecord.objects.get(person=self.person).id, ids,
+            'a fellow member of the group must not be visible',
+        )
+
+    def test_a_clinician_still_sees_their_group_panel_in_the_list(self):
+        client = APIClient()
+        client.force_authenticate(user=self.group_doctor)
+        resp = client.get('/api/patient-info/')
+
+        self.assertEqual(resp.status_code, 200)
+        rows = resp.data.get('results', resp.data) if isinstance(resp.data, dict) else resp.data
+        ids = {row['id'] for row in rows}
+        self.assertIn(PatientRecord.objects.get(person=self.person).id, ids)
+
+    def test_the_strongest_role_wins_when_several_grants_apply(self):
+        """Two paths to the same patient must not make the answer arbitrary."""
+        from omop_core.models import GroupAccess
+        from omop_core.authorization import get_actor_role
+
+        both = Identity.objects.create_user(email='both-ways@test.com', password='pw')
+        GroupAccess.objects.create(identity=both, group=self.group, role='analyst')
+        GroupAccess.objects.create(identity=both, org=self.org, role='org_admin')
+
+        self.assertEqual(get_actor_role(both, self.person.person_id), 'org_admin')
+
+
 # ---------------------------------------------------------------------------
 # Vocabulary Snapshot (streaming NDJSON) tests
 # ---------------------------------------------------------------------------

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -17519,3 +17519,107 @@ class BulkOmopUpsertTest(TestCase):
             PatientRecord.objects.get(person=self.person).derived_at,
             derived_before,
             'the collapse landed without refreshing the read model')
+
+
+class PatientSelfCreateTest(TestCase):
+    """POST to the clinical viewsets with the acting user's own credential.
+
+    The six viewsets carrying ``_ProvenanceMixin`` use ``PatientCrudPermission``
+    so that a patient can record their own data and a clinician can record data
+    for a patient they hold access to. Neither previously could: the base
+    ``ScopedTokenPermission`` denies POST to every authenticated caller without
+    ``is_staff``, which rejected the request before ``can_write_patient`` — the
+    rule that actually decides who may write for whom — ever ran.
+
+    These tests pin the pairing. The permission opens the method; the ownership
+    check in ``perform_create`` still decides the person.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from patient_portal.models import PatientUser
+        from omop_core.models import GroupAccess, Organization
+
+        _make_vocab_fixtures()
+        cls.observation_concept = Concept.objects.get(concept_id=4112853)
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+
+        # Patient A, in an organization a clinician will have access to.
+        cls.org = Organization.objects.create(name='Self Create Org', slug='self-create-org-94')
+        cls.person_a = Person.objects.create(person_id=94001, family_name='Able', given_name='Amy')
+        PatientRecord.objects.create(person=cls.person_a, organization=cls.org)
+        cls.patient_a = Identity.objects.create_user(email='sc-a@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.patient_a, person=cls.person_a)
+
+        # Patient B, in no organization — outside the clinician's reach.
+        cls.person_b = Person.objects.create(person_id=94002, family_name='Baker', given_name='Bob')
+        PatientRecord.objects.create(person=cls.person_b)
+        cls.patient_b = Identity.objects.create_user(email='sc-b@test.com', password='pw')
+        PatientUser.objects.create(identity=cls.patient_b, person=cls.person_b)
+
+        cls.clinician = Identity.objects.create_user(email='sc-doc@test.com', password='pw')
+        GroupAccess.objects.create(identity=cls.clinician, org=cls.org, role='doctor')
+
+        cls.staff = Identity.objects.create_user(email='sc-staff@test.com', password='pw', is_staff=True)
+
+    def _payload(self, person):
+        return {
+            'person': person.person_id,
+            'observation_concept': self.observation_concept.concept_id,
+            'observation_date': str(date.today()),
+            'observation_type_concept': self.type_concept.concept_id,
+            'value_as_string': 'ECOG 1',
+        }
+
+    def _post(self, identity, person):
+        client = APIClient()
+        if identity is not None:
+            client.force_authenticate(user=identity)
+        return client.post('/api/observations/', self._payload(person), format='json')
+
+    def test_patient_creates_own_observation(self):
+        resp = self._post(self.patient_a, self.person_a)
+        self.assertEqual(resp.status_code, 201, resp.data)
+        self.assertEqual(
+            Observation.objects.filter(person=self.person_a).count(), 1
+        )
+
+    def test_patient_cannot_create_for_another_person(self):
+        resp = self._post(self.patient_a, self.person_b)
+        self.assertEqual(resp.status_code, 403, resp.data)
+        self.assertFalse(Observation.objects.filter(person=self.person_b).exists())
+
+    def test_clinician_creates_for_patient_in_their_org(self):
+        resp = self._post(self.clinician, self.person_a)
+        self.assertEqual(resp.status_code, 201, resp.data)
+
+    def test_clinician_cannot_create_outside_their_org(self):
+        resp = self._post(self.clinician, self.person_b)
+        self.assertEqual(resp.status_code, 403, resp.data)
+        self.assertFalse(Observation.objects.filter(person=self.person_b).exists())
+
+    def test_staff_creates_for_any_person(self):
+        resp = self._post(self.staff, self.person_b)
+        self.assertEqual(resp.status_code, 201, resp.data)
+
+    def test_unauthenticated_is_rejected(self):
+        resp = self._post(None, self.person_a)
+        self.assertIn(resp.status_code, (401, 403), resp.data)
+        self.assertFalse(Observation.objects.filter(person=self.person_a).exists())
+
+    def test_reads_are_unchanged_for_patients(self):
+        """The permission swap must not widen what a patient can read."""
+        Observation.objects.create(
+            observation_id=94901,
+            person=self.person_b,
+            observation_concept=self.observation_concept,
+            observation_date=date.today(),
+            observation_type_concept=self.type_concept,
+        )
+        client = APIClient()
+        client.force_authenticate(user=self.patient_a)
+        resp = client.get('/api/observations/')
+        self.assertEqual(resp.status_code, 200)
+        rows = resp.data['results'] if isinstance(resp.data, dict) else resp.data
+        returned = [row['person'] for row in rows]
+        self.assertNotIn(self.person_b.person_id, returned)


### PR DESCRIPTION
> **Draft — not finished.** The permission change, the four defects end-to-end testing turned up,
> the four API gaps that blocked the consumer, and their tests are complete and green. What is
> still open is listed at the bottom.

## What this changes

`ScopedTokenPermission` grants unsafe methods to a service token or a staff user, and gives every
other authenticated caller read plus `PATCH`. That denies POST to two actors the system already
means to allow:

- a **patient** recording their own data
- a **clinician** recording data for a patient they hold `GroupAccess` to

Both were rejected at the view, before `can_write_patient` — the rule that actually decides who may
write for whom — ever ran.

The six clinical viewsets carrying `_ProvenanceMixin` now use `PatientCrudPermission`:
`ConditionOccurrence`, `DrugExposure`, `Measurement`, `Observation`, `ProcedureOccurrence`,
`Episode`. That is the class already serving `PatientSurveyResponseViewSet` and
`PatientMessageViewSet` for exactly this reason.

## Why it is safe

The permission opens the method. Ownership is decided underneath it and is unchanged:

- `_ProvenanceMixin.perform_create` calls `can_write_patient` for every non-service caller
- `_OmopBulkCreateMixin._bulk_create` applies the same check for the batched path

`can_write_patient` returns true for staff, the patient's own `person_id`, a `VERIFIED`
`PersonalRepresentative`, and a `GroupAccess` holder with a `doctor` or `org_admin` role scoped to
that patient's group or org. A patient reaching at another person, and a clinician reaching outside
their organization, are both refused.

## Deliberately not included

`EpisodeEventViewSet`, `PatientDocumentViewSet` and `PatientTrialEnrollmentViewSet` stay on the base
class. They carry **no `_ProvenanceMixin`**, so they fall back to DRF's default `perform_create`
with no ownership check at all — opening POST there would allow a write against any `person_id`.
They need that check added first.

## Tests

Seven new, in `PatientSelfCreateTest`:

| case | expected |
| --- | --- |
| patient creates a row for themselves | 201 |
| patient posts with another person's id | 403 |
| clinician with `GroupAccess` creates for their patient | 201 |
| same clinician targets a patient outside their org | 403 |
| staff creates for any person | 201 |
| unauthenticated | 401 |
| a patient's reads are not widened | unchanged |

Four more in `FindOrCreatePersonTest`, two in `AuditLogMiddlewareTest`. Full suite:
**1180 `patient_portal` + 231 `omop_core`, all passing**.

An end-to-end suite lives on the consumer side (`one/tests/promop-double-write/`, 40 tests). It
drives this service over HTTP in Docker with `DEBUG=False`, so the CORS allowlist and the
production auth stack are the ones under test — under `DEBUG` PRomop allows every origin and
accepts HTTP Basic, which would prove nothing. `seed_double_write_e2e` here creates the fixtures.

## API gaps closed

These are the four the consumer's plan tracks as P3, P4, P6 and P7.

**Provenance now records the subject, not only the actor (P3).** `_record_provenance` always
accepted `target_patient_id`; `_ProvenanceMixin._prov` never passed one, so a write made on a
patient's behalf said who acted and not for whom — the field carrying the point of an on-behalf-of
write was the blank one. The batched path already did this.

**A write from a person must declare its origin (P4).** Recording provenance was opt-in: a request
with no source header wrote the clinical row and no provenance at all. An unrecognised source is
refused too — `source` has `choices`, which Django does not enforce on `create()`, so an invented
value stored happily and then matched none of the filters written against the real ones.

The requirement covers the six clinical viewsets and only callers who are people. Machines are
deliberately left on today's contract: a service token or an OAuth client already has an identity
fixed by its credential, and integrations are written against the current behaviour — as is this
service's own frontend, on the survey endpoint. Both are worth tightening. Neither belongs in the
change that opened browser-direct writes, and doing it here would have broken 83 tests standing in
for those callers.

**A clinician can resolve a patient they may write for (P6).** `find_or_create` was staff-only,
which left a clinician able to write a patient's labs but unable to look up the `person_id` to write
them against. Resolution is open to any caller who already holds access to that person; minting one
is not, since creating records is more than resolution needs and a `created` flag distinguishing
found from new would otherwise let a clinician probe which subjects exist. An unknown subject and an
unreachable one are refused identically.

**`/api/deaths/` exists (P7).** `Death` had a model and no route, so mortality could not be written
at all. `person` is the primary key, so a second report corrects the first rather than failing on
the key.

## Authorization: one predicate, explicit roles

A `GroupAccess` grant reaches a patient two ways — through a group they belong to, or through the
organization holding their record. `can_write_patient` matched both; `can_access_patient` and
`get_actor_role` matched only the group. Three copies of one query that had drifted. An org-level
grant therefore permitted a write its holder could not read back, and anything resolving a row
through a read before updating it refused a caller entitled to make the change — which is how it
surfaced, building `/api/deaths/`. They now share `professional_grants`.

**Widening reads exposed a second hole**, caught by `PatientRecordIsolationTest` rather than by
inspection, and worth a careful look in review. A patient identity carries a `GroupAccess` row with
role `patient`: it records which organization they belong to and confers no standing over anyone
else in it. Matching every role at org scope showed one patient every other patient in their org.
Their own record was never at stake — that arrives by self-access.

So the predicate takes an explicit role set at every call site, with no permissive default to fall
into: `PROFESSIONAL_READ_ROLES` for reading and role lookup, `PROFESSIONAL_WRITE_ROLES` for writing.
The patient-record list query builds its own visible set instead of calling these helpers and had
the same role hole; it now applies the same filter, with a test.

`get_actor_role` also resolved an actor holding grants down both paths by taking whichever row came
back first. It returns the strongest role instead.

## Defects it found

Each of these sits between the calling app and this service, which is why the tests on either side
missed all of them.

**The CORS preflight refused the provenance headers.** `X-Provenance-Source` and
`X-Provenance-User-Id` are not in the default set, so every cross-origin clinical write would have
failed in the browser and left no trace here. Named in `CORS_ALLOW_HEADERS`.

**`find_or_create` resolved a known patient to a new person.** The portal links a patient to a
Person through `PatientUser` and never populates `Person.actor_iss/actor_sub`, which is all
`find_or_create` matched on. Any staff-entered value for a patient who had signed in would have
landed on a second person, invisible from their own record. It now consults the identity link first
and backfills the columns so both paths agree from then on.

**A second correction to the same row returned 500.** `uq_provenance_object_actor_source` allows one
row per (record, actor, source), and provenance was recorded with an unconditional create, so the
same actor editing the same record twice hit the constraint. It refreshes that row instead.

**No partner-authenticated request produced an audit row.** `_get_client_id` returned
`str(request.auth)`, which for a partner token is a repr of every claim it carries — past the
255-character column, so the insert failed and was swallowed as a warning. It also put the token's
contents in the SIEM line. Now the issuer and subject, bounded.

## Also here

`docker-compose.yml` could not start the server with `DEBUG` off at all: `ALLOWED_HOSTS` had no
passthrough, and the folded `command:` block put each gunicorn flag on its own line, where the shell
ran them as separate commands (a folded scalar keeps the newline of any line indented deeper than
its first). Both fixed, with the CORS, Firebase and host-port variables plumbed through so a local
container can be brought up in the shape a deployment uses.

## Still open

- [ ] The deployed environments need their real app origins in `CORS_ALLOWED_ORIGINS` — config, not code
- [ ] Provenance stays optional for machine callers and on the survey endpoint. Worth closing; a migration with its own coordination, not a rider on this

## Closed here

- [x] `CORS_ALLOWED_ORIGINS` and `CORS_ALLOW_HEADERS`
- [x] End-to-end verification against a running instance
- [x] Provenance was silently optional (P4)
- [x] `_prov` did not pass `target_patient_id` (P3)
- [x] `find_or_create` was `is_staff`-only (P6)
- [x] No `/api/deaths/` (P7)
- [x] Reads and writes disagreed about org-level grants (P12)

Context, and the consumer this is for, in the plan and gap analysis:
`docs/promop-double-write-plan.md` and `docs/promop-api-gaps.md` on the `one` side.



