### PR TITLE
fix: verify required clinical vocabularies after load

### DIFF
--- a/docs/concept-mapping.md
+++ b/docs/concept-mapping.md
@@ -303,8 +303,10 @@ name-based matching, which is functional but loses semantic precision.
 
 1. Go to [athena.ohdsi.org](https://athena.ohdsi.org) and create a free account.
 2. Select the vocabularies your deployment needs:
-   - **Always required**: LOINC, SNOMED CT, RxNorm, HemOnc, OMOP Extension
-   - **Recommended**: RxNorm Extension, NDF-RT, ATC
+   - **Required for deployed clinical environments**: LOINC, SNOMED CT,
+     RxNorm, ICD10CM
+   - **Required for PROMOP oncology features**: HemOnc
+   - **Included when available**: RxNorm Extension and ATC
 3. Download the ZIP — it contains one TSV file per vocabulary table.
 
 ### Step 2 — Load into PostgreSQL
@@ -316,8 +318,7 @@ unzip athena_download.zip -d /tmp/athena_vocab
 # Run the loader (uses PostgreSQL COPY for fast bulk insert)
 DATABASE_URL="postgresql://postgres@localhost:5432/promop_dev" \
   .venv/bin/python manage.py load_athena_vocabularies \
-    --path /tmp/athena_vocab \
-    --vocabularies LOINC SNOMED RxNorm HemOnc
+    --path /tmp/athena_vocab
 
 # Verify
 DATABASE_URL="postgresql://postgres@localhost:5432/promop_dev" \
@@ -325,7 +326,8 @@ DATABASE_URL="postgresql://postgres@localhost:5432/promop_dev" \
 from omop_core.models import Concept
 print('LOINC:', Concept.objects.filter(vocabulary_id='LOINC').count())
 print('SNOMED:', Concept.objects.filter(vocabulary_id='SNOMED').count())
-print('HemOnc:', Concept.objects.filter(vocabulary_id='HemOnc').count())
+print('RxNorm:', Concept.objects.filter(vocabulary_id='RxNorm').count())
+print('ICD10CM:', Concept.objects.filter(vocabulary_id='ICD10CM').count())
 "
 ```
 
@@ -335,11 +337,13 @@ On Render (or any production platform), vocabulary loading is a one-time operati
 the first deploy. Upload the Athena TSV files to object storage (GCS or S3) and run:
 
 ```bash
-python manage.py load_athena_vocabularies --gcs-bucket your-bucket-name
+python manage.py load_athena_vocabularies --bucket your-bucket-name
 ```
 
-The `load_athena_vocabularies` command supports `--replace` to overwrite existing vocabulary
-data on a vocabulary update, and `--dry-run` to count records without writing.
+The command verifies LOINC, RxNorm, SNOMED, and ICD10CM after a non-dry-run
+load. `--dry-run` counts records without writing. Avoid `--replace` for a
+partial-load repair: it truncates vocabulary tables and cascades to clinical
+tables; the normal upsert is safe for an existing clinical environment.
 
 ---
 

--- a/docs/vocabularies.md
+++ b/docs/vocabularies.md
@@ -148,6 +148,31 @@ The high unmapped counts in `drug_exposure` and `observation` are source data th
 | `seed_omop_concepts` | Seeds the minimal concept set for dev/test, using **genuine Athena `concept_id`s** so it cannot manufacture duplicates on a database that already has the vocabulary |
 | `backfill_concept_source` | Fills `source='HealthKey'` on locally-minted rows, dry-run by default |
 
+### Required clinical vocabulary verification
+
+PROMOP requires **LOINC**, **RxNorm**, **SNOMED**, and **ICD10CM** in every
+environment that ingests or serves clinical records. LOINC and RxNorm alone
+are insufficient: SNOMED backs standard condition/procedure concepts and
+ICD10CM backs EHR diagnosis codes before they map to SNOMED.
+
+`load_athena_vocabularies` now verifies those four vocabularies after every
+non-dry-run load and fails before publishing a vocabulary release if one is
+missing. This makes a partial Athena bundle or an incomplete load visible
+immediately rather than allowing clinical lookups to silently return `null`.
+
+To repair an environment with a partial vocabulary load, obtain an Athena
+bundle that contains the missing vocabularies and rerun the normal upsert load:
+
+```bash
+python manage.py load_athena_vocabularies --bucket <athena-bucket>
+```
+
+Do **not** use `--replace` for this repair. The default path upserts vocabulary
+rows and preserves clinical data; `--replace` truncates `concept` and cascades
+to clinical tables. `--skip-clinical-vocabulary-verification` is reserved for
+intentionally minimal local/test bundles and must not be used for deployed
+clinical environments.
+
 To check what a code means:
 
 ```sql

--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -8,6 +8,7 @@ csv.field_size_limit(sys.maxsize)
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
+from django.db.models import Count
 
 import logging
 
@@ -29,6 +30,11 @@ VOCAB_SCOPE = frozenset({
     # export, so it loads once a CVX-inclusive bundle is fetched.
     'SNOMED', 'ICD10CM', 'CVX',
 })
+# These vocabularies underpin the clinical concepts PROMOP presents and maps.
+# Do not include CVX here: it is deliberately absent from the current Athena
+# bundle, even though the importer supports it when a CVX-inclusive bundle is
+# used.
+REQUIRED_CLINICAL_VOCABULARIES = frozenset({'LOINC', 'RxNorm', 'SNOMED', 'ICD10CM'})
 RXNORM_CLASS_SCOPE = frozenset({'Ingredient', 'Clinical Drug', 'Branded Drug', 'Clinical Drug Comp'})
 # A --replace reload deletes the entire vocabulary before applying this filter.
 # Keep every LOINC domain already required by our deployed vocabulary; the
@@ -138,12 +144,15 @@ class Command(BaseCommand):
                             help='Clear vocabulary rows before loading')
         parser.add_argument('--dry-run', action='store_true', dest='dry_run',
                             help='Count rows without writing to DB')
