### PR TITLE
Make the Docker stack configurable, and able to start with DEBUG off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,42 @@ APP_BASE_URL=http://localhost:5173
 # Required in production (DEBUG=False). Must include the scheme.
 # Example: https://app.example.com,https://www.example.com
 # CORS_ALLOWED_ORIGINS=https://app.example.com
+
+# ── Docker: host-side knobs ───────────────────────────────────────────
+# The container always listens on 8000; this is the port on the host. Handy
+# when 8000 is already taken by a sibling service in a full local stack.
+PROMOP_HOST_PORT=8000
+# Container names, so two stacks can run side by side.
+# PROMOP_DB_CONTAINER=promop_db
+# PROMOP_WEB_CONTAINER=promop_web
+# GUNICORN_WORKERS=4
+# GUNICORN_THREADS=2
+# GUNICORN_TIMEOUT=120
+# GUNICORN_LOG_LEVEL=info
+
+# ── Required whenever DEBUG=False ─────────────────────────────────────
+# Settings refuse to start without these, so a production-shaped container
+# will not come up until they are set. Comma-separated.
+# ALLOWED_HOSTS=localhost,127.0.0.1
+# Origins of browsers that call this API directly. The patient app and the
+# admin app are SEPARATE origins; allow-listing one but not the other fails
+# that app's writes in the browser and nowhere else.
+# CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3200
+# CSRF_TRUSTED_ORIGINS=http://localhost:5173,http://localhost:3200
+
+# ── Firebase identity: pick ONE mode ──────────────────────────────────
+# Mode A — emulator. The Admin SDK uses a null credential and accepts
+# unsigned tokens. No GCP access needed; this is what the e2e suites use.
+# FIREBASE_PROJECT_ID=demo-healthtree-one
+# FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+# FIREBASE_SKIP_REVOCATION_CHECK=true
+#
+# Mode B — a real project (staging). Leave FIREBASE_AUTH_EMULATOR_HOST unset
+# and mount Application Default Credentials. Without them the SDK initialises
+# fine and the FIRST token verification raises DefaultCredentialsError, so
+# every request 401s with nothing explaining why. Run once:
+#   gcloud auth application-default login
+# FIREBASE_PROJECT_ID=healthtree-staging-a7b7a
+# GOOGLE_APPLICATION_CREDENTIALS=/adc.json
+# PROMOP_ADC_SOURCE=/Users/you/.config/gcloud/application_default_credentials.json
+# PROMOP_ADC_TARGET=/adc.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
-version: "3.9"
-
 services:
   db:
     image: postgres:15
     restart: always
-    container_name: promop_db
+    container_name: ${PROMOP_DB_CONTAINER:-promop_db}
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -22,7 +20,7 @@ services:
   web:
     build: .
     restart: always
-    container_name: promop_web
+    container_name: ${PROMOP_WEB_CONTAINER:-promop_web}
     depends_on:
       db:
         condition: service_healthy
@@ -35,20 +33,50 @@ services:
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       PORT: 8000
+
+      # Settings REQUIRE these whenever DEBUG is off, so without them a
+      # production-shaped container cannot start at all.
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-}
+      # Origins of the browsers that call this API directly. Comma-separated.
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-}
+
+      # Firebase identity. Two modes:
+      #  - emulator: set FIREBASE_AUTH_EMULATOR_HOST; the Admin SDK then uses a
+      #    null credential and accepts unsigned tokens. No GCP access needed.
+      #  - real project: leave it unset and mount Application Default
+      #    Credentials (see the adc profile below). Without them the SDK
+      #    initialises but the first verify_id_token raises
+      #    DefaultCredentialsError, so every request 401s with no explanation.
+      FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID:-}
+      FIREBASE_AUTH_EMULATOR_HOST: ${FIREBASE_AUTH_EMULATOR_HOST:-}
+      FIREBASE_SKIP_REVOCATION_CHECK: ${FIREBASE_SKIP_REVOCATION_CHECK:-}
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
+
+      # phr identity service, when verifying phr-issued tokens.
+      PHR_ISSUER: ${PHR_ISSUER:-}
+      PHR_BASE_URL: ${PHR_BASE_URL:-}
+
+      SERVICE_AUTH_TOKEN: ${SERVICE_AUTH_TOKEN:-}
     ports:
