### PR TITLE
Document PatientRecord OMOP write migration contract

### DIFF
--- a/API_SURFACE.md
+++ b/API_SURFACE.md
@@ -1,7 +1,7 @@
 # PRomop API Surface
 
 > **Canonical base URL:** `https://promop.onrender.com/api/v1/` (production) | `http://localhost:8000/api/v1/` (dev)
-> Last revised: 2026-07-22
+> Last revised: 2026-08-18
 
 > **Versioning note:** All new integrations should target `/api/v1/` paths. The legacy
 > unversioned `/api/` paths still work but return `Deprecation: true` / `Sunset: Tue, 01 Sep 2026 00:00:00 GMT`
@@ -29,6 +29,11 @@ their OMOP source records change, and its profile/admin compatibility fields are
 from HealthKey extension columns on `Person`. The API rejects direct writes to
 `PatientRecord`; OMOP APIs, FHIR imports, and `Person` profile updates own writes, then
 the projection refreshes.
+
+The field-by-field ownership and migration plan is
+[`docs/omop_to_patientrecord.md`](docs/omop_to_patientrecord.md). It is the authoritative
+answer to which OMOP record supplies each output column; a PatientRecord field name is
+never a substitute for a clinical concept, event date, unit, or provenance.
 
 > **Legacy SQL compatibility only:** `public.patient_info` is a read-only database view
 > retained solely for existing consumers. New integrations must not query it or depend on
@@ -210,11 +215,32 @@ Returns the PatientRecord for the authenticated patient. Only available to patie
 
 ### PatientRecord mutation policy
 
-`PATCH /api/v1/patient-records/{person_id}/` rejects direct writes. Clinical values must
-be written through their OMOP resources (or FHIR import), after which the signal chain
-refreshes `PatientRecord` from OMOP. Profile/admin values that are displayed on
-PatientRecord, such as email and validation metadata, are written to HealthKey extension
-columns on `Person` via `PATCH /api/v1/persons/{person_id}/` and then projected back.
+`PATCH /api/v1/patient-records/{person_id}/` returns **405 Method Not Allowed** for every
+OMOP-mapped clinical field. It returns the rejected names so callers can migrate without
+guessing:
+
+```json
+{
+  "detail": "OMOP-mapped PatientRecord fields are read-only. Write a complete clinical fact to the appropriate OMOP resource, then rederive the record.",
+  "fields": ["hemoglobin_g_dl"]
+}
+```
+
+Clinical values must be written through their OMOP resources (or FHIR import), after
+which the signal chain refreshes `PatientRecord` from OMOP. Profile/admin values that are
+displayed on PatientRecord, such as email and validation metadata, are written to HealthKey
+extension columns on `Person` via `PATCH /api/v1/persons/{person_id}/` and then projected back.
+
+| PatientRecord output category | Write the source fact to | Required source detail |
+|---|---|---|
+| Laboratory, vital, tumour-marker, or numeric pathology value | `/api/v1/measurements/` or FHIR `Observation` | clinical concept, known event date, value, unit, provenance |
+| Coded clinical, eligibility, disease-state, imaging, or social assertion | `/api/v1/observations/`, `/api/v1/conditions/`, or equivalent FHIR resource | standard concept, known event date, coded/value assertion, provenance |
+| Medication or line-of-therapy fact | `/api/v1/drug-exposures/`, `/api/v1/episodes/`, `/api/v1/episode-events/`, or FHIR | medication/episode concept, known dates, provenance |
+| Demographic or supported profile value | `PATCH /api/v1/persons/{person_id}/` | the Person source attribute; refresh projects it |
+
+There are no writable concrete PatientRecord clinical columns. The field-level mapping,
+including the small set of server lifecycle attributes that are never client-writable, is
+maintained in [`docs/omop_to_patientrecord.md`](docs/omop_to_patientrecord.md).
 
 New integrations should write semantically complete OMOP facts to their own resource
 endpoint—for example a dated `Measurement` with its LOINC and unit—or use FHIR ingest.
