### PR TITLE
Remove fixed CTOMOP database-name assumptions (#551)

### DIFF
--- a/docs/vocabularies.md
+++ b/docs/vocabularies.md
@@ -2,7 +2,10 @@
 
 What each vocabulary is, where it is stored, what its concept codes look like, and what they refer to.
 
-All figures are from **staging** (`ctomop_dev`), the reference environment for this work.
+The row counts below are a captured staging snapshot, included to explain the
+shape of the loaded vocabulary corpus. They are not a required database name
+or deployment hostname; deployments select their PostgreSQL database through
+the `DATABASE_URL` environment variable.
 
 Companion documents:
 - [concept-mapping.md](concept-mapping.md) — how FHIR codes are resolved to OMOP concepts at ingestion

--- a/docs/wearable-omop-mapping.md
+++ b/docs/wearable-omop-mapping.md
@@ -259,14 +259,14 @@ history.
 
 ## Gaps and proposed work
 
-> **Environments.** Concept resolution claims here were verified against **staging**
-> (`ctomop_dev`, `promop-staging.onrender.com`, full Athena load: 1,979,424 concepts /
-> 277,790 LOINC rows) and against local `promop_dev` (partial `seed_omop_concepts` set only).
-> Staging is the reference environment for this work.
+> **Environments.** Concept resolution claims here were verified against a
+> captured staging vocabulary snapshot (1,979,424 concepts / 277,790 LOINC rows)
+> and against local `promop_dev` (partial `seed_omop_concepts` set only).
+> Staging is the reference environment for this work; the PostgreSQL database
+> name and hostname are deployment-specific and come from `DATABASE_URL`.
 >
-> Note that CLAUDE.md's Database Selection table is stale: it references a `STAGING_DATABASE_URL`
-> that is not defined in `.env`, and a production host that does not match the one `DATABASE_URL`
-> actually points at — which is staging (`ctomop_dev`).
+> Do not infer a database name or host from this document. Use the deployment's
+> configured `DATABASE_URL` for migrations and validation.
 
 ### Gap A — Garmin has no adapter for six metrics (#444)
 

--- a/tests/test_database_name_portability.py
+++ b/tests/test_database_name_portability.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_database_configuration_is_url_driven():
+    """The Django database name must come from DATABASE_URL, never a fixed name."""
+    settings = (ROOT / "ctomop" / "settings.py").read_text()
+    database_block = settings.split("# Database", 1)[1].split("# Password validation", 1)[0]
+
+    assert "DATABASE_URL" in database_block
+    assert "dj_database_url.config" in database_block
+    assert "ctomop_dev" not in database_block
+    assert "ctomop" not in database_block
+
+
+def test_operational_docs_do_not_require_ctomop_database_name():
+    """Environment-specific database names must not become deployment requirements."""
+    docs = [ROOT / "docs" / "vocabularies.md", ROOT / "docs" / "wearable-omop-mapping.md"]
+    for path in docs:
+        assert "ctomop_dev" not in path.read_text()


### PR DESCRIPTION
## Summary
- Documents that PostgreSQL database names and hosts come from `DATABASE_URL`.
- Removes stale `ctomop_dev` deployment names from vocabulary and wearable operational docs.
- Adds static contract tests covering URL-driven configuration and documentation portability.

The `ctomop` Python package and Cloud Run service names are intentionally unchanged; they are application/deployment identifiers, not database names.

## Validation
- `pytest -q tests/test_database_name_portability.py` (2 passed)
- `git diff --check` clean