### PR TITLE
fix: enforce OMOP local concept_id range (>= 2B) for HK-minted concepts

### DIFF
--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -180,7 +180,10 @@ class Command(BaseCommand):
             self._validate_replace_loinc_scope()
 
         if self._direct:
+            self._hk_concepts = self._save_healthkey_concepts()
             self._clear()
+        else:
+            self._hk_concepts = []
 
         counts = {
             'relationship':         self._load_relationships(dry_run),
@@ -188,12 +191,18 @@ class Command(BaseCommand):
             'domain':               self._load_domains(dry_run),
             'concept_class':        self._load_concept_classes(dry_run),
             'concept':              self._load_concepts(dry_run),
+        }
+        # Restore HealthKey-minted concepts after the Athena concept load
+        # but before relationship/ancestor loads that reference concept IDs.
+        if self._hk_concepts and not dry_run:
+            self._restore_healthkey_concepts()
+        counts.update({
             'concept_relationship': self._load_concept_relationships(dry_run),
             'concept_ancestor':     self._load_concept_ancestors(dry_run),
             'concept_synonym':      self._load_concept_synonym(dry_run),
             'drug_strength':        self._load_drug_strength(dry_run),
             'source_to_concept_map': self._load_source_to_concept_map(dry_run),
-        }
+        })
         if not dry_run:
             self._seed_concept_zero()
             self._sync_cdm_source_metadata()
@@ -257,6 +266,65 @@ class Command(BaseCommand):
             if tmp.exists():
                 tmp.unlink()
                 self._log(f'  Cleaned up {filename}.')
+
+    # -- HealthKey concept preservation across --replace -----------------
+
+    _HK_CONCEPT_COLS = (
+        'concept_id', 'concept_name', 'domain_id', 'vocabulary_id',
+        'concept_class_id', 'standard_concept', 'concept_code',
+        'valid_start_date', 'valid_end_date', 'invalid_reason', 'source',
+    )
+
+    def _save_healthkey_concepts(self):
+        """Snapshot source='HealthKey' concept rows before TRUNCATE.
+
+        Returns a list of tuples matching ``_HK_CONCEPT_COLS`` order.
+        """
+        qs = Concept.objects.filter(source='HealthKey')
+        count = qs.count()
+        if not count:
+            self._log('  No HealthKey-minted concepts to preserve.')
+            return []
+        rows = list(qs.values_list(*self._HK_CONCEPT_COLS))
+        self._log(f'  Saved {len(rows):,} HealthKey concept(s) for restore after TRUNCATE.')
+        return rows
+
+    def _restore_healthkey_concepts(self):
+        """Re-insert saved HealthKey concepts after TRUNCATE + Athena reload.
+
+        FK references (vocabulary, domain, concept_class) that were not restored
+        by the Athena reload are created as minimal placeholder rows so the
+        INSERT does not violate FK constraints.
+        """
+        if not self._hk_concepts:
+            return
+        # Ensure FK targets exist — Athena reload may not include HK-specific
+        # vocabulary / domain / concept_class rows.
+        vocab_ids = {r[3] for r in self._hk_concepts}
+        domain_ids = {r[2] for r in self._hk_concepts}
+        class_ids = {r[4] for r in self._hk_concepts}
+
+        for vid in vocab_ids:
+            Vocabulary.objects.get_or_create(
+                vocabulary_id=vid,
+                defaults={'vocabulary_name': vid, 'vocabulary_concept_id': 0},
+            )
+        for did in domain_ids:
+            Domain.objects.get_or_create(
+                domain_id=did,
+                defaults={'domain_name': did, 'domain_concept_id': 0},
+            )
+        for cid in class_ids:
+            ConceptClass.objects.get_or_create(
+                concept_class_id=cid,
+                defaults={'concept_class_name': cid, 'concept_class_concept_id': 0},
+            )
+
+        _copy_rows(
+            'concept', self._HK_CONCEPT_COLS, self._hk_concepts,
+            self._log, direct=True,
+        )
+        self._log(f'  Restored {len(self._hk_concepts):,} HealthKey concept(s).')
 
     def _clear(self):
         self._log('Clearing existing vocabulary data (TRUNCATE)...')

--- a/omop_core/services/pk.py
+++ b/omop_core/services/pk.py
@@ -9,6 +9,11 @@ allocation first self-heals the sequence to ``>= MAX(pk)`` before drawing.
 """
 from django.db import connection
 
+# OMOP CDM reserves concept_id >= 2,000,000,000 for local (site-specific) use.
+# All HealthKey-minted concepts must live in this range so they never collide
+# with a future Athena vocabulary release.  Issue #425.
+LOCAL_CONCEPT_MIN_ID = 2_000_000_000
+
 _SEQ_NAME_TEMPLATE = '{table}_{pk_field}_seq'
 
 
@@ -22,15 +27,28 @@ def _reseed_to_max(cur, model, pk_field, seq):
     """Advance ``seq`` so the next value exceeds both its current position and
     ``MAX(pk)`` — making sequence allocation immune to legacy MAX(id)+1 writers
     that bypass the sequence. (Identifiers come from model meta, not user input.)