@@ -868,7 +894,7 @@ Clinical write APIs operate on OMOP resources, not on projection fields. A numer
 observation must carry its clinical concept, event time, value, and unit; terminology
 mapping and canonical-unit policy are documented in
 [`docs/concept-mapping.md`](docs/concept-mapping.md) and
-[`docs/canonical-units-policy.md`](docs/canonical-units-policy.md). This prevents a
+[`docs/clinical-unit-policy.md`](docs/clinical-unit-policy.md). This prevents a
 lossy projection update from being mistaken for a source clinical fact.
 
 ---

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -478,12 +478,14 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
         })
 
     def partial_update(self, request, pk=None):
-        """PATCH only projection-owned fields with no OMOP representation.
+        """Patch the PatientRecord compatibility surface.
 
-        A mapped clinical PatientRecord field is output from an OMOP fact.  It
+        A mapped clinical PatientRecord field is output from an OMOP fact. It
         cannot safely supply the fact's concept, time, unit, or provenance, so
-        this endpoint rejects it rather than recreating the retired
-        PatientRecord-to-OMOP write-through path.
+        it returns 405 rather than recreating the retired PatientRecord-to-OMOP
+        write-through path. Write the appropriate OMOP resource (or ingest
+        FHIR) and let refresh_patient_record rebuild this read model. See
+        docs/omop_to_patientrecord.md for the field-to-source mapping.
         """
         try:
             person = Person.objects.get(person_id=pk)

--- a/tests/test_patient_record_derive_only_contract.py
+++ b/tests/test_patient_record_derive_only_contract.py
@@ -39,11 +39,25 @@ def test_public_contract_documents_read_only_mapped_fields_and_legacy_policy():
     ).read_text()
 
     assert "PatientRecord fields are read-only." in api_surface
-    assert "Profile/admin values that are displayed on" in api_surface
+    assert "Profile/admin values that are\ndisplayed on PatientRecord" in api_surface
     assert "PatientRecord, such as email and validation metadata" in api_surface
     assert "PATCH /api/v1/persons/{person_id}/" in api_surface
     assert "Legacy SQL compatibility only:" in api_surface
     assert "New integrations must not query it" in api_surface
+    assert "405 Method Not Allowed" in api_surface
+    assert '"fields": ["hemoglobin_g_dl"]' in api_surface
+    assert "docs/omop_to_patientrecord.md" in api_surface
+    assert "There are no writable concrete PatientRecord clinical columns." in api_surface
+    assert "`PATCH /api/v1/persons/{person_id}/`" in api_surface
     assert "PatientRecord fields are read-only at the PatientRecord API." in architecture_brief
     assert "Producers write" in architecture_brief
     assert "complete, provenance-bearing OMOP facts (or FHIR)" in architecture_brief
+
+
+def test_partial_update_schema_description_explains_omop_write_migration():
+    """The generated OpenAPI operation inherits this method documentation."""
+    api_views = (REPOSITORY_ROOT / "patient_portal/api/views.py").read_text()
+
+    assert "returns 405" in api_views
+    assert "docs/omop_to_patientrecord.md" in api_views
+    assert "Write the appropriate OMOP resource" in api_views


### PR DESCRIPTION
Closes #511.

## Contract
- Documents the 405 response returned when callers PATCH an OMOP-mapped PatientRecord field.
- Maps each output category to its OMOP/FHIR or Person write surface and required fact data.
- Links the field-level ownership plan in `docs/omop_to_patientrecord.md`.
- Restates that `patient_info` is legacy-only and corrects the canonical-unit-policy link.
- Adds regression guards and a schema-visible PATCH method description.

## Verification
`DATABASE_URL=postgresql://postgres@localhost:5432/promop_511_ci /Users/adamblum/promop/.venv/bin/python -m pytest -q tests/test_patient_record_derive_only_contract.py`

5 passed.