### PR TITLE
fix: filter 'No matching concept' sentinel from therapy labels (#458)

### DIFF
--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -22,22 +22,6 @@ from omop_core.models import (
     Death, ConceptRelationship, PERSON_YEAR_PLACEHOLDERS,
 )
 from omop_core.services.concept_cache import concept_by_id as _cc_by_id, concept_by_loinc as _cc_by_loinc
-
-# Concept 0 is seeded with this name; it must never leak into user-visible
-# labels.  _get_disease_data already guards against it; the same guard must be
-# applied everywhere a concept_name is surfaced (therapy labels, concomitant
-# medications, etc.).  See #458.
-_SENTINEL_CONCEPT_NAME = 'No matching concept'
-
-
-def _usable_concept_name(concept) -> str | None:
-    """Return the concept's name unless it is the unmapped sentinel (concept 0)."""
-    if concept is None:
-        return None
-    name = concept.concept_name
-    if not name or name == _SENTINEL_CONCEPT_NAME:
-        return None
-    return name
 from omop_core.services.mappings import (
     WEARABLE_CONCEPT_CODE, WEARABLE_ARTIFACT_BOUNDS, WEARABLE_MIN_VALID_DAYS,
     WEARABLE_TREND_IMPROVING_PCT, WEARABLE_TREND_DECLINING_PCT,
@@ -55,6 +39,22 @@ from omop_core.services.lot_regimens import (
 # ---------------------------------------------------------------------------
 
 logger = logging.getLogger(__name__)
+
+# Concept 0 is seeded with this name; it must never leak into user-visible
+# labels.  _get_disease_data already guards against it; the same guard must be
+# applied everywhere a concept_name is surfaced (therapy labels, concomitant
+# medications, etc.).  See #458.
+_SENTINEL_CONCEPT_NAME = 'No matching concept'
+
+
+def _usable_concept_name(concept) -> str | None:
+    """Return the concept's name unless it is the unmapped sentinel (concept 0)."""
+    if concept is None:
+        return None
+    name = concept.concept_name
+    if not name or name == _SENTINEL_CONCEPT_NAME:
+        return None
+    return name
 
 # Bump this whenever aggregation or computation logic changes in any section
 # extractor or in _compute_derived_fields.  See DERIVATION_CHANGELOG.md.

--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -22,6 +22,22 @@ from omop_core.models import (
     Death, ConceptRelationship, PERSON_YEAR_PLACEHOLDERS,
 )
 from omop_core.services.concept_cache import concept_by_id as _cc_by_id, concept_by_loinc as _cc_by_loinc
+
+# Concept 0 is seeded with this name; it must never leak into user-visible
+# labels.  _get_disease_data already guards against it; the same guard must be
+# applied everywhere a concept_name is surfaced (therapy labels, concomitant
+# medications, etc.).  See #458.
+_SENTINEL_CONCEPT_NAME = 'No matching concept'
+
+
+def _usable_concept_name(concept) -> str | None:
+    """Return the concept's name unless it is the unmapped sentinel (concept 0)."""
+    if concept is None:
+        return None
+    name = concept.concept_name
+    if not name or name == _SENTINEL_CONCEPT_NAME:
+        return None
+    return name
 from omop_core.services.mappings import (
     WEARABLE_CONCEPT_CODE, WEARABLE_ARTIFACT_BOUNDS, WEARABLE_MIN_VALID_DAYS,
     WEARABLE_TREND_IMPROVING_PCT, WEARABLE_TREND_DECLINING_PCT,
@@ -559,13 +575,8 @@ def _get_disease_data(person: Person) -> dict:
     ).filter(concept_q | source_q).order_by('-condition_start_date').first()
 
     if cancer_condition:
-        # Prefer source_value when concept is unmapped (id=0 / "No matching concept")
-        concept_name = (
-            cancer_condition.condition_concept.concept_name
-            if cancer_condition.condition_concept_id
-            and cancer_condition.condition_concept.concept_name != 'No matching concept'
-            else None
-        )
+        # Prefer source_value when concept is unmapped (id=0 / sentinel)
+        concept_name = _usable_concept_name(cancer_condition.condition_concept) if cancer_condition.condition_concept_id else None
         raw_name = concept_name or cancer_condition.condition_source_value or ''
         if raw_name:
             data['disease'] = _canonicalize_disease(raw_name)
@@ -639,8 +650,9 @@ def _get_treatment_data(person: Person) -> dict:
 
     current_meds = []
     for drug in recent_drugs[:5]:
-        if drug.drug_concept:
-            current_meds.append(drug.drug_concept.concept_name)
+        name = _usable_concept_name(drug.drug_concept) or drug.drug_source_value
+        if name:
+            current_meds.append(name)
     if current_meds:
         data['concomitant_medications'] = ', '.join(current_meds)
 
@@ -896,11 +908,12 @@ def _apply_inferred_lots(data: dict, lots) -> None:
         for de in (DrugExposure.objects
                    .filter(drug_exposure_id__in=exp_ids)
                    .select_related('drug_concept')):
-            if de.drug_concept:
+            name = _usable_concept_name(de.drug_concept)
+            if name:
                 de_info_by_id[de.drug_exposure_id] = (
                     de.drug_concept.concept_id,
                     de.drug_concept.vocabulary_id,
-                    de.drug_concept.concept_name,
+                    name,
                 )
             else:
                 de_info_by_id[de.drug_exposure_id] = (None, None, de.drug_source_value or 'Unknown')
@@ -1021,9 +1034,10 @@ def _get_treatment_data_from_episodes(person, data, episodes, drug_exposures):
         drugs_in_episode = [de_by_id[eid] for eid in event_ids if eid in de_by_id]
 
         drug_name_set = {
-            normalize_drug_name(de.drug_concept.concept_name)
+            normalize_drug_name(n)
             for de in drugs_in_episode
-            if de.drug_concept
+            for n in [_usable_concept_name(de.drug_concept)]
+            if n
         }
         # Drug source values (regimen names set by import handler) as fallback
         source_value_set = {
@@ -1126,7 +1140,7 @@ def _get_treatment_data_from_episodes(person, data, episodes, drug_exposures):
         else:
             # Try regimen name resolution: drug concept names first, then source values
             from omop_core.services.lot_regimens import get_regimen_name
-            _drug_cnames = [normalize_drug_name(de.drug_concept.concept_name) for de in drugs_in_episode if de.drug_concept]
+            _drug_cnames = [normalize_drug_name(n) for de in drugs_in_episode for n in [_usable_concept_name(de.drug_concept)] if n]
             _regimen_name = get_regimen_name({n.lower().strip() for n in _drug_cnames}) if _drug_cnames else None
             if not _regimen_name:
                 for sv in source_value_set:

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -4505,14 +4505,10 @@ class SentinelConceptNameFilterTest(_OmopBase):
 
     def test_disease_skips_sentinel_concept_name(self):
         """Condition with sentinel concept name falls back to source_value."""
-        sentinel_cond = _concept(
-            0, 'No matching concept', self.dom_cond, self.vocab, self.cc,
-            code='0',
-        )
         ConditionOccurrence.objects.create(
             condition_occurrence_id=94583,
             person=self.person,
-            condition_concept=sentinel_cond,
+            condition_concept=self.sentinel_concept,
             condition_source_value='Breast cancer',
             condition_start_date=date(2022, 1, 1),
             condition_type_concept=self.type_concept,

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -4451,3 +4451,78 @@ class NoFalselyStandardMintsTest(TestCase):
         self.assertEqual(second.concept_code, 'OMOP4976890')
         self.assertEqual(second.standard_concept, 'S')
         self.assertIsNone(second.source)
+
+
+# ===========================================================================
+# TEST-05: Sentinel concept name filtering (#458)
+# ===========================================================================
+
+class SentinelConceptNameFilterTest(_OmopBase):
+    """'No matching concept' (concept 0) must never leak into user-visible
+    labels — therapy regimens, concomitant medications, or disease names.
+    See #458."""
+
+    PERSON_ID = 90458
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # Concept 0: the unmapped sentinel
+        cls.sentinel_concept = _concept(
+            0, 'No matching concept', cls.dom_drug, cls.vocab, cls.cc,
+            code='0',
+        )
+
+    def test_concomitant_medications_skips_sentinel(self):
+        """Drugs mapped to concept 0 should fall back to drug_source_value,
+        not emit 'No matching concept' in concomitant_medications."""
+        DrugExposure.objects.create(
+            drug_exposure_id=94581,
+            person=self.person,
+            drug_concept=self.sentinel_concept,
+            drug_source_value='Bortezomib',
+            drug_exposure_start_date=date.today(),
+            drug_type_concept=self.type_concept,
+        )
+        pi = refresh_patient_record(self.person)
+        meds = pi.concomitant_medications or ''
+        self.assertNotIn('No matching concept', meds)
+        self.assertIn('Bortezomib', meds)
+
+    def test_concomitant_medications_skips_drug_with_no_fallback(self):
+        """A drug with sentinel concept and no source_value is omitted entirely."""
+        DrugExposure.objects.create(
+            drug_exposure_id=94582,
+            person=self.person,
+            drug_concept=self.sentinel_concept,
+            drug_source_value=None,
+            drug_exposure_start_date=date.today(),
+            drug_type_concept=self.type_concept,
+        )
+        pi = refresh_patient_record(self.person)
+        meds = pi.concomitant_medications or ''
+        self.assertNotIn('No matching concept', meds)
+
+    def test_disease_skips_sentinel_concept_name(self):
+        """Condition with sentinel concept name falls back to source_value."""
+        sentinel_cond = _concept(
+            0, 'No matching concept', self.dom_cond, self.vocab, self.cc,
+            code='0',
+        )
+        ConditionOccurrence.objects.create(
+            condition_occurrence_id=94583,
+            person=self.person,
+            condition_concept=sentinel_cond,
+            condition_source_value='Breast cancer',
+            condition_start_date=date(2022, 1, 1),
+            condition_type_concept=self.type_concept,
+        )
+        pi = refresh_patient_record(self.person)
+        self.assertNotIn('No matching concept', pi.disease or '')
+
+    def test_usable_concept_name_helper(self):
+        """Unit test for _usable_concept_name."""
+        from omop_core.services.patient_record_service import _usable_concept_name
+        self.assertIsNone(_usable_concept_name(None))
+        self.assertIsNone(_usable_concept_name(self.sentinel_concept))
+        self.assertEqual(_usable_concept_name(self.drug_concept), 'Doxorubicin')


### PR DESCRIPTION
## Summary
- Added `_usable_concept_name()` helper that returns `None` for the sentinel concept name ('No matching concept', concept 0), preventing it from leaking into user-visible labels
- Applied the filter at all five concept-name extraction points in `patient_record_service.py`:
  - Concomitant medications (falls back to `drug_source_value`)
  - Therapy regimen label builder (first pass — `drug_name_set`)
  - Therapy regimen label builder (second pass — `_drug_cnames`)
  - Inferred LOT drug info lookup (`_apply_inferred_lots`)
  - Disease name derivation (refactored to use shared helper)
- Added 4 tests covering sentinel filtering for concomitant meds, disease names, and the helper itself

Closes #458

## Test plan
- [x] All 1,384 backend tests pass (Django runner: `omop_core` + `patient_portal`)
- [x] New `SentinelConceptNameFilterTest` (4 tests) verifies sentinel is filtered from concomitant_medications and disease names
- [x] Existing therapy/disease derivation tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)