+
+    For ``concept.concept_id`` an additional floor of ``LOCAL_CONCEPT_MIN_ID``
+    is applied so that HealthKey-minted concepts always land in the OMOP-reserved
+    local range (>= 2,000,000,000) and never collide with Athena-assigned IDs.
     """
     table = connection.ops.quote_name(model._meta.db_table)
     col = connection.ops.quote_name(pk_field)
     qseq = connection.ops.quote_name(seq)
+
+    # For Concept.concept_id, enforce the local-range floor.
+    floor = (
+        LOCAL_CONCEPT_MIN_ID
+        if model._meta.db_table == 'concept' and pk_field == 'concept_id'
+        else 0
+    )
+
     cur.execute(
         f"SELECT setval(%s, GREATEST("
+        f"%s, "
         f"(SELECT last_value FROM {qseq}), "
         f"(SELECT COALESCE(MAX({col}), 0) FROM {table})), true)",
-        [seq],
+        [seq, floor],
     )
 
 

--- a/omop_core/tests.py
+++ b/omop_core/tests.py
@@ -4682,3 +4682,178 @@ class LatLonCheckConstraintTest(TestCase):
                 PatientRecord.objects.create(
                     person=person, latitude=0, longitude=181,
                 )
+
+
+# ---------------------------------------------------------------------------
+# TEST-05: Local concept ID range (issue #425)
+# ---------------------------------------------------------------------------
+
+class LocalConceptIdRangeTest(TestCase):
+    """next_pk(Concept, 'concept_id') must return IDs >= 2,000,000,000."""
+
+    def setUp(self):
+        self.vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id='OMOP_TEST',
+            defaults={'vocabulary_name': 'Test', 'vocabulary_concept_id': 0},
+        )
+        self.domain, _ = Domain.objects.get_or_create(
+            domain_id='Metadata',
+            defaults={'domain_name': 'Metadata', 'domain_concept_id': 0},
+        )
+        self.cc, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Undefined',
+            defaults={'concept_class_name': 'Undefined', 'concept_class_concept_id': 0},
+        )
+
+    def test_next_pk_concept_returns_local_range(self):
+        """next_pk for Concept must always return >= LOCAL_CONCEPT_MIN_ID."""
+        from omop_core.services.pk import next_pk, LOCAL_CONCEPT_MIN_ID
+        pk = next_pk(Concept, 'concept_id')
+        self.assertGreaterEqual(pk, LOCAL_CONCEPT_MIN_ID)
+
+    def test_next_pk_batch_concept_returns_local_range(self):
+        """next_pk_batch for Concept must return all IDs >= LOCAL_CONCEPT_MIN_ID."""
+        from omop_core.services.pk import next_pk_batch, LOCAL_CONCEPT_MIN_ID
+        pks = next_pk_batch(Concept, 'concept_id', 5)
+        self.assertEqual(len(pks), 5)
+        for pk in pks:
+            self.assertGreaterEqual(pk, LOCAL_CONCEPT_MIN_ID)
+
+    def test_next_pk_concept_above_athena_max(self):
+        """Even if an Athena concept exists below 2B, next_pk stays >= 2B."""
+        from omop_core.services.pk import next_pk, LOCAL_CONCEPT_MIN_ID
+        # Create a concept in the Athena range (below 2B)
+        Concept.objects.get_or_create(
+            concept_id=999_999,
+            defaults={
+                'concept_name': 'Athena test',
+                'domain_id': 'Metadata',
+                'vocabulary_id': 'OMOP_TEST',
+                'concept_class_id': 'Undefined',
+                'concept_code': 'TEST999999',
+                'valid_start_date': '1970-01-01',
+                'valid_end_date': '2099-12-31',
+            },
+        )
+        pk = next_pk(Concept, 'concept_id')
+        self.assertGreaterEqual(pk, LOCAL_CONCEPT_MIN_ID)
+
+    def test_next_pk_other_model_not_affected(self):
+        """The 2B floor must NOT apply to non-Concept models."""
+        from omop_core.services.pk import next_pk
+        # Person uses person_id — should not be subject to the 2B floor.
+        pk = next_pk(Person, 'person_id')
+        # It should be a small integer based on MAX(person_id)+1.
+        # We just verify it is NOT forced to >= 2B.
+        self.assertLess(pk, 2_000_000_000)
+
+
+class HealthKeyConceptSurvivesReloadTest(TestCase):
+    """source='HealthKey' concept rows must survive a --replace vocab reload."""
+
+    def setUp(self):
+        self.vocab, _ = Vocabulary.objects.get_or_create(
+            vocabulary_id='HK-Test',
+            defaults={'vocabulary_name': 'HK Test', 'vocabulary_concept_id': 0},
+        )
+        self.domain, _ = Domain.objects.get_or_create(
+            domain_id='Metadata',
+            defaults={'domain_name': 'Metadata', 'domain_concept_id': 0},
+        )
+        self.cc, _ = ConceptClass.objects.get_or_create(
+            concept_class_id='Undefined',
+            defaults={'concept_class_name': 'Undefined', 'concept_class_concept_id': 0},
+        )
+
+    def test_save_and_restore_healthkey_concepts(self):
+        """_save + TRUNCATE + _restore round-trips HealthKey concepts."""
+        from omop_core.management.commands.load_athena_vocabularies import Command
+        import io
+
+        # Count pre-existing HK concepts (seeded by migrations)
+        pre_existing = Concept.objects.filter(source='HealthKey').count()
+
+        # Create an HK concept
+        Concept.objects.create(
+            concept_id=2_000_000_001,
+            concept_name='HK test concept',
+            domain_id='Metadata',
+            vocabulary_id='HK-Test',
+            concept_class_id='Undefined',
+            concept_code='HK-TEST-001',
+            valid_start_date='1970-01-01',
+            valid_end_date='2099-12-31',
+            source='HealthKey',
+        )
+
+        cmd = Command()
+        cmd.stdout = io.StringIO()
+
+        # Save
+        saved = cmd._save_healthkey_concepts()
+        self.assertEqual(len(saved), pre_existing + 1)
+        saved_ids = {r[0] for r in saved}
+        self.assertIn(2_000_000_001, saved_ids)
+
+        # Simulate TRUNCATE — delete all concepts
+        Concept.objects.all().delete()
+        self.assertFalse(Concept.objects.filter(concept_id=2_000_000_001).exists())
+
+        # Re-create FK targets (simulating what the Athena loader does)
+        Vocabulary.objects.get_or_create(
+            vocabulary_id='HK-Test',
+            defaults={'vocabulary_name': 'HK Test', 'vocabulary_concept_id': 0},
+        )
+        Domain.objects.get_or_create(
+            domain_id='Metadata',
+            defaults={'domain_name': 'Metadata', 'domain_concept_id': 0},
+        )
+        ConceptClass.objects.get_or_create(
+            concept_class_id='Undefined',
+            defaults={'concept_class_name': 'Undefined', 'concept_class_concept_id': 0},
+        )
+
+        # Restore
+        cmd._hk_concepts = saved
+        cmd._restore_healthkey_concepts()
+
+        # Verify our test concept round-tripped
+        restored = Concept.objects.get(concept_id=2_000_000_001)
+        self.assertEqual(restored.concept_name, 'HK test concept')
+        self.assertEqual(restored.source, 'HealthKey')
+        self.assertEqual(restored.concept_code, 'HK-TEST-001')
+        # All saved HK concepts should be restored
+        self.assertEqual(
+            Concept.objects.filter(source='HealthKey').count(),
+            pre_existing + 1,
+        )
+
+    def test_non_healthkey_concepts_not_saved(self):
+        """Only source='HealthKey' rows are preserved; Athena rows are not."""
+        from omop_core.management.commands.load_athena_vocabularies import Command
+        import io
+
+        # Count pre-existing HK concepts (seeded by migrations)
+        pre_existing = Concept.objects.filter(source='HealthKey').count()
+
+        # Create an Athena concept (source=None)
+        Concept.objects.create(
+            concept_id=100,
+            concept_name='Athena concept',
+            domain_id='Metadata',
+            vocabulary_id='HK-Test',
+            concept_class_id='Undefined',
+            concept_code='ATHENA-100',
+            valid_start_date='1970-01-01',
+            valid_end_date='2099-12-31',
+            source=None,
+        )
+
+        cmd = Command()
+        cmd.stdout = io.StringIO()
+
+        saved = cmd._save_healthkey_concepts()
+        # Should only have pre-existing HK rows, not the new Athena one
+        self.assertEqual(len(saved), pre_existing)
+        saved_ids = {r[0] for r in saved}
+        self.assertNotIn(100, saved_ids)


### PR DESCRIPTION
## Summary

Fixes #425. Two changes to prevent HealthKey-minted `concept_id` values from colliding with Athena vocabulary releases:

- **`omop_core/services/pk.py`**: `next_pk` and `next_pk_batch` now apply a floor of `LOCAL_CONCEPT_MIN_ID` (2,000,000,000) when allocating `concept_id` values for the `Concept` model. All other models continue to use normal `max+1` behavior. This ensures locally minted concepts always land in the OMOP CDM reserved local range.

- **`omop_core/management/commands/load_athena_vocabularies.py`**: `--replace` vocabulary reloads now snapshot `source='HealthKey'` concept rows before `TRUNCATE` and restore them after the Athena concept load completes. FK targets (vocabulary, domain, concept_class) are re-created if the Athena reload did not include them.

## Test plan

- [x] `LocalConceptIdRangeTest` (4 tests): verifies `next_pk` returns >= 2B for Concept, `next_pk_batch` returns all IDs >= 2B, floor applies even with Athena concepts below 2B, and other models (Person) are not affected
- [x] `HealthKeyConceptSurvivesReloadTest` (2 tests): verifies save/restore round-trip for HK concepts, and that non-HK concepts are not preserved
- [x] Full Django test suite: 1405 tests pass
- [x] Full pytest suite: 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)