### PR TITLE
ci: run paper draft only on branch pushes

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -3,10 +3,6 @@ on:
     branches:
       - main
       - dev
-  pull_request:
-    branches:
-      - main
-      - dev
 
 jobs:
   paper:


### PR DESCRIPTION
## Summary

Stop running the JOSS paper-draft PDF workflow for every pull request. The workflow continues to build and upload the paper artifact on pushes to `dev` and `main`.

## Validation

- `git diff --check`