### PR TITLE
fix: use standard Athena question/answer pattern for smoking status (#451)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -131,6 +131,38 @@ def django_db_setup(django_db_setup, django_db_blocker):
                 'valid_start_date': '1970-01-01', 'valid_end_date': '2099-12-31',
             },
         )
+        # Tobacco smoking status answer concepts — needed by the question/answer
+        # pattern used in enrich_breast_cancer_omop_data (#451).
+        # First ensure the LOINC vocabulary and Meas Value domain exist.
+        Vocabulary.objects.get_or_create(
+            vocabulary_id='LOINC',
+            defaults={'vocabulary_name': 'Logical Observation Identifiers Names and Codes',
+                      'vocabulary_reference': 'https://loinc.org',
+                      'vocabulary_version': '2.77', 'vocabulary_concept_id': 0},
+        )
+        Domain.objects.get_or_create(
+            domain_id='Meas Value',
+            defaults={'domain_name': 'Meas Value', 'domain_concept_id': 0},
+        )
+        ConceptClass.objects.get_or_create(
+            concept_class_id='Answer',
+            defaults={'concept_class_name': 'Answer', 'concept_class_concept_id': 0},
+        )
+        for cid, name, code in [
+            (45879404, 'Never smoker',             'LA18978-9'),
+            (45883458, 'Former smoker',            'LA15920-4'),
+            (45881517, 'Current every day smoker', 'LA18976-3'),
+        ]:
+            Concept.objects.get_or_create(
+                concept_id=cid,
+                defaults={
+                    'concept_name': name, 'domain_id': 'Meas Value',
+                    'vocabulary_id': 'LOINC', 'concept_class_id': 'Answer',
+                    'standard_concept': 'S', 'concept_code': code,
+                    'valid_start_date': '1970-01-01', 'valid_end_date': '2099-12-31',
+                },
+            )
+
         for code, title in [
             ('eligibleAuto', 'eligible for autologous SCT'),
             ('eligibleAllo', 'eligible for allogeneic SCT'),

--- a/omop_core/management/commands/enrich_breast_cancer_omop_data.py
+++ b/omop_core/management/commands/enrich_breast_cancer_omop_data.py
@@ -82,29 +82,25 @@ logger = logging.getLogger(__name__)
 # Lymphoma uses Lugano, myeloma IMWG, CLL iwCLL — and IMWG's VGPR/sCR and
 # iwCLL's CRi/PR-L have no RECIST equivalent, so one four-value set cannot
 # express them. Tracked separately; see the hemonc roadmap's P5.
-# TRADEOFF, deliberate: the three tobacco concepts are non-standard in Athena
-# (4144272 / 4310250 / 4298794 all have standard_concept=NULL) and have no
-# 'Maps to' edge to a Standard concept, so observation_concept_id will hold a
-# non-standard concept. That deviates from OMOP's convention and means these
-# rows are invisible to concept_ancestor rollups — a cohort query walking the
-# hierarchy from a Standard concept will not see them.
-#
-# It is still the right call here. The only "Standard" tobacco rows in the
-# database were this command's own mints, which hardcoded standard_concept='S'
-# and so fabricated a standardness the genuine concept does not have. Using the
-# real non-standard concept is honest; inventing a Standard one is what we are
-# stopping.
-#
-# The conformant alternative is a question/answer pair — observation_concept_id
-# = a tobacco-status question concept, value_as_concept_id = a Standard LOINC
-# answer (LA18978-9 "Never smoker", LA15920-4 "Former smoker",
-# LA18976-3 "Current every day smoker"). That restructures how the observation
-# is written and every reader keyed on these SNOMED codes, so it is tracked
-# separately rather than smuggled in here.
-_TOBACCO_CODES = {
-    ('SNOMED', '266919005'): ('Never smoked tobacco', 0.7),
-    ('SNOMED', '8517006'):   ('Ex-smoker', 0.2),
-    ('SNOMED', '77176002'):  ('Smoker', 0.1),
+# Tobacco smoking status — OMOP question/answer pattern (#451).
+# observation_concept_id = LOINC 72166-2 "Tobacco smoking status" (the question)
+# value_as_concept_id   = one of the three LOINC answer concepts below.
+# The old approach wrote non-standard SNOMED concepts (4144272/4310250/4298794)
+# directly into observation_concept_id; this replaces it with the conformant
+# pattern so rows are visible to concept_ancestor rollups.
+_TOBACCO_QUESTION_CODE = ('LOINC', '72166-2')
+_TOBACCO_ANSWER_CODES = {
+    # (vocabulary_id, concept_code): (display_name, weight)
+    ('LOINC', 'LA18978-9'): ('Never smoker',             0.7),
+    ('LOINC', 'LA15920-4'): ('Former smoker',             0.2),
+    ('LOINC', 'LA18976-3'): ('Current every day smoker',  0.1),
+}
+# Legacy SNOMED codes — kept only so the idempotency guard can detect
+# old-format rows that already exist and avoid duplicating them.
+_OLD_TOBACCO_SNOMED_CODES = {
+    ('SNOMED', '266919005'),
+    ('SNOMED', '8517006'),
+    ('SNOMED', '77176002'),
 }
 _RESPONSE_CODES = {
     ('SNOMED', '182840001'): 'Complete Response',
@@ -491,7 +487,9 @@ class Command(BaseCommand):
         # (--refresh-only), since these concepts are then never read.
         if person_ids:
             self._write_progress('Checking required concepts exist...')
-            for (vocab, code), (name, _weight) in _TOBACCO_CODES.items():
+            # Tobacco question concept
+            _resolve_concept(*_TOBACCO_QUESTION_CODE, 'Tobacco smoking status')
+            for (vocab, code), (name, _weight) in _TOBACCO_ANSWER_CODES.items():
                 _resolve_concept(vocab, code, name)
             for (vocab, code), name in _RESPONSE_CODES.items():
                 _resolve_concept(vocab, code, name)
@@ -504,7 +502,21 @@ class Command(BaseCommand):
         # Person-invariant, so resolved once here rather than per patient in
         # _create_missing_observations — the same reasoning as the wearable
         # prefetch below.
-        self._tobacco_concept_ids = _concept_ids_for(_TOBACCO_CODES)
+        # Include both old SNOMED codes and the new LOINC question code so
+        # the idempotency guard in _create_missing_observations detects either
+        # old-format or new-format tobacco rows.
+        self._tobacco_question_concept_id = None
+        q_vocab, q_code = _TOBACCO_QUESTION_CODE
+        q_concept = Concept.objects.filter(
+            vocabulary_id=q_vocab, concept_code=q_code
+        ).order_by('concept_id').first()
+        if q_concept:
+            self._tobacco_question_concept_id = q_concept.concept_id
+        self._tobacco_answer_concept_ids = _concept_ids_for(_TOBACCO_ANSWER_CODES)
+        # For idempotency: detect old-format SNOMED rows too
+        self._old_tobacco_concept_ids = _concept_ids_for(
+            _OLD_TOBACCO_SNOMED_CODES
+        )
         self._response_concept_ids = _concept_ids_for(_RESPONSE_CODES)
 
         # Pre-fetch all wearable LOINC concepts in one query. This avoids N+1
@@ -779,20 +791,37 @@ class Command(BaseCommand):
             )
             existing_concept_ids.add(concept.concept_id)
 
-        # Tobacco status — weighted random pick. Guard on the whole category,
-        # not just the randomly-chosen code: a rerun that happens to pick a
-        # *different* tobacco code than a prior run would otherwise pass the
-        # per-concept check in _make() and add a second, contradictory
-        # tobacco-status observation instead of being a no-op.
-        # Resolved once in handle() and passed down: these are person-invariant,
-        # and this method runs per patient. Resolving rather than assuming
-        # concept_id == int(code) is the point — that assumption is what minted
-        # duplicates shadowing the genuine SNOMED concepts (#415).
-        tobacco_concept_ids = self._tobacco_concept_ids
-        if not existing_concept_ids & tobacco_concept_ids:
-            keys, weights = zip(*[(k, w) for k, (_, w) in _TOBACCO_CODES.items()])
-            tobacco_key = random.choices(keys, weights=weights, k=1)[0]
-            _make(tobacco_key, None)
+        # Tobacco status — question/answer pattern (#451).
+        # observation_concept_id = LOINC 72166-2 (the question)
+        # value_as_concept_id   = one of the LOINC answer concepts
+        #
+        # Guard on both old-format (SNOMED codes in observation_concept_id) and
+        # new-format (72166-2 in observation_concept_id) to stay idempotent
+        # across the migration boundary.
+        tobacco_question_cid = self._tobacco_question_concept_id
+        has_tobacco = bool(
+            existing_concept_ids & self._old_tobacco_concept_ids
+            or (tobacco_question_cid and tobacco_question_cid in existing_concept_ids)
+        )
+        if not has_tobacco and tobacco_question_cid is not None:
+            keys, weights = zip(*[(k, w) for k, (_, w) in _TOBACCO_ANSWER_CODES.items()])
+            answer_key = random.choices(keys, weights=weights, k=1)[0]
+            answer_vocab, answer_code = answer_key
+            answer_concept = Concept.objects.filter(
+                vocabulary_id=answer_vocab, concept_code=answer_code
+            ).order_by('concept_id').first()
+            if answer_concept is not None:
+                created += 1
+                if not dry_run:
+                    Observation.objects.create(
+                        observation_id=observation_ids.take(),
+                        person=person,
+                        observation_concept_id=tobacco_question_cid,
+                        observation_date=obs_date,
+                        observation_type_concept_id=ehr_type_concept_id,
+                        value_as_concept=answer_concept,
+                    )
+                    existing_concept_ids.add(tobacco_question_cid)
 
         # Tumor/metastasis staging, consistent with the patient's existing
         # stage. Deterministic (not random), so the per-concept check in

--- a/omop_core/management/commands/seed_omop_concepts.py
+++ b/omop_core/management/commands/seed_omop_concepts.py
@@ -99,6 +99,7 @@ _CONCEPT_CLASSES = [
     dict(concept_class_id='Undefined',           concept_class_name='Undefined',            concept_class_concept_id=0),
     dict(concept_class_id='Clinical Finding',    concept_class_name='Clinical Finding',     concept_class_concept_id=0),
     dict(concept_class_id='Context-dependent',   concept_class_name='Context-dependent',    concept_class_concept_id=0),
+    dict(concept_class_id='Answer',              concept_class_name='Answer',               concept_class_concept_id=0),
 ]
 
 
@@ -289,6 +290,12 @@ _CONCEPTS = [
     # ------------------------------------------------------------------
     _c(36305384, 'ECOG Performance Status score', 'Measurement',  'LOINC', 'Clinical Observation', 'S', '89247-1'),
     _c(43054909, 'Tobacco smoking status',         'Observation',  'LOINC', 'Clinical Observation', 'S', '72166-2'),
+
+    # Standard LOINC answer concepts for tobacco smoking status (question/answer pattern).
+    # observation_concept_id = 72166-2 (question), value_as_concept_id = answer below.
+    _c(45879404, 'Never smoker',              'Meas Value', 'LOINC', 'Answer', 'S', 'LA18978-9'),
+    _c(45883458, 'Former smoker',             'Meas Value', 'LOINC', 'Answer', 'S', 'LA15920-4'),
+    _c(45881517, 'Current every day smoker',  'Meas Value', 'LOINC', 'Answer', 'S', 'LA18976-3'),
 
     # ------------------------------------------------------------------
     # CBC — hemoglobin (missing from original seeder; required for CRAB)

--- a/omop_core/migrations/0147_convert_tobacco_to_question_answer.py
+++ b/omop_core/migrations/0147_convert_tobacco_to_question_answer.py
@@ -1,0 +1,102 @@
+"""
+Data migration: convert smoking status observations from old SNOMED format
+(observation_concept_id = SNOMED code) to OMOP question/answer format
+(observation_concept_id = LOINC 72166-2, value_as_concept_id = LOINC answer).
+
+See issue #451.
+"""
+import logging
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+# Old SNOMED concept_code -> new LOINC answer concept_code
+_SNOMED_TO_LOINC_ANSWER = {
+    '266919005': 'LA18978-9',   # Never smoked tobacco -> Never smoker
+    '8517006':   'LA15920-4',   # Ex-smoker -> Former smoker
+    '77176002':  'LA18976-3',   # Smoker -> Current every day smoker
+}
+
+
+def _convert_tobacco_observations(apps, schema_editor):
+    Concept = apps.get_model('omop_core', 'Concept')
+    Observation = apps.get_model('omop_core', 'Observation')
+
+    # Look up the question concept: LOINC 72166-2
+    question_concept = Concept.objects.filter(
+        vocabulary_id='LOINC', concept_code='72166-2'
+    ).order_by('concept_id').first()
+    if question_concept is None:
+        logger.warning(
+            'LOINC 72166-2 concept not found — skipping tobacco migration. '
+            'Run seed_omop_concepts first.'
+        )
+        return
+
+    # Look up the answer concepts
+    answer_concepts = {}
+    for snomed_code, loinc_answer_code in _SNOMED_TO_LOINC_ANSWER.items():
+        answer = Concept.objects.filter(
+            vocabulary_id='LOINC', concept_code=loinc_answer_code
+        ).order_by('concept_id').first()
+        if answer is None:
+            logger.warning(
+                'LOINC answer concept %s not found — rows with SNOMED %s '
+                'will not be converted. Run seed_omop_concepts first.',
+                loinc_answer_code, snomed_code,
+            )
+        else:
+            answer_concepts[snomed_code] = answer
+
+    if not answer_concepts:
+        logger.warning('No answer concepts found — nothing to migrate.')
+        return
+
+    # Find old-format rows: observation_concept is one of the three SNOMED codes
+    old_rows = Observation.objects.filter(
+        observation_concept__concept_code__in=list(_SNOMED_TO_LOINC_ANSWER.keys()),
+        observation_concept__vocabulary_id='SNOMED',
+    ).select_related('observation_concept')
+
+    updated = []
+    for obs in old_rows:
+        snomed_code = obs.observation_concept.concept_code
+        answer = answer_concepts.get(snomed_code)
+        if answer is None:
+            continue
+        obs.observation_concept_id = question_concept.concept_id
+        obs.value_as_concept_id = answer.concept_id
+        updated.append(obs)
+
+    if updated:
+        Observation.objects.bulk_update(
+            updated,
+            ['observation_concept_id', 'value_as_concept_id'],
+            batch_size=500,
+        )
+        logger.info('Converted %d tobacco observation(s) to question/answer format.', len(updated))
+    else:
+        logger.info('No old-format tobacco observations found to convert.')
+
+
+def _reverse_noop(apps, schema_editor):
+    # The original SNOMED concept_ids cannot be recovered per-row after
+    # remapping (we don't know which answer mapped from which SNOMED code
+    # without storing that). Rolling back leaves rows in question/answer
+    # format. Manual correction is required if reversal is needed.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('omop_core', '0146_patientrecord_patientrecord_lat_lon_both_or_neither_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _convert_tobacco_observations,
+            _reverse_noop,
+        ),
+    ]

--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -1766,21 +1766,48 @@ def _get_behavior_data(person: Person) -> dict:
         .order_by('-measurement_date')
     )
 
