### PR TITLE
chore: add Cancer Modifier and NAACCR to VOCAB_SCOPE

### DIFF
--- a/omop_core/management/commands/load_athena_vocabularies.py
+++ b/omop_core/management/commands/load_athena_vocabularies.py
@@ -31,6 +31,8 @@ VOCAB_SCOPE = frozenset({
     'SNOMED', 'ICD10CM', 'CVX',
     # Genomic + oncology coding vocabularies (#459)
     'OMOP Genomic', 'ICDO3', 'NCIt',
+    # Oncology staging/grading modifiers + cancer registry
+    'Cancer Modifier', 'NAACCR',
 })
 # These vocabularies underpin the clinical concepts PROMOP presents and maps.
 # Do not include CVX here: it is deliberately absent from the current Athena


### PR DESCRIPTION
## Summary
- Add `Cancer Modifier` (3,548 concepts) and `NAACCR` (34,473 concepts) to `VOCAB_SCOPE` in `load_athena_vocabularies.py`
- Both already loaded into staging successfully

## Test plan
- [x] Loaded into staging — no errors or collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)