### PR TITLE
#538  widen the Observation upsert key to the row's raw values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -750,15 +750,24 @@ append-only writes.
 
 | Model | Event identity |
 |---|---|
-| ConditionOccurrence, DrugExposure, Observation, ProcedureOccurrence | `(source_value, date)` |
+| ConditionOccurrence, DrugExposure, ProcedureOccurrence | `(source_value, date)` |
 | Measurement | `(source_value, date, datetime, value_as_number)` |
+| Observation | `(source_value, date, datetime, value_as_number, value_as_string, value_source_value)` |
 
-Measurement is the deliberate divergence: a patient legitimately has several
-distinct results for one analyte on one day, so `(source_value, date)` alone
-would not dedup a re-run — it would delete real results. The wider key matches
-what `fhir/sync.py::_insert_discrete_observations` already dedups on. The concept
-column stays *outside* every key, which is what lets a vocabulary load upgrade a
-stored row in place instead of stranding a duplicate beside it.
+Measurement and Observation diverge on purpose: a patient legitimately has
+several distinct results for one analyte on one day, so `(source_value, date)`
+alone would delete real results instead of deduping a re-run.
+
+The concept column stays outside every key, which lets a vocabulary load upgrade
+a stored row in place instead of stranding a duplicate beside it. The same rule
+picks which value columns may join a key: only raw ones. `value_as_concept` is
+re-resolved by a vocabulary load just like `observation_concept`, so keying on
+it would strand the duplicate the design prevents. `value_source_value` is the
+raw text behind that resolution, so it separates two coded answers safely.
+
+A batch that trips a database constraint returns **409** with the driver's first
+error line, not 500. The whole batch rolled back, so the caller can retry, and a
+500 reads as "the service is down".
 
 A row with no `source_value` or no date has no identity and is always inserted.
 

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Callable, ContextManager
 
 from rest_framework import viewsets, status
 from rest_framework.decorators import action, api_view, permission_classes
@@ -11,7 +11,7 @@ from rest_framework.throttling import ScopedRateThrottle
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from patient_portal.models import Identity
 from django.contrib.auth import logout, login, authenticate
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, models, transaction
 from django.db.models import Q, F
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
@@ -22,6 +22,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import validate_email
 from omop_core.models import (
+    Organization,
     Person, PatientRecord, Concept, ConceptClass, Domain, ProvenanceRecord, Vocabulary,
     ConditionOccurrence, DrugExposure, Measurement, MeasurementOwnership,
     Observation, ProcedureOccurrence, VisitOccurrence, VisitDetail, Location, Death,
@@ -4988,13 +4989,14 @@ def _prefetch_bulk_related(serializer, rows):
 #: vocabulary load resolves a code that previously fell back to 'No matching
 #: concept'.
 #:
-#: Measurement is the one deliberate divergence. A patient legitimately has
-#: several distinct results for one analyte on one day (repeat draws, sub-daily
-#: vitals), so keying it on (source_value, date) alone would not dedup a re-run
-#: — it would delete real results and keep one. Its timestamp and value
-#: therefore join the key, which is exactly what
-#: ``fhir/sync.py::_insert_discrete_observations`` already dedups discrete
-#: readings on.
+#: Measurement and Observation diverge on purpose. A patient legitimately has
+#: several distinct results for one analyte on one day, so keying them on
+#: (source_value, date) alone would delete real results instead of deduping.
+#:
+#: Only raw value columns may join a key. ``value_as_concept`` is re-resolved by
+#: a vocabulary load just like the concept column, so keying on it would strand
+#: a duplicate beside the row it should have upgraded. ``value_source_value`` is
+#: the raw text behind that resolution, so it separates two coded answers safely.
 #:
 #: Format: model name -> (source_value field, date field, concept field, extra key fields)
 _UPSERT_KEYS = {
@@ -5006,7 +5008,9 @@ _UPSERT_KEYS = {
                             'measurement_concept',
                             ('measurement_datetime', 'value_as_number')),
     'Observation':         ('observation_source_value', 'observation_date',
-                            'observation_concept', ()),
+                            'observation_concept',
+                            ('observation_datetime', 'value_as_number',
+                             'value_as_string', 'value_source_value')),
     'ProcedureOccurrence': ('procedure_source_value', 'procedure_date',
                             'procedure_concept', ()),
 }
@@ -5347,6 +5351,42 @@ class _OmopBulkCreateMixin:
 
         from omop_core.signals import suppress_patient_record_refresh
 
