### PR TITLE
#532 feat: let clinical writes defer the derivation, and trigger one …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,6 +700,28 @@ The FHIR upload endpoint in `patient_portal/api/views.py` (`upload_fhir_bundle`)
 
 ---
 
+## Deferring the PatientRecord Derivation
+
+Every clinical write re-derives the whole `PatientRecord`, and derivation cost
+grows with the rows the person already holds. On a bulk loaded patient that is
+12-32s per row level write.
+
+`?skip_refresh=true` suppresses it, on the bulk POST and on the row level
+`PATCH` and `DELETE` of the five clinical endpoints. Opt-in: without it every
+verb still derives, because existing callers depend on that.
+
+A client that defers must derive afterwards:
+
+```
+POST /api/v1/patient-records/{person_id}/refresh/
+```
+
+Admin or service-token only. It does not swallow a failing derivation, unlike
+the signal path in `omop_core/signals.py`, because a 2xx over a record that did
+not re-derive would be a lie on an endpoint that exists only to derive.
+
+---
+
 ## Bulk OMOP Row Writes
 
 The five OMOP clinical CRUD endpoints (`conditions`, `drug-exposures`, `measurements`,

--- a/patient_portal/api/v1_urls.py
+++ b/patient_portal/api/v1_urls.py
@@ -2,7 +2,8 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import (
-    CurrentUserViewSet, PatientRecordViewSet, login_view, logout_view, auth_test,
+    CurrentUserViewSet, PatientRecordViewSet,
+    PatientRecordV1ViewSet, login_view, logout_view, auth_test,
     change_password,
     PersonViewSet,
     ConditionOccurrenceViewSet, DrugExposureViewSet, MeasurementViewSet,
@@ -40,7 +41,7 @@ from .break_glass import break_glass
 router = DefaultRouter()
 
 router.register(r'user', CurrentUserViewSet, basename='v1-user')
-router.register(r'patient-records', PatientRecordViewSet, basename='v1-patient-records')
+router.register(r'patient-records', PatientRecordV1ViewSet, basename='v1-patient-records')
 router.register(r'persons', PersonViewSet, basename='v1-persons')
 router.register(r'conditions', ConditionOccurrenceViewSet, basename='v1-conditions')
 router.register(r'drug-exposures', DrugExposureViewSet, basename='v1-drug-exposures')

--- a/patient_portal/api/views.py
+++ b/patient_portal/api/views.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 from rest_framework import viewsets, status
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
@@ -4676,6 +4679,39 @@ _PERSON_REPLACEABLE_FIELDS = {
 
 
 @method_decorator(csrf_exempt, name='dispatch')
+class PatientRecordV1ViewSet(PatientRecordViewSet):
+    """v1-only PatientRecord surface.
+
+    The legacy /api/patient-info/ prefix registers PatientRecordViewSet itself,
+    so anything added there widens a frozen API. New actions belong here.
+    """
+
+    @action(detail=True, methods=['post'], url_path='refresh',
+            permission_classes=[ScopedTokenPermission, PatientSelfScopePermission])
+    def refresh(self, request: Request, pk: str | None = None) -> Response:
+        """Re-derive this person's PatientRecord once, on demand."""
+        person, patient_info, err = self._resolve_patient_with_auth(request, pk)
+        if err:
+            return err
+
+        if not _is_admin_actor(request):
+            return Response(
+                {'detail': 'Only administrators can trigger a derivation.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # Unguarded on purpose. A 2xx over a record that did not re-derive
+        # would be a lie on an endpoint that exists only to derive.
+        record: PatientRecord = refresh_patient_record(person)
+        return Response({
+            'person_id': person.person_id,
+            'refreshed': True,
+            'derived_at': getattr(record, 'derived_at', None),
+            'derivation_version': getattr(record, 'derivation_version', None),
+        })
+
+
+
 class PersonViewSet(viewsets.GenericViewSet):
     """
     Endpoints:
@@ -5133,6 +5169,52 @@ def _apply_upsert_plan(plan, model_cls, pk_field, model_name):
     return ids, new_ids
 
 
+def _is_admin_actor(request: Request) -> bool:
+    """Whether this caller may act on a patient administratively."""
+    actor = request.user
+    return (
+        is_service_token(request)
+        or bool(getattr(actor, 'is_staff', False))
+        or get_admin_orgs(actor).exists()
+    )
+
+
+def _skip_refresh_requested(request: Request) -> bool:
+    """Whether the caller asked to defer, and is allowed to.
+
+    Only actors who can call the refresh action may defer. Otherwise a patient
+    could PATCH their own row with the flag and strand their PatientRecord
+    stale with no way to rebuild it.
+    """
+    asked = str(
+        request.query_params.get('skip_refresh', 'false')
+    ).strip().lower() in ('1', 'true', 'yes')
+    return asked and _is_admin_actor(request)
+
+
+class _OmopDeferRefreshMixin:
+    """Let row level writes defer the PatientRecord derivation.
+
+    Derivation cost grows with the rows a person already holds, so on a
+    bulk loaded patient one PATCH or DELETE costs 12-32s. A caller that defers
+    has to call the refresh action afterwards.
+    """
+
+    def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        if not _skip_refresh_requested(request):
+            return super().update(request, *args, **kwargs)
+        from omop_core.signals import suppress_patient_record_refresh
+        with suppress_patient_record_refresh():
+            return super().update(request, *args, **kwargs)
+
+    def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        if not _skip_refresh_requested(request):
+            return super().destroy(request, *args, **kwargs)
+        from omop_core.signals import suppress_patient_record_refresh
+        with suppress_patient_record_refresh():
+            return super().destroy(request, *args, **kwargs)
+
+
 class _OmopBulkCreateMixin:
     """Accept a JSON *list* on POST and insert the rows in one batched transaction.
 
@@ -5408,7 +5490,7 @@ class _ProvenanceMixin:
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class ConditionOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class ConditionOccurrenceViewSet(_OmopDeferRefreshMixin, _OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ConditionOccurrenceSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = ConditionOccurrence.objects.all()
@@ -5417,7 +5499,7 @@ class ConditionOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFi
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class DrugExposureViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class DrugExposureViewSet(_OmopDeferRefreshMixin, _OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = DrugExposureSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = DrugExposure.objects.all()
@@ -5426,7 +5508,7 @@ class DrugExposureViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMix
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class MeasurementViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class MeasurementViewSet(_OmopDeferRefreshMixin, _OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = MeasurementSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Measurement.objects.all()
@@ -5464,7 +5546,7 @@ class MeasurementViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixi
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class ObservationViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class ObservationViewSet(_OmopDeferRefreshMixin, _OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ObservationSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = Observation.objects.all()
@@ -5473,7 +5555,7 @@ class ObservationViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixi
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class ProcedureOccurrenceViewSet(_OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
+class ProcedureOccurrenceViewSet(_OmopDeferRefreshMixin, _OmopBulkCreateMixin, _ProvenanceMixin, _OmopFilterMixin, viewsets.ModelViewSet):
     serializer_class = ProcedureOccurrenceSerializer
     permission_classes = [ScopedTokenPermission, PatientSelfScopePermission]
     queryset = ProcedureOccurrence.objects.all()

--- a/patient_portal/tests.py
+++ b/patient_portal/tests.py
@@ -17716,3 +17716,181 @@ class BulkOmopUpsertTest(TestCase):
             PatientRecord.objects.get(person=self.person).derived_at,
             derived_before,
             'the collapse landed without refreshing the read model')
+
+
+from unittest.mock import patch  # noqa: E402
+from rest_framework.response import Response  # noqa: E402
+from patient_portal.models import PatientUser  # noqa: E402
+
+
+class OmopDeferRefreshTest(TestCase):
+    """Deferring the derivation on row level writes, and triggering one."""
+
+    @classmethod
+    def setUpTestData(cls):
+        _make_vocab_fixtures()
+        cls.person = Person.objects.create(person_id=32201)
+        PatientRecord.objects.create(person=cls.person)
+        cls.concept = Concept.objects.get(concept_id=3000963)
+        cls.type_concept = Concept.objects.get(concept_id=32817)
+        cls.service_identity = Identity.objects.get_or_create(
+            issuer='urn:service', sub='defer-refresh-test',
+        )[0]
+        cls.service_identity.set_unusable_password()
+        cls.service_identity.save()
+
+    def setUp(self):
+        from django.core.cache import cache
+        cache.clear()
+        self.client = APIClient()
+        self.client.force_authenticate(
+            user=self.service_identity, token="service-token")
+        self.measurement = Measurement.objects.create(
+            measurement_id=920001,
+            person=self.person,
+            measurement_concept=self.concept,
+            measurement_date=date(2024, 1, 1),
+            measurement_type_concept=self.type_concept,
+            measurement_source_value='718-7',
+            value_as_number=5,
+        )
+
+    def _patch(self, query: str = '') -> Response:
+        return self.client.patch(
+            f'/api/v1/measurements/{self.measurement.pk}/{query}',
+            {'value_as_number': 9}, format='json')
+
+    def _delete(self, query: str = '') -> Response:
+        return self.client.delete(
+            f'/api/v1/measurements/{self.measurement.pk}/{query}')
+
+    def test_patch_with_skip_refresh_does_not_derive(self):
+        with patch('omop_core.services.patient_record_service.refresh_patient_record') as refresh:
+            resp = self._patch('?skip_refresh=true')
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
+        refresh.assert_not_called()
+        self.measurement.refresh_from_db()
+        self.assertEqual(self.measurement.value_as_number, 9)
+
+    def test_delete_with_skip_refresh_does_not_derive(self):
+        with patch('omop_core.services.patient_record_service.refresh_patient_record') as refresh:
+            resp = self._delete('?skip_refresh=true')
+
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        refresh.assert_not_called()
+        self.assertFalse(Measurement.objects.filter(pk=920001).exists())
+
+    def test_patch_without_the_flag_still_derives(self):
+        # The flag must not become the default, every existing caller depends
+        # on a write deriving.
+        with patch('omop_core.services.patient_record_service.refresh_patient_record') as refresh:
+            self._patch()
+
+        self.assertTrue(refresh.called)
+
+    def test_delete_without_the_flag_still_derives(self):
+        with patch('omop_core.services.patient_record_service.refresh_patient_record') as refresh:
+            self._delete()
+
+        self.assertTrue(refresh.called)
+
+    def test_skip_refresh_false_still_derives(self):
+        with patch('omop_core.services.patient_record_service.refresh_patient_record') as refresh:
+            self._patch('?skip_refresh=false')
+
+        self.assertTrue(refresh.called)
+
+    def test_refresh_endpoint_derives_once(self):
+        with patch('patient_portal.api.views.refresh_patient_record') as refresh:
+            # The response reads attributes off the record, and a bare
+            # MagicMock makes the JSON encoder walk it forever.
+            refresh.return_value = PatientRecord.objects.get(person=self.person)
+            resp = self.client.post(
+                f'/api/v1/patient-records/{self.person.person_id}/refresh/')
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
+        self.assertEqual(refresh.call_count, 1)
+        self.assertEqual(resp.data['person_id'], self.person.person_id)
+        self.assertTrue(resp.data['refreshed'])
+
+    def test_refresh_endpoint_reflects_deferred_writes(self):
+        # Asserted on a field the measurement actually projects into. A
+        # timestamp proves nothing here, setUp already populated it.
+        record = PatientRecord.objects.get(person=self.person)
+        self.assertEqual(float(record.hemoglobin_g_dl), 5.0)
+
+        self.client.patch(
+            f'/api/v1/measurements/{self.measurement.pk}/?skip_refresh=true',
+            {'value_as_number': 42}, format='json')
+
+        record.refresh_from_db()
+        self.assertEqual(float(record.hemoglobin_g_dl), 5.0,
+                         'the deferred PATCH derived anyway')
+
+        resp = self.client.post(
+            f'/api/v1/patient-records/{self.person.person_id}/refresh/')
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
+        record.refresh_from_db()
+        self.assertEqual(float(record.hemoglobin_g_dl), 42.0,
+                         'refresh did not pick up the deferred write')
+
+    def test_refresh_endpoint_rejects_a_non_admin(self):
+        patient_identity = Identity.objects.create_user(
+            email='defer-patient@example.test', password='pw')
+        PatientUser.objects.create(identity=patient_identity, person=self.person)
+        client = APIClient()
+        client.force_authenticate(user=patient_identity)
+
+        resp = client.post(
+            f'/api/v1/patient-records/{self.person.person_id}/refresh/')
+
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_a_non_admin_cannot_defer(self):
+        # Otherwise a patient defers their own write and cannot rebuild, because
+        # the refresh action is admin only.
+        patient_identity = Identity.objects.create_user(
+            email='defer-nonadmin@example.test', password='pw')
+        PatientUser.objects.create(identity=patient_identity, person=self.person)
+        client = APIClient()
+        client.force_authenticate(user=patient_identity)
+
+        with patch('omop_core.services.patient_record_service.refresh_patient_record') as refresh:
+            client.patch(
+                f'/api/v1/measurements/{self.measurement.pk}/?skip_refresh=true',
+                {'value_as_number': 9}, format='json')
+
+        self.assertTrue(refresh.called, 'a non-admin deferred and cannot recover')
+
+    def test_refresh_is_not_published_on_the_legacy_prefix(self):
+        # The legacy router registers PatientRecordViewSet itself, so an action
+        # added there would widen a frozen API. Asserted on resolution rather
+        # than status, because the unmatched path falls through to the SPA
+        # catch-all and its status is not this test's business.
+        from django.urls import resolve
+
+        legacy = resolve(f'/api/patient-info/{self.person.person_id}/refresh/')
+        v1 = resolve(f'/api/v1/patient-records/{self.person.person_id}/refresh/')
+
+        self.assertEqual(getattr(v1.func, 'actions', {}).get('post'), 'refresh')
+        self.assertNotEqual(getattr(legacy.func, 'actions', {}).get('post'), 'refresh')
+
+    def test_refresh_endpoint_is_post_only(self):
+        resp = self.client.get(
+            f'/api/v1/patient-records/{self.person.person_id}/refresh/')
+
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_refresh_endpoint_404s_for_an_unknown_person(self):
+        resp = self.client.post('/api/v1/patient-records/99999999/refresh/')
+
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_a_failing_derivation_is_reported_not_swallowed(self):
+        with patch('patient_portal.api.views.refresh_patient_record',
+                   side_effect=ValueError('derivation exploded')):
+            with self.assertRaises(ValueError):
+                self.client.post(
+                    f'/api/v1/patient-records/{self.person.person_id}/refresh/')


### PR DESCRIPTION
…on demand

Every clinical write re-derives the whole PatientRecord, and derivation cost grows with the rows the person already holds. On a bulk loaded patient that is 12-32s per row level write, so one reconciliation pass of 57 updates and 23 deletes spent over half an hour re-deriving the same record 80 times. The bulk POST could already opt out, PATCH and DELETE could not, so an authoritative writer had no cheap way to retract a stale row.

Deferring was only half usable: the sole way to trigger a derivation over HTTP was to write a row. POST /api/v1/patient-records/{id}/refresh/ closes that.

Does not cover the bulk PATCH and DELETE forms #532 also asks for.