+        parser.add_argument('--skip-clinical-vocabulary-verification', action='store_true',
+                            help='Do not verify that required clinical vocabularies loaded')
 
     def handle(self, *args, **options):
         base = options['path']
         bucket_name = options['bucket']
         replace = options['replace']
         dry_run = options['dry_run']
+        skip_clinical_vocabulary_verification = options['skip_clinical_vocabulary_verification']
 
         if not base and not bucket_name:
             raise CommandError('Provide either --path or --bucket')
@@ -188,6 +197,8 @@ class Command(BaseCommand):
         if not dry_run:
             self._seed_concept_zero()
             self._sync_cdm_source_metadata()
+            if not skip_clinical_vocabulary_verification:
+                self._verify_required_clinical_vocabularies()
             self._record_version_history(replace)
             self._publish_release(counts)
         elapsed = time.monotonic() - t0
@@ -212,6 +223,28 @@ class Command(BaseCommand):
     def _log(self, msg):
         self.stdout.write(msg)
         self.stdout.flush()
+
+    def _verify_required_clinical_vocabularies(self):
+        """Fail the load when a partial Athena bundle omits core clinical vocabularies."""
+        counts = dict(
+            Concept.objects.filter(vocabulary_id__in=REQUIRED_CLINICAL_VOCABULARIES)
+            .values('vocabulary_id')
+            .annotate(total=Count('concept_id'))
+            .values_list('vocabulary_id', 'total')
+        )
+        missing = sorted(REQUIRED_CLINICAL_VOCABULARIES - counts.keys())
+        if missing:
+            raise CommandError(
+                'Required clinical vocabularies are missing after the load: '
+                f"{', '.join(missing)}. This database cannot reliably map clinical "
+                'conditions, diagnoses, medications, and labs. Fetch an Athena bundle '
+                'that includes the missing vocabularies and rerun this command without '
+                '--replace; --replace truncates clinical data.'
+            )
+        self._log(
+            '  verified required clinical vocabularies: ' +
+            ', '.join(f'{vid} ({counts[vid]:,})' for vid in sorted(counts))
+        )
 
     def _open(self, filename):
         if self._gcs_bucket:

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -4617,6 +4617,14 @@ class VocabularyRelationshipModelTest(TestCase):
 class AthenaVocabularyLoadTest(TestCase):
     """Test load_athena_vocabularies management command with minimal fixture TSV files."""
 
+    def _load_minimal_athena(self, directory, **options):
+        """Load the deliberately partial fixture without deployment verification."""
+        from django.core.management import call_command
+        call_command(
+            'load_athena_vocabularies', path=directory,
+            skip_clinical_vocabulary_verification=True, **options,
+        )
+
     def _write_tsv(self, directory, filename, headers, rows):
         path = os.path.join(directory, filename)
         with open(path, 'w', newline='') as f:
@@ -4683,19 +4691,17 @@ class AthenaVocabularyLoadTest(TestCase):
 
     def test_load_creates_relationship_rows(self):
         from omop_core.models import Relationship
-        from django.core.management import call_command
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_minimal_athena(tmpdir)
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
         self.assertTrue(Relationship.objects.filter(relationship_id='Maps to').exists())
         self.assertTrue(Relationship.objects.filter(relationship_id='Is a').exists())
 
     def test_load_filters_concepts_to_scope(self):
         from omop_core.models import Concept
-        from django.core.management import call_command
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_minimal_athena(tmpdir)
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
         self.assertTrue(Concept.objects.filter(concept_id=5000001).exists())  # HemOnc
         self.assertTrue(Concept.objects.filter(concept_id=5000003).exists())  # RxNorm Ingredient
         self.assertTrue(Concept.objects.filter(concept_id=5000004).exists())  # RxNorm Branded
@@ -4703,10 +4709,9 @@ class AthenaVocabularyLoadTest(TestCase):
 
     def test_load_filters_concept_relationships(self):
         from omop_core.models import ConceptRelationship
