### PR TITLE
fix: map direct bilirubin to LOINC

### DIFF
--- a/omop_core/services/mappings.py
+++ b/omop_core/services/mappings.py
@@ -30,6 +30,7 @@ LAB_FIELD_TO_LOINC = {
     'phosphorus':                     ('2777-1',   'mg/dL',           'Phosphate [Mass/volume] in Serum or Plasma'),
     # Liver function
     'bilirubin_total_mg_dl':          ('1975-2',   'mg/dL',           'Bilirubin.total [Mass/volume] in Serum or Plasma'),
+    'serum_bilirubin_level_direct':  ('1968-7',   'mg/dL',           'Bilirubin.direct [Mass/volume] in Serum or Plasma'),
     'alt_u_l':                        ('1742-6',   'U/L',             'Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma'),
     'ast_u_l':                        ('1920-8',   'U/L',             'Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma'),
     'alkaline_phosphatase_u_l':       ('6768-6',   'U/L',             'Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma'),

--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -101,7 +101,7 @@ _OMOP_DERIVED_FIELDS = [
     'serum_calcium_mg_dl', 'serum_creatinine_mg_dl', 'creatinine_clearance_ml_min',
     'egfr_ml_min_173m2', 'bun_mg_dl', 'sodium_meq_l', 'potassium_meq_l', 'magnesium_mg_dl',
     # LFT / cardiac (LOINC-derived)
-    'bilirubin_total_mg_dl', 'alt_u_l', 'ast_u_l', 'alkaline_phosphatase_u_l',
+    'bilirubin_total_mg_dl', 'serum_bilirubin_level_direct', 'alt_u_l', 'ast_u_l', 'alkaline_phosphatase_u_l',
     'albumin_g_dl', 'total_protein', 'troponin_ng_ml', 'bnp_pg_ml',
     'glucose_mg_dl', 'hba1c_percent', 'ldh_u_l',
     # Other markers (LOINC-derived)
@@ -199,6 +199,7 @@ _LOINC_LAB_FIELDS = {
     '2339-0':  ('glucose_mg_dl',                  int),    # mCODE: Glucose in Blood
     # LFT / cardiac
     '1975-2':  ('bilirubin_total_mg_dl',          float),
+    '1968-7':  ('serum_bilirubin_level_direct',  float),
     '1742-6':  ('alt_u_l',                        int),
     '1920-8':  ('ast_u_l',                        int),
     '6768-6':  ('alkaline_phosphatase_u_l',       int),
@@ -251,6 +252,8 @@ _SOURCE_VALUE_LAB_FIELDS = {
     'Magnesium':                                  'magnesium_mg_dl',
     'Bilirubin.total [Mass/volume] in Serum or Plasma': 'bilirubin_total_mg_dl',
     'Total Bilirubin':                            'bilirubin_total_mg_dl',
+    'Bilirubin.direct [Mass/volume] in Serum or Plasma': 'serum_bilirubin_level_direct',
+    'Direct Bilirubin':                           'serum_bilirubin_level_direct',
     'Alanine aminotransferase [Enzymatic activity/volum': 'alt_u_l',
     'ALT':                                        'alt_u_l',
     'Aspartate aminotransferase [Enzymatic activity/vol': 'ast_u_l',

--- a/tests/test_direct_bilirubin_mapping.py
+++ b/tests/test_direct_bilirubin_mapping.py
@@ -1,0 +1,59 @@
+from datetime import date
+
+import pytest
+
+from omop_core.models import Measurement
+from omop_core.services.mappings import LAB_FIELD_TO_LOINC
+from omop_core.services.omop_write_service import sync_to_omop
+from omop_core.services.patient_record_service import refresh_patient_record
+from tests.factories import (
+    ConceptClassFactory,
+    ConceptFactory,
+    DomainFactory,
+    PatientRecordFactory,
+    PersonFactory,
+    VocabularyFactory,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_direct_bilirubin_round_trips_through_measurement():
+    loinc = VocabularyFactory(vocabulary_id='LOINC')
+    domain = DomainFactory(domain_id='Measurement')
+    concept_class = ConceptClassFactory(concept_class_id='Lab Test')
+    ConceptFactory(
+        concept_id=3_000_963,
+        concept_name='Laboratory test result',
+        concept_code='generic-lab',
+        vocabulary=loinc,
+        domain=domain,
+        concept_class=concept_class,
+    )
+    ConceptFactory(
+        concept_id=1_968_007,
+        concept_name='Bilirubin.direct [Mass/volume] in Serum or Plasma',
+        concept_code='1968-7',
+        vocabulary=loinc,
+        domain=domain,
+        concept_class=concept_class,
+    )
+    person = PersonFactory()
+    record = PatientRecordFactory(person=person, serum_bilirubin_level_direct=0.4)
+
+    sync_to_omop(record, {'serum_bilirubin_level_direct'}, today=date(2026, 8, 14))
+
+    measurement = Measurement.objects.get(person=person, measurement_source_value='1968-7')
+    assert float(measurement.value_as_number) == 0.4
+    assert measurement.unit_source_value == 'mg/dL'
+
+    refreshed = refresh_patient_record(person)
+    assert float(refreshed.serum_bilirubin_level_direct) == 0.4
+    assert 'serum_bilirubin_level_direct' not in refreshed.user_edited_fields
+
+
+def test_anc_uses_the_standard_absolute_neutrophil_count_loinc():
+    assert LAB_FIELD_TO_LOINC['anc_thousand_per_ul'] == (
+        '751-8', '10*3/uL', 'Neutrophils [#/volume] in Blood',
+    )


### PR DESCRIPTION
Maps PatientRecord serum_bilirubin_level_direct to LOINC 1968-7, derives it from both LOINC and source-value paths, and marks it OMOP-derived. The existing ANC mapping is verified as LOINC 751-8 with unit 10*3/uL. Focused isolated-database regression suite: 2 passed. Closes #472.