-      - "8000:8000"
+      # Host port is configurable: 8000 is commonly taken by a sibling service
+      # in a full local stack. The container always listens on 8000.
+      - "${PROMOP_HOST_PORT:-8000}:8000"
+    volumes:
+      # Present only so a caller can mount ADC without an override file:
+      #   GOOGLE_APPLICATION_CREDENTIALS=/adc.json
+      #   PROMOP_ADC_SOURCE=$HOME/.config/gcloud/application_default_credentials.json
+      # Defaults to a harmless self-mount when unset, so the stanza is inert.
+      - ${PROMOP_ADC_SOURCE:-/dev/null}:${PROMOP_ADC_TARGET:-/dev/null}:ro
+    # The gunicorn flags stay on ONE line. A folded scalar (">") keeps the
+    # newline of any line indented deeper than the block's first, so wrapped
+    # flags arrive as separate shell commands — "sh: --bind: not found" — and
+    # the server never starts.
     command: >
       sh -c "
         python manage.py migrate --noinput &&
         python manage.py setup_admin &&
-        gunicorn ctomop.wsgi:application
-          --bind 0.0.0.0:8000
-          --workers 4
-          --threads 2
-          --timeout 120
-          --access-logfile -
-          --error-logfile -
-          --log-level info
+        gunicorn ctomop.wsgi:application --bind 0.0.0.0:8000 --workers ${GUNICORN_WORKERS:-4} --threads ${GUNICORN_THREADS:-2} --timeout ${GUNICORN_TIMEOUT:-120} --access-logfile - --error-logfile - --log-level ${GUNICORN_LOG_LEVEL:-info}
       "
 
 volumes:


### PR DESCRIPTION
`docker compose up` cannot bring up a production-shaped container on `dev`. Three faults, and the second hides behind the first.

1. **`ALLOWED_HOSTS` and `CORS_ALLOWED_ORIGINS` are never passed into the web service.** Settings require both when `DEBUG` is off, so startup fails on `ImproperlyConfigured`.
2. **The folded `command:` block splits gunicorn's flags.** A folded scalar keeps the newline of any line indented deeper than the block's first, so the shell runs them as separate commands — `sh: --bind: not found`.
3. **The host port is hardcoded to 8000**, which collides in a full local stack.

Also adds the passthrough the two identity modes need. With `FIREBASE_AUTH_EMULATOR_HOST` set the Admin SDK takes a null credential and accepts unsigned tokens (what the e2e suites use). Against a real project it verifies signatures and needs ADC — and without them `initialize_app` *succeeds*, because `ApplicationDefault()` is lazy, so the first `verify_id_token` raises `DefaultCredentialsError` and every request 401s with nothing explaining why. `PROMOP_ADC_SOURCE`/`_TARGET` mount them without an override file, defaulting to an inert self-mount.

Container names and gunicorn tuning are variables too, so two stacks can run side by side.

## Verified

Three configurations brought up from this branch:

| mode | result |
|---|---|
| `DEBUG=False` + emulator | starts; CORS answers both app origins; bad token → `InvalidIdTokenError` |
| `DEBUG=False` + real project, ADC mounted | starts; `/adc.json` present; bad token → `InvalidIdTokenError` (signatures really checked) |
| `DEBUG=True`, nothing else set (`.env.example` default) | starts |

The auth mode is confirmed by *which* exception a bad token raises: `InvalidIdTokenError` means verification is real, `DefaultCredentialsError` means credentials are missing.

No behaviour change for existing callers — every new variable defaults to today's value.