### PR TITLE
fix: recognize service tokens in FHIR sync

### DIFF
--- a/patient_portal/api/fhir/sync.py
+++ b/patient_portal/api/fhir/sync.py
@@ -37,7 +37,7 @@ from omop_core.models import (
 )
 from omop_core.services.pk import next_pk_batch
 from omop_core.signals import suppress_patient_record_refresh
-from patient_portal.api.permissions import ScopedTokenPermission, get_request_org
+from patient_portal.api.permissions import ScopedTokenPermission, get_request_org, is_service_token
 # Reuse the proven HK-Labs concept-fallback machinery.
 from patient_portal.api.lab_results.sync import HK_LABS_VOCAB_ID, _ensure_hk_deps
 

--- a/patient_portal/api/fhir/tests.py
+++ b/patient_portal/api/fhir/tests.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIClient
 
 from patient_portal.models import Identity, PatientUser
 from omop_core.models import (
-    ConditionOccurrence, DrugExposure, Measurement, ProvenanceRecord,
+    ConditionOccurrence, DrugExposure, Measurement, Person, ProvenanceRecord,
 )
 
 # OMOP tables use manually-assigned integer PKs fed by Postgres sequences that
@@ -120,6 +120,28 @@ class FhirSyncTests(TestCase):
         anon = APIClient()
         resp = anon.post('/api/fhir/sync/', {'bundle': SAMPLE_BUNDLE}, format='json')
         self.assertIn(resp.status_code, (401, 403))
+
+    def test_service_token_syncs_explicit_person_without_actor_identity(self):
+        """Trusted service callers may sync an explicit person without actor fields."""
+        from omop_core.services.pk import next_pk_batch
+
+        person = Person.objects.create(
+            person_id=next_pk_batch(Person, 'person_id', 1)[0],
+        )
+        service_user = Identity.objects.create(issuer='urn:service', sub='fhir-sync')
+        service_user.set_unusable_password()
+        service_user.save(update_fields=['password'])
+        client = APIClient()
+        client.force_authenticate(user=service_user, token='service-token')
+
+        resp = client.post('/api/fhir/sync/', {
+            'person_id': person.person_id,
+            'bundle': SAMPLE_BUNDLE,
+        }, format='json')
+
+        self.assertEqual(resp.status_code, 201, resp.content)
+        self.assertEqual(resp.json()['person_id'], person.person_id)
+        self.assertEqual(Measurement.objects.filter(person=person).count(), 1)
 
     # ---- B0 connector: patient self-service ingest ---------------------- #
 


### PR DESCRIPTION
## Summary

Fixes the trusted service-to-service FHIR sync path by importing the existing
`is_service_token` helper in `patient_portal.api.fhir.sync`.

When a trusted service submits a FHIR Bundle for an explicit `person_id` without
an end-user actor identity, `FhirSyncView._resolve_person()` calls
`is_service_token(request)`. The helper exists in
`patient_portal.api.permissions` but was not imported, causing a `NameError`
before any FHIR-to-OMOP mapping occurs.

Was found when implementing the LUMINA implementation.

## Change

- Import `is_service_token` alongside the existing permission helpers.

## Impact

- Restores PRomop’s intended authenticated backend-service FHIR sync flow.
- Does not change API contracts, mappings, OMOP models, migrations, or clinical logic.

## Validation

- Confirmed the current upstream `dev` branch calls the helper without importing it.
- Verified in a local synthetic Archive → PRomop FHIR sync that the request
  successfully creates the expected OMOP measurement after this import is present.