-        from django.core.management import call_command
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_minimal_athena(tmpdir)
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
         # Edge between two in-scope concepts should be loaded
         self.assertTrue(ConceptRelationship.objects.filter(
             concept_1_id=5000003, concept_2_id=5000002
@@ -4718,10 +4723,9 @@ class AthenaVocabularyLoadTest(TestCase):
 
     def test_load_concept_ancestors_hemonc_only(self):
         from omop_core.models import ConceptAncestor
-        from django.core.management import call_command
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_minimal_athena(tmpdir)
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
         self.assertTrue(ConceptAncestor.objects.filter(
             ancestor_concept_id=5000001, descendant_concept_id=5000002
         ).exists())
@@ -4732,23 +4736,21 @@ class AthenaVocabularyLoadTest(TestCase):
 
     def test_idempotent_reload(self):
         from omop_core.models import Concept
-        from django.core.management import call_command
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_minimal_athena(tmpdir)
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
             count_after_first = Concept.objects.filter(vocabulary_id='HemOnc').count()
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
             count_after_second = Concept.objects.filter(vocabulary_id='HemOnc').count()
         self.assertEqual(count_after_first, count_after_second)
 
     def test_dry_run_writes_nothing(self):
         from omop_core.models import Concept, Relationship
-        from django.core.management import call_command
         before_concepts = Concept.objects.count()
         before_rels = Relationship.objects.count()
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_minimal_athena(tmpdir)
-            call_command('load_athena_vocabularies', path=tmpdir, dry_run=True)
+            self._load_minimal_athena(tmpdir, dry_run=True)
         self.assertEqual(Concept.objects.count(), before_concepts)
         self.assertEqual(Relationship.objects.count(), before_rels)
 
@@ -4760,14 +4762,13 @@ class AthenaVocabularyLoadTest(TestCase):
         loads accumulate rows rather than overwriting.)
         """
         from omop_core.models import VocabularyVersionHistory
-        from django.core.management import call_command
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_minimal_athena(tmpdir)
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
             after_first = VocabularyVersionHistory.objects.filter(
                 action=VocabularyVersionHistory.ACTION_LOADED).count()
             self.assertGreater(after_first, 0)
-            call_command('load_athena_vocabularies', path=tmpdir)
+            self._load_minimal_athena(tmpdir)
             after_second = VocabularyVersionHistory.objects.filter(
                 action=VocabularyVersionHistory.ACTION_LOADED).count()
         # Second load appends more history rows rather than replacing the trail.

--- a/tests/test_load_athena_vocabularies.py
+++ b/tests/test_load_athena_vocabularies.py
@@ -1,0 +1,33 @@
+from io import StringIO
+
+import pytest
+from django.core.management import CommandError
+
+from omop_core.management.commands.load_athena_vocabularies import (
+    Command,
+    REQUIRED_CLINICAL_VOCABULARIES,
+)
+from tests.factories import ConceptFactory, VocabularyFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_required_clinical_vocabulary_verification_reports_loaded_counts():
+    for vocabulary_id in REQUIRED_CLINICAL_VOCABULARIES:
+        ConceptFactory(vocabulary=VocabularyFactory(vocabulary_id=vocabulary_id))
+
+    output = StringIO()
+    Command(stdout=output)._verify_required_clinical_vocabularies()
+
+    text = output.getvalue()
+    assert 'verified required clinical vocabularies' in text
+    for vocabulary_id in REQUIRED_CLINICAL_VOCABULARIES:
+        assert vocabulary_id in text
+
+
+def test_required_clinical_vocabulary_verification_fails_for_partial_load():
+    ConceptFactory(vocabulary=VocabularyFactory(vocabulary_id='LOINC'))
+
+    with pytest.raises(CommandError, match='ICD10CM.*RxNorm.*SNOMED'):
+        Command(stdout=StringIO())._verify_required_clinical_vocabularies()


### PR DESCRIPTION
## Summary\n- fail non-dry-run Athena loads that omit LOINC, RxNorm, SNOMED, or ICD10CM\n- preserve a documented escape hatch only for intentionally minimal local/test bundles\n- document safe non-destructive recovery for partial staging loads and correct stale loader flags\n\n## Verification\n- ..                                                                       [100%]
=============================== warnings summary ===============================
omop_core/models.py:112
  /Users/adamblum/promop/.worktrees/issue-457-clinical-vocabularies/omop_core/models.py:112: RemovedInDjango60Warning: CheckConstraint.check is deprecated in favor of `.condition`.
    models.CheckConstraint(

omop_core/models.py:119
  /Users/adamblum/promop/.worktrees/issue-457-clinical-vocabularies/omop_core/models.py:119: RemovedInDjango60Warning: CheckConstraint.check is deprecated in favor of `.condition`.
    models.CheckConstraint(

omop_core/models.py:381
  /Users/adamblum/promop/.worktrees/issue-457-clinical-vocabularies/omop_core/models.py:381: RemovedInDjango60Warning: CheckConstraint.check is deprecated in favor of `.condition`.
    models.CheckConstraint(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2 passed, 3 warnings in 0.37s\n- \n- \n\nCloses #457