### PR TITLE
fix: return field-level errors from org patient signup (#351)

### DIFF
--- a/frontend/src/components/Auth/OrgSignup.test.tsx
+++ b/frontend/src/components/Auth/OrgSignup.test.tsx
@@ -146,6 +146,39 @@ describe("OrgSignup", () => {
     });
   });
 
+  it("handles field-level errors dict from backend", async () => {
+    mockGet.mockResolvedValue({
+      data: { name: "Acme Clinic", slug: "acme", allows_patient_signup: true },
+    });
+    mockPost.mockRejectedValue({
+      response: {
+        data: {
+          errors: {
+            email: ["Enter a valid email address."],
+            password: ["This password is too short.", "This password is too common."],
+          },
+        },
+        status: 400,
+      },
+    });
+    renderOrgSignup();
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Clinic")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "test@test.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "validpassword1" } });
+    fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "validpassword1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Enter a valid email address. This password is too short. This password is too common.")
+      ).toBeInTheDocument();
+    });
+  });
+
   it("shows name fields as optional", async () => {
     mockGet.mockResolvedValue({
       data: { name: "Acme Clinic", slug: "acme", allows_patient_signup: true },

--- a/frontend/src/components/Auth/OrgSignup.tsx
+++ b/frontend/src/components/Auth/OrgSignup.tsx
@@ -62,9 +62,16 @@ export default function OrgSignup() {
     } catch (err: unknown) {
       let msg = "Signup failed. Please try again.";
       if (err && typeof err === "object" && "response" in err) {
-        const resp = (err as { response?: { data?: { error?: string }; status?: number } }).response;
-        const rawError = resp?.data?.error;
-        if (rawError) msg = Array.isArray(rawError) ? rawError.join(' ') : rawError;
+        const resp = (err as { response?: { data?: { error?: string | string[]; errors?: Record<string, string[]> }; status?: number } }).response;
+        // Prefer field-level errors dict — flatten into a single message
+        const fieldErrors = resp?.data?.errors;
+        if (fieldErrors && typeof fieldErrors === "object") {
+          const messages = Object.values(fieldErrors).flat();
+          if (messages.length > 0) msg = messages.join(" ");
+        } else {
+          const rawError = resp?.data?.error;
+          if (rawError) msg = Array.isArray(rawError) ? rawError.join(" ") : rawError;
+        }
       }
       setError(msg);
     } finally {

--- a/patient_portal/api/org_views.py
+++ b/patient_portal/api/org_views.py
@@ -772,74 +772,102 @@ class OrgPatientSignupView(APIView):
         given_name = (request.data.get('given_name') or '').strip()
         family_name = (request.data.get('family_name') or '').strip()
 
-        if not email:
-            return Response({'error': 'email is required.'}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            from django.core.validators import validate_email as _validate_email
-            _validate_email(email)
-        except ValidationError:
-            return Response({'error': 'Invalid email address.'}, status=status.HTTP_400_BAD_REQUEST)
-        if not password:
-            return Response({'error': 'password is required.'}, status=status.HTTP_400_BAD_REQUEST)
+        # Collect field-level validation errors so the frontend can display
+        # them next to the relevant input rather than as a single blob.
+        field_errors: dict[str, list[str]] = {}
 
-        from patient_portal.services import password_validation_errors, set_new_password
-        pw_errors = password_validation_errors(password, email=email)
-        if pw_errors:
-            return Response({'error': pw_errors}, status=status.HTTP_400_BAD_REQUEST)
+        if not email:
+            field_errors.setdefault('email', []).append('Email is required.')
+        else:
+            try:
+                from django.core.validators import validate_email as _validate_email
+                _validate_email(email)
+            except ValidationError:
+                field_errors.setdefault('email', []).append(
+                    'Enter a valid email address.'
+                )
+
+        if not password:
+            field_errors.setdefault('password', []).append('Password is required.')
+        else:
+            from patient_portal.services import password_validation_errors
+            pw_errors = password_validation_errors(password, email=email)
+            if pw_errors:
+                field_errors.setdefault('password', []).extend(pw_errors)
+
+        if field_errors:
+            return Response(
+                {'errors': field_errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        from patient_portal.services import set_new_password
 
         # Check for existing account with this email
         existing = _find_identity_by_email(email)
         if existing and existing.has_usable_password():
             return Response(
-                {'error': 'An account with this email already exists. Please log in instead.'},
+                {
+                    'error': 'An account with this email already exists. Please log in instead.',
+                    'errors': {
+                        'email': ['An account with this email already exists. Please log in instead.'],
+                    },
+                },
                 status=status.HTTP_409_CONFLICT,
             )
 
-        with transaction.atomic():
-            if existing:
-                # Placeholder identity from a prior invitation — set its password
-                identity = existing
-                set_new_password(identity, password)
-                if given_name:
-                    identity.name = f"{given_name} {family_name}".strip()
-                    identity.save(update_fields=['name'])
-            else:
-                identity = Identity.objects.create_user(
-                    email=email,
-                    password=password,
-                    name=f"{given_name} {family_name}".strip(),
-                )
+        try:
+            with transaction.atomic():
+                if existing:
+                    # Placeholder identity from a prior invitation — set its password
+                    identity = existing
+                    set_new_password(identity, password)
+                    if given_name:
+                        identity.name = f"{given_name} {family_name}".strip()
+                        identity.save(update_fields=['name'])
+                else:
+                    identity = Identity.objects.create_user(
+                        email=email,
+                        password=password,
+                        name=f"{given_name} {family_name}".strip(),
+                    )
 
-            # Reuse existing PatientUser link if present (e.g. from a prior invitation
-            # or signup at another org)
-            existing_pu = PatientUser.objects.filter(identity=identity).first()
-            if existing_pu:
-                person = existing_pu.person
-                # Ensure a PatientRecord exists for this person in the new org
-                PatientRecord.objects.get_or_create(
-                    person=person,
-                    organization=org,
-                    defaults={'email': email},
-                )
-            else:
-                new_id = next_pk(Person, 'person_id')
-                person = Person.objects.create(
-                    person_id=new_id,
-                    given_name=given_name or None,
-                    family_name=family_name or None,
-                    year_of_birth=1900,
-                    gender_source_value='unknown',
-                    race_source_value='unknown',
-                    ethnicity_source_value='unknown',
-                )
-                PatientRecord.objects.create(person=person, email=email, organization=org)
-                PatientUser.objects.create(identity=identity, person=person)
+                # Reuse existing PatientUser link if present (e.g. from a prior invitation
+                # or signup at another org)
+                existing_pu = PatientUser.objects.filter(identity=identity).first()
+                if existing_pu:
+                    person = existing_pu.person
+                    # Ensure a PatientRecord exists for this person in the new org
+                    PatientRecord.objects.get_or_create(
+                        person=person,
+                        organization=org,
+                        defaults={'email': email},
+                    )
+                else:
+                    new_id = next_pk(Person, 'person_id')
+                    person = Person.objects.create(
+                        person_id=new_id,
+                        given_name=given_name or None,
+                        family_name=family_name or None,
+                        year_of_birth=1900,
+                        gender_source_value='unknown',
+                        race_source_value='unknown',
+                        ethnicity_source_value='unknown',
+                    )
+                    PatientRecord.objects.create(person=person, email=email, organization=org)
+                    PatientUser.objects.create(identity=identity, person=person)
 
-            # Grant patient access to this org
-            GroupAccess.objects.get_or_create(
-                identity=identity,
-                org=org,
-                defaults={'role': 'patient'},
+                # Grant patient access to this org
+                GroupAccess.objects.get_or_create(
+                    identity=identity,
+                    org=org,
+                    defaults={'role': 'patient'},
+                )
+        except Exception:
+            logger.exception('Unexpected error during patient signup for %s', email)
+            return Response(
+                {'error': 'Could not create your account. Please try again or contact support.'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
         # Auto-login via session

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -14910,19 +14910,56 @@ class OrgPatientSignupTest(TestCase):
         })
         self.assertEqual(resp.status_code, 409)
 
-    def test_signup_weak_password_returns_400(self):
+    def test_signup_weak_password_returns_400_with_field_errors(self):
         resp = APIClient().post('/api/v1/orgs/signup-org/patient-signup/', {
             'email': 'weak@test.com',
             'password': '123',
         })
         self.assertEqual(resp.status_code, 400)
+        self.assertIn('errors', resp.data)
+        self.assertIn('password', resp.data['errors'])
+        # Django's validators produce specific messages for short/common/numeric passwords
+        pw_errors = resp.data['errors']['password']
+        self.assertTrue(len(pw_errors) > 0)
 
-    def test_signup_missing_email_returns_400(self):
+    def test_signup_missing_email_returns_400_with_field_errors(self):
         resp = APIClient().post('/api/v1/orgs/signup-org/patient-signup/', {
             'email': '',
             'password': 'Str0ng!Pass99',
         })
         self.assertEqual(resp.status_code, 400)
+        self.assertIn('errors', resp.data)
+        self.assertIn('email', resp.data['errors'])
+
+    def test_signup_missing_password_returns_400_with_field_errors(self):
+        resp = APIClient().post('/api/v1/orgs/signup-org/patient-signup/', {
+            'email': 'nopass@test.com',
+            'password': '',
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('errors', resp.data)
+        self.assertIn('password', resp.data['errors'])
+
+    def test_signup_invalid_email_returns_400_with_field_errors(self):
+        resp = APIClient().post('/api/v1/orgs/signup-org/patient-signup/', {
+            'email': 'not-an-email',
+            'password': 'Str0ng!Pass99',
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('errors', resp.data)
+        self.assertIn('email', resp.data['errors'])
+        self.assertIn('Enter a valid email address.', resp.data['errors']['email'])
+
+    def test_signup_missing_both_fields_returns_all_errors(self):
+        """Both email and password errors are returned together."""
+        resp = APIClient().post('/api/v1/orgs/signup-org/patient-signup/', {
+            'email': '',
+            'password': '',
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('errors', resp.data)
+        self.assertIn('email', resp.data['errors'])
+        self.assertIn('password', resp.data['errors'])
 
     def test_signup_cross_org_rejects_existing_account(self):
         """A patient who already signed up at Org A gets 409 when trying to
@@ -14945,6 +14982,9 @@ class OrgPatientSignupTest(TestCase):
         })
         self.assertEqual(resp.status_code, 409)
         self.assertIn('already exists', resp.data['error'])
+        # Also includes field-level errors for frontend display
+        self.assertIn('errors', resp.data)
+        self.assertIn('email', resp.data['errors'])
 
 
 @override_settings(


### PR DESCRIPTION
## Summary

Fixes #351. The org patient signup endpoint previously returned errors in a way that caused the frontend to fall back to the generic "Signup failed. Please try again." message. This PR:

- **Backend**: Returns a structured errors dict with field-level validation messages instead of a single error string. Collects all validation errors (email + password) before returning so users see everything wrong at once. Wraps the transaction block in a try/except to catch unexpected exceptions and return a meaningful message instead of a bare 500.
- **Frontend**: Parses both the new errors dict format and the legacy error string/array format, flattening field-level messages into a single display string.
- **Tests**: Adds 4 new backend tests (invalid email, missing password, missing both fields, field-level error structure on 409) and 1 new frontend test (field-level errors dict rendering). Updates 2 existing backend tests to verify the new response shape.

## Test plan

- [x] Backend: OrgPatientSignupTest -- 9 tests pass
- [x] Backend: full Django suite -- 1401 tests pass
- [x] Backend: pytest suite -- 181 pass, 1 pre-existing failure (unrelated #450)
- [x] Frontend: OrgSignup.test.tsx -- 10 tests pass
- [x] Frontend: full suite -- 184 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
