### PR TITLE
fix: use alc_thousand_per_ul for iwCLL threshold (#544)

### DIFF
--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -186,8 +186,9 @@ _OMOP_DERIVED_FIELDS = [
     'histologic_type', 'biopsy_grade',
     # Genomics
     'genetic_mutations',
-    # CLL
-    'absolute_lymphocyte_count', 'serum_beta2_microglobulin_level',
+    # CLL (absolute_lymphocyte_count removed — canonical source is
+    # alc_thousand_per_ul via _get_laboratory_data; see issue #544)
+    'serum_beta2_microglobulin_level',
     'binet_stage', 'tumor_burden', 'disease_activity',
     'bone_marrow_involvement', 'hepatomegaly', 'splenomegaly', 'lymphadenopathy',
     'btk_inhibitor_refractory', 'bcl2_inhibitor_refractory', 'lymphocyte_doubling_time',
@@ -2884,8 +2885,11 @@ def _get_cll_data(person: Person) -> dict:
     )
     conditions = ConditionOccurrence.objects.filter(person=person)
 
+    # 731-0 (ALC) is intentionally absent — the canonical column is
+    # alc_thousand_per_ul, populated by _get_laboratory_data via
+    # _LOINC_LAB_FIELDS.  Deriving absolute_lymphocyte_count here duplicated
+    # the value under an ambiguous name (see issue #544).
     loinc_map = {
-        '731-0':   'absolute_lymphocyte_count',
         '48094-6': 'serum_beta2_microglobulin_level',
         '8632-1':  'qtcf_value',
         '44996-6': 'spleen_size',
@@ -3201,7 +3205,9 @@ def _compute_derived_fields(patient_info: PatientRecord) -> None:
         imwg = False
     patient_info.measurable_disease_imwg = imwg
 
-    alc = patient_info.absolute_lymphocyte_count
+    # Use the canonical LOINC-derived column (10³/µL) for the iwCLL 5.0
+    # threshold.  absolute_lymphocyte_count is no longer derived (issue #544).
+    alc = patient_info.alc_thousand_per_ul
     lns = patient_info.largest_lymph_node_size
     spleen = patient_info.splenomegaly
     liver = patient_info.hepatomegaly

--- a/omop_core/services/patient_record_service.py
+++ b/omop_core/services/patient_record_service.py
@@ -186,8 +186,10 @@ _OMOP_DERIVED_FIELDS = [
     'histologic_type', 'biopsy_grade',
     # Genomics
     'genetic_mutations',
-    # CLL (absolute_lymphocyte_count removed — canonical source is
-    # alc_thousand_per_ul via _get_laboratory_data; see issue #544)
+    # CLL (absolute_lymphocyte_count is no longer actively derived —
+    # canonical source is alc_thousand_per_ul; kept here so the API
+    # contract test still treats it as a read-only derived column)
+    'absolute_lymphocyte_count',
     'serum_beta2_microglobulin_level',
     'binet_stage', 'tumor_burden', 'disease_activity',
     'bone_marrow_involvement', 'hepatomegaly', 'splenomegaly', 'lymphadenopathy',

--- a/omop_core/services/provenance_registry.py
+++ b/omop_core/services/provenance_registry.py
@@ -495,7 +495,7 @@ _MANUAL_ENTRIES: dict[str, FieldProvenance] = {
         selection_rule="composite",
         description="iwCLL measurable disease based on ALC, node size, spleen, liver",
         constituent_fields=[
-            "absolute_lymphocyte_count", "largest_lymph_node_size",
+            "alc_thousand_per_ul", "largest_lymph_node_size",
             "splenomegaly", "hepatomegaly",
         ],
     ),

--- a/tests/test_populate_patient_info.py
+++ b/tests/test_populate_patient_info.py
@@ -124,12 +124,15 @@ class TestLaterTherapies:
 
 class TestCllMeasurements:
 
-    def test_absolute_lymphocyte_count(self):
+    def test_alc_not_derived_by_cll_data(self):
+        """731-0 ALC is no longer derived by _get_cll_data — the canonical
+        column alc_thousand_per_ul is populated by _get_laboratory_data
+        instead (issue #544)."""
         person = PersonFactory()
         concept = _loinc_concept('731-0', 'Lymphocytes [#/volume] in Blood')
         MeasurementFactory(person=person, measurement_concept=concept, value_as_number=12.5)
         data = _cmd().get_cll_data(person)
-        assert data['absolute_lymphocyte_count'] == pytest.approx(12.5)
+        assert 'absolute_lymphocyte_count' not in data
 
     def test_serum_beta2_microglobulin_level(self):
         person = PersonFactory()
@@ -213,7 +216,7 @@ class TestCllMeasurements:
     def test_missing_measurement_not_in_data(self):
         person = PersonFactory()
         data = _cmd().get_cll_data(person)
-        for field in ('absolute_lymphocyte_count', 'serum_beta2_microglobulin_level',
+        for field in ('serum_beta2_microglobulin_level',
                       'qtcf_value', 'spleen_size', 'largest_lymph_node_size'):
             assert field not in data
 
@@ -575,6 +578,46 @@ class TestMeasurableDiseaseImwg:
                       kappa_flc=None, lambda_flc=None)
         _cmd()._compute_derived_fields(pi)
         assert pi.measurable_disease_imwg is None
+
+
+# ---------------------------------------------------------------------------
+# _compute_derived_fields — measurable_disease_iwcll (issue #544)
+# ---------------------------------------------------------------------------
+
+class TestMeasurableDiseaseIwcll:
+
+    def _pi(self, **kwargs):
+        """PatientRecord with controlled CLL fields; skip save() side effects."""
+        return PatientRecordFactory.build(**kwargs)
+
+    def test_alc_above_threshold_sets_true(self):
+        """alc_thousand_per_ul >= 5.0 (10³/µL) → iwCLL measurable."""
+        pi = self._pi(alc_thousand_per_ul=5.5)
+        _cmd()._compute_derived_fields(pi)
+        assert pi.measurable_disease_iwcll is True
+
+    def test_alc_below_threshold_alone_sets_false(self):
+        """alc_thousand_per_ul < 5.0 with no other criteria → not measurable."""
+        pi = self._pi(alc_thousand_per_ul=3.0, largest_lymph_node_size=None,
+                      splenomegaly=None, hepatomegaly=None)
+        _cmd()._compute_derived_fields(pi)
+        assert pi.measurable_disease_iwcll is False
+
+    def test_all_none_stays_none(self):
+        pi = self._pi(alc_thousand_per_ul=None, largest_lymph_node_size=None,
+                      splenomegaly=None, hepatomegaly=None)
+        _cmd()._compute_derived_fields(pi)
+        assert pi.measurable_disease_iwcll is None
+
+    def test_old_absolute_lymphocyte_count_ignored(self):
+        """absolute_lymphocyte_count is no longer read by the IWCLL check."""
+        pi = self._pi(absolute_lymphocyte_count=50.0, alc_thousand_per_ul=None,
+                      largest_lymph_node_size=None, splenomegaly=None,
+                      hepatomegaly=None)
+        _cmd()._compute_derived_fields(pi)
+        # absolute_lymphocyte_count is set but alc_thousand_per_ul is None
+        # and no other criteria are present → None
+        assert pi.measurable_disease_iwcll is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove 731-0 to absolute_lymphocyte_count mapping from _get_cll_data to eliminate the ambiguously-named duplicate column that confused external consumers on units
- Update _compute_derived_fields iwCLL check to read from alc_thousand_per_ul (the canonical LOINC-derived column, already populated by _get_laboratory_data) instead of absolute_lymphocyte_count
- Update provenance registry to reference alc_thousand_per_ul as constituent field for measurable_disease_iwcll

## Test plan
- [x] Updated existing test_absolute_lymphocyte_count to verify 731-0 no longer populates absolute_lymphocyte_count via _get_cll_data
- [x] Added TestMeasurableDiseaseIwcll with 4 tests: ALC above threshold, below threshold, all-None, and old column ignored
- [ ] Run full pytest suite
- [ ] Run Django test suite

Closes #544