### PR TITLE
fix: filter sentinel from episode concept_name_map (#480)

### DIFF
--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -1093,16 +1093,22 @@ def _get_treatment_data_from_episodes(person, data, episodes, drug_exposures):
 
     # ── Bulk-fetch Concept names in one query ──────────────────────────────
     # Concept rows already loaded via select_related are re-used directly.
+    # Filter the sentinel so concept 0 / 'No matching concept' never reaches
+    # therapy labels (#480, follow-up to #458).
     concept_name_map: dict = {
-        ep.episode_source_concept_id: ep.episode_source_concept.concept_name
+        ep.episode_source_concept_id: name
         for ep in episodes
         if ep.episode_source_concept_id and ep.episode_source_concept
+        for name in [_usable_concept_name(ep.episode_source_concept)]
+        if name
     }
     to_fetch = needed_concept_ids - set(concept_name_map)
     if to_fetch:
         concept_name_map.update(
-            (c.concept_id, c.concept_name)
+            (c.concept_id, name)
             for c in Concept.objects.filter(concept_id__in=to_fetch).only('concept_id', 'concept_name')
+            for name in [_usable_concept_name(c)]
+            if name
         )
 
     # ── Second pass: populate data dict ───────────────────────────────────

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -4579,6 +4579,42 @@ class SentinelConceptNameFilterTest(_OmopBase):
         pi = refresh_patient_record(self.person)
         self.assertNotIn('No matching concept', pi.disease or '')
 
+    def test_episode_therapy_label_skips_sentinel(self):
+        """Episode whose source concept is the sentinel must not leak into
+        first_line_therapy_display.  The fallback chain should produce a label
+        from drug_source_value instead.  See #480."""
+        from omop_oncology.models import Episode, EpisodeEvent
+
+        # episode_concept 32531 = 'Treatment Regimen' — use type_concept as stand-in
+        ep = Episode.objects.create(
+            episode_id=94584,
+            person=self.person,
+            episode_concept=self.type_concept,
+            episode_object_concept=self.type_concept,
+            episode_type_concept=self.type_concept,
+            episode_start_date=date(2023, 1, 1),
+            episode_number=1,
+            episode_source_value='VRd',
+            episode_source_concept=self.sentinel_concept,
+        )
+        de = DrugExposure.objects.create(
+            drug_exposure_id=94584,
+            person=self.person,
+            drug_concept=self.drug_concept,
+            drug_source_value='Doxorubicin',
+            drug_exposure_start_date=date(2023, 1, 1),
+            drug_type_concept=self.type_concept,
+        )
+        # 1147094 = DrugExposure.drug_exposure_id field concept — use type_concept
+        EpisodeEvent.objects.create(
+            episode_id=ep.episode_id,
+            event_id=de.drug_exposure_id,
+            episode_event_field_concept=self.type_concept,
+        )
+        pi = refresh_patient_record(self.person)
+        label = pi.first_line_therapy or ''
+        self.assertNotIn('No matching concept', label)
+
     def test_usable_concept_name_helper(self):
         """Unit test for _usable_concept_name."""
         from omop_core.services.patient_record_service import _usable_concept_name


### PR DESCRIPTION
## Summary
- Applied _usable_concept_name() filter when building concept_name_map in _get_treatment_data_from_episodes()
- If an episode source_concept is concept 0, the sentinel is excluded, falling through to the drug name / source value chain
- Added test verifying the episode path skips the sentinel

Closes #480

## Test plan
- [x] All 1,392 backend tests pass
- [x] New test test_episode_therapy_label_skips_sentinel verifies sentinel is filtered

Generated with Claude Code