-    tobacco_obs = observations.filter(
-        observation_concept__concept_code__in=['266919005', '8517006', '77176002']
+    # New format (question/answer, #451): observation_concept = LOINC 72166-2,
+    # answer in value_as_concept (LA18978-9 / LA15920-4 / LA18976-3).
+    tobacco_qa_obs = (
+        observations
+        .filter(observation_concept__concept_code='72166-2',
+                observation_concept__vocabulary_id='LOINC')
+        .select_related('value_as_concept')
     )
+    _ANSWER_MAP = {
+        'LA18978-9': (True,  'Never smoker'),
+        'LA15920-4': (False, None),           # date appended below
+        'LA18976-3': (False, 'Current smoker'),
+    }
+    for obs in tobacco_qa_obs:
+        if obs.value_as_concept_id is None:
+            continue
+        answer_code = obs.value_as_concept.concept_code
+        if answer_code in _ANSWER_MAP:
+            no_use, details = _ANSWER_MAP[answer_code]
+            data['no_tobacco_use_status'] = no_use
+            if answer_code == 'LA15920-4':
+                data['tobacco_use_details'] = f'Former smoker, quit {obs.observation_date}'
+            else:
+                data['tobacco_use_details'] = details
 
-    for obs in tobacco_obs:
-        code = obs.observation_concept.concept_code
-        if code == '266919005':
-            data['no_tobacco_use_status'] = True
-            data['tobacco_use_details'] = 'Never smoker'
-        elif code == '8517006':
-            data['no_tobacco_use_status'] = False
-            data['tobacco_use_details'] = f'Former smoker, quit {obs.observation_date}'
-        elif code == '77176002':
-            data['no_tobacco_use_status'] = False
-            data['tobacco_use_details'] = 'Current smoker'
+    # Backward compat: old format wrote SNOMED codes directly into
+    # observation_concept_id. Only apply if the new format didn't match.
+    if 'no_tobacco_use_status' not in data:
+        old_tobacco_obs = observations.filter(
+            observation_concept__concept_code__in=['266919005', '8517006', '77176002']
+        )
+        for obs in old_tobacco_obs:
+            code = obs.observation_concept.concept_code
+            if code == '266919005':
+                data['no_tobacco_use_status'] = True
+                data['tobacco_use_details'] = 'Never smoker'
+            elif code == '8517006':
+                data['no_tobacco_use_status'] = False
+                data['tobacco_use_details'] = f'Former smoker, quit {obs.observation_date}'
+            elif code == '77176002':
+                data['no_tobacco_use_status'] = False
+                data['tobacco_use_details'] = 'Current smoker'
 
     for measurement in measurements:
         code = _measurement_code(measurement)

--- a/tests/test_enrich_breast_cancer_omop_data.py
+++ b/tests/test_enrich_breast_cancer_omop_data.py
@@ -66,10 +66,14 @@ def _seed_loinc_concepts_the_command_assumes_exist():
     # per-disease outcome value sets, since only breast cancer uses RECIST
     # (lymphoma uses Lugano, myeloma IMWG, CLL iwCLL).
     from omop_core.management.commands.enrich_breast_cancer_omop_data import (
-        _RESPONSE_CODES, _TOBACCO_CODES,
+        _RESPONSE_CODES, _TOBACCO_QUESTION_CODE, _TOBACCO_ANSWER_CODES,
     )
-    for (vocab, code), (name, _weight) in _TOBACCO_CODES.items():
-        _loinc_concept(code, name, vocabulary_id=vocab, domain_id='Observation')
+    # Tobacco question concept (LOINC 72166-2)
+    q_vocab, q_code = _TOBACCO_QUESTION_CODE
+    _loinc_concept(q_code, 'Tobacco smoking status', vocabulary_id=q_vocab, domain_id='Observation')
+    # Tobacco answer concepts
+    for (vocab, code), (name, _weight) in _TOBACCO_ANSWER_CODES.items():
+        _loinc_concept(code, name, vocabulary_id=vocab, domain_id='Meas Value')
     for (vocab, code), name in _RESPONSE_CODES.items():
         _loinc_concept(code, name, vocabulary_id=vocab, domain_id='Observation')
 
@@ -132,17 +136,24 @@ class TestPerformanceAndStageBackfill:
 
 class TestMissingObservations:
 
-    def test_creates_tobacco_status_observation(self):
+    def test_creates_tobacco_status_observation_question_answer(self):
+        """Tobacco status uses question/answer pattern (#451):
+        observation_concept = LOINC 72166-2, value_as_concept = answer."""
         person = PersonFactory()
         PatientRecordFactory(person=person, stage='II')
 
         call_command('enrich_breast_cancer_omop_data', person_ids=str(person.person_id), confirm=True)
 
-        codes = set(
-            Observation.objects.filter(person=person)
-            .values_list('observation_concept__concept_code', flat=True)
+        tobacco_obs = Observation.objects.filter(
+            person=person,
+            observation_concept__concept_code='72166-2',
+            observation_concept__vocabulary_id='LOINC',
         )
-        assert codes & {'266919005', '8517006', '77176002'}
+        assert tobacco_obs.exists(), 'Expected a tobacco observation with LOINC 72166-2'
+        obs = tobacco_obs.first()
+        assert obs.value_as_concept_id is not None, 'Expected value_as_concept_id to be set'
+        answer_codes = {'LA18978-9', 'LA15920-4', 'LA18976-3'}
+        assert obs.value_as_concept.concept_code in answer_codes
 
     def test_creates_staging_observations_consistent_with_existing_stage(self):
         person = PersonFactory()


### PR DESCRIPTION
## Summary

- Replaces non-standard SNOMED smoking status concepts (4144272/4310250/4298794 in `observation_concept_id`) with the OMOP-conformant question/answer pattern: `observation_concept_id` = LOINC 72166-2 "Tobacco smoking status", `value_as_concept_id` = standard LOINC answer concept (45879404 Never smoker / 45883458 Former smoker / 45881517 Current every day smoker)
- Updates `_get_behavior_data` in `patient_record_service.py` to read the new format first, with backward compatibility for old SNOMED-style rows
- Adds data migration 0147 to convert existing old-format observation rows to the new format in-place
- Seeds the three LOINC answer concepts and the `Answer` concept class in `seed_omop_concepts`

## Test plan

- [x] Django test suite (1398 tests) — all pass on `promop_test_5`
- [x] Pytest suite (182 tests) — all pass
- [x] `test_creates_tobacco_status_observation_question_answer` verifies the new pattern
- [x] Idempotency test confirms re-runs do not duplicate rows
- [x] PatientRecord refresh test confirms `no_tobacco_use_status`/`tobacco_use_details` are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)