+        try:
+            return self._bulk_write(
+                request, person, org, model_cls, pk_field, model_name, validated,
+                source, source_user_id, reason, skip_refresh, upsert,
+                suppress_patient_record_refresh)
+        except IntegrityError as exc:
+            # A conflict over data, not a server fault. The distinction decides
+            # whether the caller retries, and a 500 reads as "service is down".
+            logger.exception(
+                'bulk %s write for person %s failed on a database constraint',
+                model_name, person.person_id)
+            return Response(
+                {'detail': (
+                    'The batch conflicted with a database constraint and was '
+                    'rolled back whole; no rows were written. Retrying is safe.'
+                ), 'error': str(exc).strip().partition('\n')[0]},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+    def _bulk_write(
+        self,
+        request: Request,
+        person: Person,
+        org: Organization | None,
+        model_cls: type[models.Model],
+        pk_field: str,
+        model_name: str,
+        validated: list[dict[str, Any]],
+        source: str | None,
+        source_user_id: str | None,
+        reason: str | None,
+        skip_refresh: bool,
+        upsert: bool,
+        suppress_patient_record_refresh: Callable[[], ContextManager[None]],
+    ) -> Response:
+        """Write one validated batch and derive the read model once."""
         with transaction.atomic():
             # bulk_create does not fire post_save today, so the per-row refresh
             # receivers would not run anyway. Suppressing explicitly is the

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -11,6 +11,7 @@ Test flow:
 
 import io
 import json
+from typing import Any
 import os
 import tempfile
 import unittest
@@ -17894,3 +17895,223 @@ class OmopDeferRefreshTest(TestCase):
             with self.assertRaises(ValueError):
                 self.client.post(
                     f'/api/v1/patient-records/{self.person.person_id}/refresh/')
+
+
+class BulkUpsertObservationIdentityTest(TestCase):
+    """Observation event identity, and how a constraint failure is reported."""
+
+    @classmethod
+    def setUpTestData(cls):
+        _make_vocab_fixtures()
+        cls.person = Person.objects.create(person_id=32101)
+        PatientRecord.objects.create(person=cls.person)
+        cls.concept = Concept.objects.get(concept_id=3000963)
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+        cls.service_identity = Identity.objects.get_or_create(
+            issuer='urn:service', sub='bulk-upsert-obs-test',
+        )[0]
+        cls.service_identity.set_unusable_password()
+        cls.service_identity.save()
+
+    def setUp(self):
+        from django.core.cache import cache
+        cache.clear()
+        self.client = APIClient()
+        self.client.force_authenticate(
+            user=self.service_identity, token="service-token")
+
+    def _obs(self, source_value: str | None, day: str = '2024-01-01',
+             value: str | None = None) -> dict[str, Any]:
+        row = {
+            'person': self.person.person_id,
+            'observation_concept': self.concept.concept_id,
+            'observation_date': day,
+            'observation_type_concept': self.type_concept.concept_id,
+            'observation_source_value': source_value,
+        }
+        if value is not None:
+            row['value_as_string'] = value
+        return row
+
+    def _repeated_key_batch(self) -> list[dict[str, Any]]:
+        """176 rows over 116 distinct events, 20 of them repeated 4 times.
+
+        Repeats have to match in every key column, not just source_value. The
+        key includes raw values, so rows differing by value are distinct events
+        and exercise nothing.
+        """
+        rows = []
+        for i in range(20):
+            rows += [self._obs(f'OBS-{i}', value='result') for _ in range(4)]
+        rows += [self._obs(f'FILL-{i}', value='tail') for i in range(96)]
+        assert len(rows) == 176
+        return rows
+
+    def test_batch_with_repeated_new_keys_does_not_500(self):
+        rows = self._repeated_key_batch()
+
+        resp = self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        # Without this the batch can stop containing repeats, which a key
+        # change already did once, and the test keeps passing regardless.
+        self.assertEqual(resp.data['created'], 116)
+        self.assertEqual(
+            Observation.objects.filter(person=self.person).count(), 116,
+            'within-batch repeats did not collapse')
+
+    def test_batch_with_repeated_new_keys_does_not_500_with_refresh(self):
+        rows = self._repeated_key_batch()
+
+        resp = self.client.post('/api/v1/observations/', rows, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+
+    def test_batch_with_repeated_new_keys_does_not_500_with_provenance(self):
+        rows = self._repeated_key_batch()
+
+        resp = self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json',
+            HTTP_X_PROVENANCE_SOURCE='healthtree', HTTP_X_PROVENANCE_USER_ID='etl')
+
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+
+    def test_repeated_keys_repost_does_not_500(self):
+        """Second run: now the repeated keys DO already exist on file."""
+        rows = self._repeated_key_batch()
+
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+        resp = self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+
+    def test_batch_with_repeated_new_keys_does_not_500_unprefixed_route(self):
+        rows = self._repeated_key_batch()
+
+        resp = self.client.post(
+            '/api/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+
+    def test_distinct_results_on_one_date_both_survive(self):
+        """Two different results on one date are two events, not one."""
+        rows = [
+            self._obs('OBS-1', value='positive'),
+            self._obs('OBS-1', value='negative'),
+        ]
+
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        stored = set(
+            Observation.objects.filter(person=self.person)
+            .values_list('value_as_string', flat=True))
+        self.assertEqual(stored, {'positive', 'negative'})
+
+    def test_distinct_results_still_converge_on_repost(self):
+        """Widening the key must not cost idempotency."""
+        rows = [
+            self._obs('OBS-1', value='positive'),
+            self._obs('OBS-1', value='negative'),
+        ]
+
+        first = self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+        second = self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(first.data['created'], 2)
+        self.assertEqual(second.data['created'], 0)
+        self.assertEqual(second.data['ids'], first.data['ids'])
+        self.assertEqual(Observation.objects.filter(person=self.person).count(), 2)
+
+    def test_concept_still_upgrades_in_place(self):
+        """The concept stays outside the key, so a vocabulary load corrects it."""
+        upgraded = Concept.objects.get(concept_id=4112853)
+        rows = [self._obs('OBS-1', value='positive')]
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        rows[0]['observation_concept'] = upgraded.concept_id
+        resp = self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(resp.data['created'], 0)
+        self.assertEqual(resp.data['updated'], 1)
+        stored = Observation.objects.filter(person=self.person)
+        self.assertEqual(stored.count(), 1, 'the concept change duplicated the row')
+        self.assertEqual(stored.first().observation_concept_id, upgraded.concept_id)
+
+    def test_value_as_concept_stays_out_of_the_key(self):
+        """value_as_concept is vocabulary resolved, so it must update in place."""
+        resolved = Concept.objects.get(concept_id=4112853)
+        rows = [self._obs('OBS-1', value='positive')]
+        rows[0]['value_source_value'] = 'POS'
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        rows[0]['value_as_concept'] = resolved.concept_id
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(
+            Observation.objects.filter(person=self.person).count(), 1,
+            'resolving value_as_concept stranded a duplicate')
+
+    def test_rows_without_an_identity_are_still_always_inserted(self):
+        rows = [self._obs(None, value='a'), self._obs(None, value='b')]
+
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(Observation.objects.filter(person=self.person).count(), 4)
+
+    def test_database_constraint_failure_is_a_409_not_a_500(self):
+        """A 500 reads as "service is down", which changes whether to retry."""
+        from unittest.mock import patch
+        from django.db import IntegrityError
+
+        rows = [self._obs('OBS-1', value='x')]
+
+        with patch.object(Observation.objects, 'bulk_create',
+                          side_effect=IntegrityError('duplicate key value')):
+            resp = self.client.post(
+                '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT, resp.data)
+        self.assertIn('rolled back whole', resp.data['detail'])
+        self.assertEqual(resp.data['error'], 'duplicate key value')
+        self.assertEqual(Observation.objects.filter(person=self.person).count(), 0)
+
+    def test_constraint_failure_with_an_empty_message_is_still_a_409(self):
+        """Summarising the driver message must not itself raise."""
+        from unittest.mock import patch
+        from django.db import IntegrityError
+
+        rows = [self._obs('OBS-1', value='x')]
+
+        with patch.object(Observation.objects, 'bulk_create',
+                          side_effect=IntegrityError('   ')):
+            resp = self.client.post(
+                '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT, resp.data)
+        self.assertEqual(resp.data['error'], '')
+
+    def test_distinct_times_on_one_date_are_distinct_events(self):
+        rows = [
+            self._obs('OBS-1', value='x'),
+            self._obs('OBS-1', value='x'),
+        ]
+        rows[0]['observation_datetime'] = '2024-01-01T08:00:00Z'
+        rows[1]['observation_datetime'] = '2024-01-01T20:00:00Z'
+
+        self.client.post(
+            '/api/v1/observations/?skip_refresh=true', rows, format='json')
+
+        self.assertEqual(Observation.objects.filter(person=self.person).count(), 2)


### PR DESCRIPTION
Observation was keyed on (source_value, date), so two different results recorded on one date collapsed into one and the earlier was silently dropped. That is the same case Measurement already diverges for -- a patient legitimately has several distinct results in a day -- and it is not an edge case for the HealthTree load, where 27% of observation rows carry no code.

Only raw value columns join the key. value_as_concept is re-resolved by a vocabulary load exactly as observation_concept is, so keying on it would strand the duplicate the design exists to prevent; value_source_value is the raw text that resolution came from and separates two coded answers safely.

A batch tripping a database constraint now returns 409 with the driver's first error line instead of 500. The batch rolls back whole either way, but a 500 is indistinguishable from the service being down -- which is the call a retrying client has to make.

First re-run after deploy inserts one row per stored observation whose value differs from what the old key matched; that is the correction, not a leak.