### PR TITLE
Remove FHIR PatientRecord write-through

### DIFF
--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -3637,31 +3637,14 @@ class PatientRecordViewSet(viewsets.ReadOnlyModelViewSet):
                     if upload_org is not None and patient_info.organization_id is None:
                         _patch['organization'] = upload_org
 
-                    # PatientRecord accepts only projection-owned values here.
-                    # Every mapped clinical field above has to be represented by
-                    # an OMOP row (and is picked up by the preceding refresh),
-                    # never copied from this FHIR parser into the projection.
-                    _mapped_patch_fields = set(_patch) & PATIENT_RECORD_OMOP_MAPPED_FIELDS
-                    if _mapped_patch_fields:
-                        logger.info(
-                            "FHIR mapped PatientRecord fields omitted after OMOP derivation "
-                            "person_id=%s fields=%s",
-                            person.person_id,
-                            ",".join(sorted(_mapped_patch_fields)),
-                        )
-                        _patch = {
-                            field: value for field, value in _patch.items()
-                            if field not in PATIENT_RECORD_OMOP_MAPPED_FIELDS
-                        }
-
-                    # Apply projection-owned fields only (suppress
-                    # signal-triggering save).  In particular, this must not
-                    # become a PatientRecord-to-OMOP compatibility bridge.
-                    for _field, _val in _patch.items():
-                        setattr(patient_info, _field, _val)
-                    patient_info.save()
-                    if prov_source:
-                        _record_provenance(patient_info, prov_source, prov_user_id, modification_reason=prov_reason, organization=get_request_org(request))
+                    # All clinical values above were written to OMOP rows before
+                    # refresh_patient_record.  Do not copy the parser's legacy
+                    # compatibility dictionary into PatientRecord: doing so
+                    # creates a second clinical write authority.  Organization is
+                    # tenant metadata and is the sole intentional exception.
+                    if upload_org is not None and patient_info.organization_id is None:
+                        patient_info.organization = upload_org
+                        patient_info.save(update_fields=['organization', 'updated_at'])
 
                     # Commit all writes for this patient. Mark _atomic_entered=False
                     # so the finally block knows the transaction was cleanly committed.

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -19,6 +19,7 @@ from datetime import date, timedelta
 from patient_portal.models import Identity
 from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
+from django.contrib.contenttypes.models import ContentType
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -3963,7 +3964,7 @@ class ProvenancePatchTest(_SmartBase):
 
 
 class ProvenanceFhirUploadTest(_SmartBase):
-    """FHIR upload with provenance headers tags all created OMOP records."""
+    """FHIR upload tags OMOP facts; PatientRecord remains a derived read model."""
 
     def test_fhir_upload_with_ehr_sync_tags_records(self):
         bundle_bytes = json.dumps(_make_fhir_bundle()).encode('utf-8')
@@ -3978,9 +3979,30 @@ class ProvenanceFhirUploadTest(_SmartBase):
         person = Person.objects.filter(family_name='Smith', given_name='Jane').first()
         self.assertIsNotNone(person)
         pi = PatientRecord.objects.get(person=person)
+        # Clinical provenance belongs to the OMOP facts that were written from
+        # the bundle.  The PatientRecord projection must not receive a direct
+        # write-through provenance row or clinical values.
+        omop_models = (
+            ConditionOccurrence, Measurement, Observation,
+            DrugExposure, ProcedureOccurrence,
+        )
+        omop_types = [ContentType.objects.get_for_model(model) for model in omop_models]
         self.assertTrue(
-            ProvenanceRecord.objects.filter(object_id=pi.pk).exists(),
-            'PatientRecord was not tagged with provenance',
+            ProvenanceRecord.objects.filter(
+                source='EHR_SYNC',
+                source_user_id='ehr-001',
+                content_type__in=omop_types,
+            ).exists(),
+            'FHIR OMOP facts were not tagged with provenance',
+        )
+        self.assertFalse(
+            ProvenanceRecord.objects.filter(
+                source='EHR_SYNC',
+                source_user_id='ehr-001',
+                content_type=ContentType.objects.get_for_model(PatientRecord),
+                object_id=pi.pk,
+            ).exists(),
+            'FHIR upload wrote provenance directly to derived PatientRecord',
         )
 
     def test_fhir_upload_admin_correction_without_reason_rejected(self):


### PR DESCRIPTION
Closes #510. Parent #501.

Removes the residual FHIR upload `_patch` persistence path. FHIR clinical resources are written to OMOP tables and the projection is refreshed; only tenant organization metadata is stamped on PatientRecord.

Focused isolated database verification:
- FhirUploadOmopTablesTest
- FhirUploadPatientRecordTest
- SctFhirUploadTest
- 24 tests passed
- compileall and diff check clean